### PR TITLE
Messaging foundation for #78 (PR A/3): IMessageBus + outbox + in-memory provider

### DIFF
--- a/docs/adr/0001-messaging.md
+++ b/docs/adr/0001-messaging.md
@@ -1,0 +1,42 @@
+# ADR 0001 — Messaging
+
+**Status.** Adopts the ecosystem messaging ADR authored in andy-tasks ([`andy-tasks/docs/adr/0001-messaging.md`](https://github.com/rivoli-ai/andy-tasks/blob/main/docs/adr/0001-messaging.md)). This document is a thin reference that enumerates the subjects andy-containers participates in and restates the two ecosystem-wide rules that matter to this service.
+
+## What we publish
+
+| Subject | Payload | When |
+|---|---|---|
+| `andy.containers.events.run.<runId>.finished` | `{ runId, storyId?, status, exitCode?, durationSeconds? }` | Container exits with status `success`. |
+| `andy.containers.events.run.<runId>.failed` | `{ runId, storyId?, status, exitCode?, durationSeconds? }` | Container exits with non-zero status, or provisioning fails. |
+| `andy.containers.events.run.<runId>.cancelled` | `{ runId, storyId?, status, durationSeconds? }` | Container destroyed externally (operator action, scheduled cleanup). |
+
+`storyId` is propagated when the caller (typically andy-issues' `SandboxService`) stamps it on the container at create time. When absent, consumers know the run was not correlated to a backlog story.
+
+Future kinds — `session.status`, `agent.stdout`, `build.progress` — will be added as additional subjects under `andy.containers.events.*` when the use cases land, not in this foundation PR.
+
+## What we subscribe to
+
+Nothing in this PR. The scaffolding supports `SubscribeAsync` but no consumer is registered yet. andy-issues Story 15.6 tracks its correlating consumer.
+
+## Rules we inherit from the ecosystem ADR
+
+1. **Commands on HTTP, events on NATS.** REST / MCP / gRPC remain the command path into this service. NATS is strictly for past-tense events fanning *out* to other services.
+2. **Transactional outbox.** Domain changes and outbox rows commit together in a single EF transaction. The `OutboxDispatcher` background worker drains pending rows to the bus. At-least-once delivery.
+3. **Consumers are idempotent by `msg-id`.** The outbox row id *is* the `MsgId` header, so reprocessing the same row never produces two downstream effects.
+4. **No self-subscription.** andy-containers never subscribes to `andy.containers.events.*`. Cross-service events belong on the bus; intra-service notifications belong on in-process `IHostedService` / event handlers.
+5. **Generation cap.** Headers carry a `Generation` counter, incremented each time a message is emitted in response to another. The bus drops messages with `Generation > 10` as a runtime circuit breaker.
+
+## What this repo contributes
+
+This PR lands the **foundation** only:
+
+- `IMessageBus` + `MessageHeaders` + `IncomingMessage` + `SubscriptionOptions` in `Andy.Containers.Messaging`.
+- `InMemoryMessageBus` as the default provider — no NATS dependency yet.
+- `OutboxEntry` entity + EF configuration + migration.
+- `OutboxDispatcher` hosted service.
+- DI extension `AddContainersMessaging()` that selects the provider from `Messaging:Provider` (currently only `InMemory`).
+
+Follow-up PRs referenced from andy-containers#78 add:
+
+- **NATS provider wire-up.** `NatsMessageBus`, `NatsStreamProvisioner`, `docker-compose.yml` `nats:2-alpine` service, integration tests env-gated by `ANDY_CONTAINERS_TEST_NATS`.
+- **Publisher wiring.** Hook `OrchestrationService` / `ProvisioningWorker` lifecycle transitions to emit `run.*` events via the outbox. Thread `storyId` through `CreateContainerRequest`.

--- a/src/Andy.Containers.Infrastructure/Andy.Containers.Infrastructure.csproj
+++ b/src/Andy.Containers.Infrastructure/Andy.Containers.Infrastructure.csproj
@@ -10,6 +10,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Andy.Containers.Api.Tests" />
+    <InternalsVisibleTo Include="Andy.Containers.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
+++ b/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
@@ -1,3 +1,4 @@
+using Andy.Containers.Messaging;
 using Andy.Containers.Models;
 using Microsoft.EntityFrameworkCore;
 
@@ -22,6 +23,7 @@ public class ContainersDbContext : DbContext
     public DbSet<Organization> Organizations => Set<Organization>();
     public DbSet<Team> Teams => Set<Team>();
     public DbSet<ImageBuildRecord> ImageBuildRecords => Set<ImageBuildRecord>();
+    public DbSet<OutboxEntry> OutboxEntries => Set<OutboxEntry>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -227,6 +229,20 @@ public class ContainersDbContext : DbContext
             e.HasKey(r => r.Id);
             e.HasIndex(r => r.ImageReference);
             e.HasIndex(r => r.TemplateCode).IsUnique();
+        });
+
+        // OutboxEntry — transactional outbox rows for messaging (ADR 0001).
+        // The dispatcher polls on PublishedAt IS NULL ordered by CreatedAt,
+        // so the composite index covers its hot path. Subject gets its own
+        // index for ad-hoc diagnostics (e.g. "show me everything on
+        // andy.containers.events.run.*").
+        modelBuilder.Entity<OutboxEntry>(e =>
+        {
+            e.HasKey(o => o.Id);
+            e.Property(o => o.Subject).IsRequired().HasMaxLength(256);
+            e.Property(o => o.PayloadJson).IsRequired();
+            e.HasIndex(o => new { o.PublishedAt, o.CreatedAt });
+            e.HasIndex(o => o.Subject);
         });
     }
 }

--- a/src/Andy.Containers.Infrastructure/Messaging/InMemoryMessageBus.cs
+++ b/src/Andy.Containers.Infrastructure/Messaging/InMemoryMessageBus.cs
@@ -1,0 +1,171 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading.Channels;
+using Andy.Containers.Messaging;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Containers.Infrastructure.Messaging;
+
+// In-process IMessageBus implementation. Used in tests and as the default
+// development provider until NATS wire-up lands in a follow-up PR.
+// Supports NATS subject wildcards: '*' matches one token, '>' matches one
+// or more trailing tokens.
+//
+// This is deliberately not a drop-in production replacement for NATS.
+// It has no durability (messages vanish on process restart), no
+// cross-process delivery, and no back-pressure beyond channel capacity.
+// But it faithfully implements the IMessageBus contract for loopback
+// testing, which proves the outbox + dispatcher + bus wiring before the
+// real NATS client arrives.
+//
+// Runtime cycle breaker (per ADR 0001): PublishAsync drops messages
+// whose Headers.ExceedsGenerationLimit is true, logs at Error with the
+// causation chain, and returns. The drop happens before any subscriber
+// is notified.
+public sealed class InMemoryMessageBus : IMessageBus
+{
+    private readonly ILogger<InMemoryMessageBus> _logger;
+
+    // One unbounded channel per active subscription. Keyed by the exact
+    // subject filter the subscriber passed, so two subscribers with
+    // different filters each get their own channel and fan-out happens
+    // naturally in PublishAsync.
+    private readonly ConcurrentDictionary<string, Channel<IncomingMessage>> _subscriptions = new();
+
+    public InMemoryMessageBus(ILogger<InMemoryMessageBus> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task PublishAsync(
+        string subject,
+        object payload,
+        MessageHeaders headers,
+        CancellationToken ct = default)
+    {
+        if (headers.ExceedsGenerationLimit)
+        {
+            _logger.LogError(
+                "Dropping message {MsgId} on {Subject} — generation {Gen} exceeds limit {Max}. " +
+                "Correlation: {CorrId} Causation: {CausedBy}",
+                headers.MsgId, subject, headers.Generation, MessageHeaders.MaxGeneration,
+                headers.CorrelationId, headers.CausationId);
+            return Task.CompletedTask;
+        }
+
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(payload, EventJson.Options);
+
+        foreach (var (filter, channel) in _subscriptions)
+        {
+            if (!MatchesSubject(filter, subject))
+            {
+                continue;
+            }
+
+            var message = new InMemoryIncomingMessage
+            {
+                Headers = headers,
+                Subject = subject,
+                Payload = bytes,
+                ReceivedAt = DateTimeOffset.UtcNow
+            };
+
+            // Unbounded channel: TryWrite always succeeds until cancellation.
+            channel.Writer.TryWrite(message);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    // Pre-register the channel for a subject filter. Exposed so tests
+    // can avoid the race between "start subscriber task" and "publish
+    // first message" — calling this before publishing guarantees the
+    // channel exists. Production consumers don't need to call it;
+    // SubscribeAsync uses the same GetOrAdd internally.
+    internal Channel<IncomingMessage> EnsureChannel(string subjectFilter)
+    {
+        return _subscriptions.GetOrAdd(
+            subjectFilter,
+            _ => Channel.CreateUnbounded<IncomingMessage>(new UnboundedChannelOptions
+            {
+                SingleReader = false,
+                SingleWriter = false
+            }));
+    }
+
+    public async IAsyncEnumerable<IncomingMessage> SubscribeAsync(
+        string subjectFilter,
+        SubscriptionOptions options,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var channel = EnsureChannel(subjectFilter);
+
+        _logger.LogDebug("Subscription opened on {Filter} durable {Durable}",
+            subjectFilter, options.DurableName);
+
+        try
+        {
+            await foreach (var message in channel.Reader.ReadAllAsync(ct))
+            {
+                yield return message;
+            }
+        }
+        finally
+        {
+            // Best-effort cleanup. If multiple subscribers share a filter
+            // this will remove the channel on the first unsubscribe, but
+            // that is acceptable for an in-memory test bus.
+            _subscriptions.TryRemove(subjectFilter, out _);
+            _logger.LogDebug("Subscription closed on {Filter}", subjectFilter);
+        }
+    }
+
+    // NATS subject match semantics:
+    //   '*' matches exactly one token
+    //   '>' matches one or more trailing tokens (must be last)
+    internal static bool MatchesSubject(string filter, string subject)
+    {
+        if (filter == subject)
+        {
+            return true;
+        }
+
+        var filterTokens = filter.Split('.');
+        var subjectTokens = subject.Split('.');
+
+        for (int i = 0; i < filterTokens.Length; i++)
+        {
+            if (filterTokens[i] == ">")
+            {
+                // '>' is only valid as the last token and must consume
+                // at least one remaining subject token.
+                return i == filterTokens.Length - 1 && i < subjectTokens.Length;
+            }
+
+            if (i >= subjectTokens.Length)
+            {
+                return false;
+            }
+
+            if (filterTokens[i] != "*" && filterTokens[i] != subjectTokens[i])
+            {
+                return false;
+            }
+        }
+
+        // Exhausted the filter: match only if we also exhausted the subject.
+        return filterTokens.Length == subjectTokens.Length;
+    }
+}
+
+// Trivial IncomingMessage wrapper for the in-memory bus. Ack and Nack
+// are no-ops because the in-memory bus has no durable offset to advance.
+internal sealed class InMemoryIncomingMessage : IncomingMessage
+{
+    public override Task AckAsync(CancellationToken ct = default) => Task.CompletedTask;
+    public override Task NackAsync(CancellationToken ct = default) => Task.CompletedTask;
+}

--- a/src/Andy.Containers.Infrastructure/Messaging/MessagingServiceCollectionExtensions.cs
+++ b/src/Andy.Containers.Infrastructure/Messaging/MessagingServiceCollectionExtensions.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Messaging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Andy.Containers.Infrastructure.Messaging;
+
+public static class MessagingServiceCollectionExtensions
+{
+    // Registers the IMessageBus implementation selected by
+    // Messaging:Provider configuration (InMemory, default; Nats in a
+    // follow-up PR) and wires the OutboxDispatcher background worker.
+    //
+    // Callers must register ContainersDbContext separately — the
+    // dispatcher resolves it from the scope and drains OutboxEntries
+    // from whatever provider (Postgres / SQLite) the app is using.
+    public static IServiceCollection AddContainersMessaging(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var provider = configuration["Messaging:Provider"] ?? "InMemory";
+
+        if (string.Equals(provider, "Nats", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new NotSupportedException(
+                "Messaging:Provider=Nats is not wired yet. Follow-up PR to " +
+                "this repo's #78 adds NatsMessageBus + NatsStreamProvisioner. " +
+                "For now use Messaging:Provider=InMemory (the default).");
+        }
+
+        services.TryAddSingleton<IMessageBus, InMemoryMessageBus>();
+
+        services.Configure<OutboxDispatcherOptions>(
+            configuration.GetSection(OutboxDispatcherOptions.SectionName));
+        services.AddHostedService<OutboxDispatcher>();
+
+        return services;
+    }
+}

--- a/src/Andy.Containers.Infrastructure/Messaging/OutboxDispatcher.cs
+++ b/src/Andy.Containers.Infrastructure/Messaging/OutboxDispatcher.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Messaging;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Andy.Containers.Infrastructure.Messaging;
+
+// Background worker that drains the OutboxEntry table to the message bus.
+// One instance per service. Polls at a configurable interval, batches
+// pending rows, publishes each to its target subject, records success
+// or failure. Rows are never deleted — the outbox doubles as an audit
+// log. A separate retention policy may purge published rows older than
+// N days.
+//
+// Retry semantics: on publish failure the row stays pending with
+// AttemptCount incremented and LastError set. The next drain tick
+// picks it up again. Exponential backoff and poison-message DLQ
+// routing are NOT in this scaffold — they land with the NATS
+// provider and will look at LastAttemptAt to defer retries.
+public sealed class OutboxDispatcher : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<OutboxDispatcher> _logger;
+    private readonly TimeSpan _pollInterval;
+    private readonly int _batchSize;
+
+    public OutboxDispatcher(
+        IServiceScopeFactory scopeFactory,
+        ILogger<OutboxDispatcher> logger,
+        IOptions<OutboxDispatcherOptions> options)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+        _pollInterval = options.Value.PollInterval;
+        _batchSize = options.Value.BatchSize;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("OutboxDispatcher started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var drained = await DrainOnceAsync(stoppingToken);
+                if (drained == 0)
+                {
+                    await Task.Delay(_pollInterval, stoppingToken);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "OutboxDispatcher tick failed; backing off");
+                await Task.Delay(_pollInterval, stoppingToken);
+            }
+        }
+
+        _logger.LogInformation("OutboxDispatcher stopped");
+    }
+
+    internal async Task<int> DrainOnceAsync(CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ContainersDbContext>();
+        var bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+
+        var pending = await db.Set<OutboxEntry>()
+            .Where(e => e.PublishedAt == null)
+            .OrderBy(e => e.CreatedAt)
+            .Take(_batchSize)
+            .ToListAsync(ct);
+
+        if (pending.Count == 0)
+        {
+            return 0;
+        }
+
+        foreach (var entry in pending)
+        {
+            try
+            {
+                var headers = new MessageHeaders(
+                    MsgId: entry.Id,
+                    CorrelationId: entry.CorrelationId,
+                    CausationId: entry.CausationId,
+                    Generation: entry.Generation);
+
+                // Payload is stored as JSON text. IMessageBus.PublishAsync
+                // expects an object (it re-serializes). Pass a
+                // JsonDocument so the bus has something to serialize
+                // back. A follow-up PR may add a raw-bytes publish
+                // overload to avoid the round trip.
+                using var doc = JsonDocument.Parse(entry.PayloadJson);
+                await bus.PublishAsync(entry.Subject, doc.RootElement, headers, ct);
+
+                entry.PublishedAt = DateTimeOffset.UtcNow;
+                entry.LastError = null;
+            }
+            catch (Exception ex)
+            {
+                entry.AttemptCount++;
+                entry.LastAttemptAt = DateTimeOffset.UtcNow;
+                entry.LastError = ex.Message;
+                _logger.LogWarning(ex,
+                    "Outbox entry {EntryId} publish failed (attempt {Attempt})",
+                    entry.Id, entry.AttemptCount);
+            }
+        }
+
+        await db.SaveChangesAsync(ct);
+        return pending.Count;
+    }
+}

--- a/src/Andy.Containers.Infrastructure/Messaging/OutboxDispatcherOptions.cs
+++ b/src/Andy.Containers.Infrastructure/Messaging/OutboxDispatcherOptions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Containers.Infrastructure.Messaging;
+
+// Knobs for the OutboxDispatcher background worker. Bound from the
+// "Messaging:Outbox" configuration section. Integration tests override
+// PollInterval down to ~50ms so the end-to-end loops finish in tens of
+// milliseconds instead of seconds.
+public sealed class OutboxDispatcherOptions
+{
+    public const string SectionName = "Messaging:Outbox";
+
+    // Delay between drains when the outbox is empty. When a drain
+    // finds rows, the worker loops immediately to keep up with a
+    // burst; only the empty-poll path sleeps.
+    public TimeSpan PollInterval { get; set; } = TimeSpan.FromSeconds(1);
+
+    // Max rows per drain. Bounds the transaction size and the failure
+    // blast-radius of a poison message.
+    public int BatchSize { get; set; } = 100;
+}

--- a/src/Andy.Containers.Infrastructure/Migrations/20260414215325_AddOutboxEntry.Designer.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260414215325_AddOutboxEntry.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Andy.Containers.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Containers.Infrastructure.Migrations
 {
     [DbContext(typeof(ContainersDbContext))]
-    partial class ContainersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414215325_AddOutboxEntry")]
+    partial class AddOutboxEntry
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Containers.Infrastructure/Migrations/20260414215325_AddOutboxEntry.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260414215325_AddOutboxEntry.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Containers.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOutboxEntry : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ImageBuildRecords_ImageReference",
+                table: "ImageBuildRecords");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ImageBuildRecords_TemplateCode",
+                table: "ImageBuildRecords");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Architecture",
+                table: "ImageBuildRecords",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ImageCreatedAt",
+                table: "ImageBuildRecords",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ImageDigest",
+                table: "ImageBuildRecords",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "ImageSizeBytes",
+                table: "ImageBuildRecords",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "LayerCount",
+                table: "ImageBuildRecords",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Os",
+                table: "ImageBuildRecords",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "OutboxEntries",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Subject = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    PayloadType = table.Column<string>(type: "text", nullable: true),
+                    PayloadJson = table.Column<string>(type: "text", nullable: false),
+                    CorrelationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CausationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Generation = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    PublishedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    AttemptCount = table.Column<int>(type: "integer", nullable: false),
+                    LastAttemptAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    LastError = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OutboxEntries", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImageBuildRecords_ImageReference",
+                table: "ImageBuildRecords",
+                column: "ImageReference");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImageBuildRecords_TemplateCode",
+                table: "ImageBuildRecords",
+                column: "TemplateCode",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxEntries_PublishedAt_CreatedAt",
+                table: "OutboxEntries",
+                columns: new[] { "PublishedAt", "CreatedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxEntries_Subject",
+                table: "OutboxEntries",
+                column: "Subject");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OutboxEntries");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ImageBuildRecords_ImageReference",
+                table: "ImageBuildRecords");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ImageBuildRecords_TemplateCode",
+                table: "ImageBuildRecords");
+
+            migrationBuilder.DropColumn(
+                name: "Architecture",
+                table: "ImageBuildRecords");
+
+            migrationBuilder.DropColumn(
+                name: "ImageCreatedAt",
+                table: "ImageBuildRecords");
+
+            migrationBuilder.DropColumn(
+                name: "ImageDigest",
+                table: "ImageBuildRecords");
+
+            migrationBuilder.DropColumn(
+                name: "ImageSizeBytes",
+                table: "ImageBuildRecords");
+
+            migrationBuilder.DropColumn(
+                name: "LayerCount",
+                table: "ImageBuildRecords");
+
+            migrationBuilder.DropColumn(
+                name: "Os",
+                table: "ImageBuildRecords");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImageBuildRecords_ImageReference",
+                table: "ImageBuildRecords",
+                column: "ImageReference",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImageBuildRecords_TemplateCode",
+                table: "ImageBuildRecords",
+                column: "TemplateCode");
+        }
+    }
+}

--- a/src/Andy.Containers/Messaging/EventJson.cs
+++ b/src/Andy.Containers/Messaging/EventJson.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Andy.Containers.Messaging;
+
+// Canonical JSON options for every ADR 0001 event payload. Producers
+// serialize outbox rows with these options; consumers
+// (IncomingMessage.Deserialize) decode with the same. Centralizing them
+// here is the difference between "works by coincidence" and "works by
+// contract" — without it, a publisher using snake_case and a consumer
+// using default camelCase silently deserialize to default-valued fields.
+//
+// Snake case matches the ecosystem wire format (andy-tasks, andy-issues).
+// Strings for enums so consumers don't depend on ordinal stability when
+// a new enum member lands.
+public static class EventJson
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DictionaryKeyPolicy = JsonNamingPolicy.SnakeCaseLower,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.SnakeCaseLower) },
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}

--- a/src/Andy.Containers/Messaging/IMessageBus.cs
+++ b/src/Andy.Containers/Messaging/IMessageBus.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+
+namespace Andy.Containers.Messaging;
+
+// Cross-service messaging abstraction. Implementations publish to a bus
+// (default: NATS JetStream per ADR 0001) and yield incoming messages from
+// durable subscriptions.
+//
+// This interface is deliberately small and shape-identical to andy-tasks'
+// IMessageBus so the two services can eventually share a NuGet package
+// without breaking callers on either side. Subject convention and
+// causation rules are enforced by callers, not by the bus — the bus is a
+// transport.
+public interface IMessageBus
+{
+    // Publish a single message. The bus serializes payload to JSON and
+    // attaches headers. Callers should not call this directly; prefer
+    // writing to the OutboxEntry table inside the same transaction as
+    // the domain change, and let the OutboxDispatcher drain it. Direct
+    // publish is permitted only for ephemeral messages that do not need
+    // at-least-once delivery (e.g. system.health heartbeats).
+    Task PublishAsync(
+        string subject,
+        object payload,
+        MessageHeaders headers,
+        CancellationToken ct = default);
+
+    // Create a durable subscription. The stream yields incoming messages
+    // until cancellation or until the bus terminates. Consumers are
+    // expected to call Ack/Nack on each IncomingMessage before taking
+    // the next. Generation overflow (> MessageHeaders.MaxGeneration) is
+    // handled by the bus: offending messages are dropped before reaching
+    // the consumer, with an error-level log that includes the full
+    // causation chain.
+    IAsyncEnumerable<IncomingMessage> SubscribeAsync(
+        string subjectFilter,
+        SubscriptionOptions options,
+        CancellationToken ct = default);
+}
+
+// Four-field header envelope required on every message per ADR 0001.
+public sealed record MessageHeaders(
+    Guid MsgId,
+    Guid CorrelationId,
+    Guid? CausationId,
+    int Generation
+)
+{
+    // Hop limit from ADR 0001. Messages exceeding this generation count
+    // are dropped by the bus as a runtime circuit breaker for cycles.
+    public const int MaxGeneration = 10;
+
+    // Start a new causation chain. Use for messages triggered directly
+    // by user input or by a scheduled worker tick — anything not
+    // produced in response to an incoming message.
+    public static MessageHeaders NewRoot(Guid? correlationId = null)
+    {
+        var id = Guid.NewGuid();
+        return new MessageHeaders(
+            MsgId: id,
+            CorrelationId: correlationId ?? id,
+            CausationId: null,
+            Generation: 0);
+    }
+
+    // Continue an existing causation chain. Use when emitting a message
+    // in response to an incoming message from another service.
+    public static MessageHeaders Follow(MessageHeaders parent)
+    {
+        return new MessageHeaders(
+            MsgId: Guid.NewGuid(),
+            CorrelationId: parent.CorrelationId,
+            CausationId: parent.MsgId,
+            Generation: parent.Generation + 1);
+    }
+
+    public bool ExceedsGenerationLimit => Generation > MaxGeneration;
+}
+
+// Abstract incoming-message wrapper. Concrete implementations (e.g.
+// NatsIncomingMessage) attach the provider-specific ack/nack mechanism.
+public abstract class IncomingMessage
+{
+    public required MessageHeaders Headers { get; init; }
+    public required string Subject { get; init; }
+    public required ReadOnlyMemory<byte> Payload { get; init; }
+    public required DateTimeOffset ReceivedAt { get; init; }
+
+    // Decode the payload as the given type. Returns null if the payload
+    // is empty. Defaults to the canonical ADR 0001 wire options
+    // (EventJson.Options) so producers and consumers don't need to
+    // negotiate snake_case / camelCase out of band.
+    public T? Deserialize<T>(JsonSerializerOptions? options = null) where T : class
+    {
+        if (Payload.IsEmpty) return null;
+        return JsonSerializer.Deserialize<T>(Payload.Span, options ?? EventJson.Options);
+    }
+
+    // Acknowledge successful processing. The bus advances its durable
+    // consumer offset and will not redeliver this message.
+    public abstract Task AckAsync(CancellationToken ct = default);
+
+    // Negative-acknowledge. The bus will redeliver according to its
+    // retry policy up to SubscriptionOptions.MaxDeliver attempts, then
+    // move the message to the dead-letter subject.
+    public abstract Task NackAsync(CancellationToken ct = default);
+}
+
+public sealed record SubscriptionOptions(
+    // Durable consumer name. Required for JetStream subscriptions so
+    // consumer offsets survive restarts. Must be stable across service
+    // restarts — typically "<service-name>.<purpose>" e.g.
+    // "andy-containers.run-events".
+    string DurableName,
+
+    // Maximum delivery attempts before moving to the dead-letter
+    // subject. Default 10 per ADR 0001.
+    int MaxDeliver = 10,
+
+    // Whether the consumer must explicitly Ack/Nack each message.
+    // When false, the bus auto-acks on delivery (at-most-once).
+    bool ManualAck = true,
+
+    // Optional narrower filter within the subscription's base filter.
+    string? SubjectFilter = null
+);

--- a/src/Andy.Containers/Messaging/OutboxEntry.cs
+++ b/src/Andy.Containers/Messaging/OutboxEntry.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Containers.Messaging;
+
+// Transactional outbox row per ADR 0001. Publishers write to this table
+// in the same transaction as the domain change that produced the message;
+// the OutboxDispatcher background worker drains pending rows to the bus.
+// This guarantees at-least-once delivery without dual-write consistency
+// problems — a crash between commit and publish leaves the row pending
+// and it is picked up on the next dispatcher tick.
+public class OutboxEntry
+{
+    // Primary key. Also used as the MsgId when published — the outbox
+    // row id IS the message id, so reprocessing is naturally idempotent
+    // from the consumer's perspective.
+    public Guid Id { get; set; }
+
+    // NATS subject the message will be published to. Must follow the
+    // taxonomy defined in ADR 0001:
+    //   andy.<service>.events.<entity>.<id>.<kind>
+    public string Subject { get; set; } = string.Empty;
+
+    // Fully-qualified CLR type name of the payload. Used by consumers
+    // to pick the right deserialization target. Optional — subjects
+    // already encode intent, but this is a useful safety net.
+    public string? PayloadType { get; set; }
+
+    // JSON-encoded payload. Stored as text for provider portability.
+    public string PayloadJson { get; set; } = "{}";
+
+    // Correlation chain, copied into MessageHeaders at publish time.
+    public Guid CorrelationId { get; set; }
+    public Guid? CausationId { get; set; }
+    public int Generation { get; set; }
+
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    // Nullable sentinels for dispatch state. PublishedAt is set on the
+    // first successful publish; rows are never deleted so the outbox
+    // doubles as an audit log. A separate retention policy job may
+    // purge rows older than N days.
+    public DateTimeOffset? PublishedAt { get; set; }
+
+    // Attempt counter and last-error diagnostics for failed publishes.
+    // The dispatcher uses these to surface poison messages.
+    public int AttemptCount { get; set; }
+    public DateTimeOffset? LastAttemptAt { get; set; }
+    public string? LastError { get; set; }
+}

--- a/tests/Andy.Containers.Api.Tests/Messaging/InMemoryMessageBusTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Messaging/InMemoryMessageBusTests.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Messaging;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Messaging;
+
+public class InMemoryMessageBusTests
+{
+    [Fact]
+    public void MatchesSubject_ExactMatch()
+    {
+        InMemoryMessageBus.MatchesSubject("a.b.c", "a.b.c").Should().BeTrue();
+        InMemoryMessageBus.MatchesSubject("a.b.c", "a.b.d").Should().BeFalse();
+        InMemoryMessageBus.MatchesSubject("a.b.c", "a.b").Should().BeFalse();
+        InMemoryMessageBus.MatchesSubject("a.b.c", "a.b.c.d").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesSubject_StarWildcardMatchesOneToken()
+    {
+        InMemoryMessageBus.MatchesSubject("a.*.c", "a.b.c").Should().BeTrue();
+        InMemoryMessageBus.MatchesSubject("a.*.c", "a.x.c").Should().BeTrue();
+        InMemoryMessageBus.MatchesSubject("a.*.c", "a.b.d").Should().BeFalse();
+        InMemoryMessageBus.MatchesSubject("a.*.c", "a.b.c.d").Should().BeFalse();
+        InMemoryMessageBus.MatchesSubject("a.*", "a").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesSubject_GreaterThanWildcardMatchesTail()
+    {
+        InMemoryMessageBus.MatchesSubject("a.>", "a.b").Should().BeTrue();
+        InMemoryMessageBus.MatchesSubject("a.>", "a.b.c.d").Should().BeTrue();
+        InMemoryMessageBus.MatchesSubject("a.>", "a").Should().BeFalse();
+        InMemoryMessageBus.MatchesSubject("andy.containers.events.>", "andy.containers.events.run.123.finished")
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task PublishAsync_DeliversToMatchingSubscriber()
+    {
+        var bus = new InMemoryMessageBus(NullLogger<InMemoryMessageBus>.Instance);
+        bus.EnsureChannel("andy.containers.events.run.>");
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var received = new List<IncomingMessage>();
+        var subscribeTask = Task.Run(async () =>
+        {
+            await foreach (var msg in bus.SubscribeAsync(
+                "andy.containers.events.run.>",
+                new SubscriptionOptions("test"),
+                cts.Token))
+            {
+                received.Add(msg);
+                if (received.Count == 1) cts.Cancel();
+            }
+        }, cts.Token);
+
+        await bus.PublishAsync(
+            "andy.containers.events.run.abc.finished",
+            new { runId = "abc", status = "success" },
+            MessageHeaders.NewRoot());
+
+        try { await subscribeTask; } catch (OperationCanceledException) { }
+
+        received.Should().HaveCount(1);
+        received[0].Subject.Should().Be("andy.containers.events.run.abc.finished");
+    }
+
+    [Fact]
+    public async Task PublishAsync_SkipsNonMatchingSubscribers()
+    {
+        var bus = new InMemoryMessageBus(NullLogger<InMemoryMessageBus>.Instance);
+        bus.EnsureChannel("andy.issues.>");   // different filter
+        bus.EnsureChannel("andy.containers.>");
+
+        await bus.PublishAsync(
+            "andy.containers.events.run.123.finished",
+            new { runId = "123" },
+            MessageHeaders.NewRoot());
+
+        // Non-matching subscriber's channel stays empty; matching one got the message.
+        var matching = bus.EnsureChannel("andy.containers.>");
+        matching.Reader.Count.Should().Be(1);
+
+        var nonMatching = bus.EnsureChannel("andy.issues.>");
+        nonMatching.Reader.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task PublishAsync_DropsMessagesExceedingGenerationLimit()
+    {
+        var bus = new InMemoryMessageBus(NullLogger<InMemoryMessageBus>.Instance);
+        bus.EnsureChannel("andy.containers.>");
+
+        var overLimit = new MessageHeaders(
+            MsgId: Guid.NewGuid(),
+            CorrelationId: Guid.NewGuid(),
+            CausationId: Guid.NewGuid(),
+            Generation: MessageHeaders.MaxGeneration + 1);
+
+        await bus.PublishAsync("andy.containers.events.run.x.finished", new { }, overLimit);
+
+        bus.EnsureChannel("andy.containers.>").Reader.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void MessageHeaders_Follow_IncrementsGeneration()
+    {
+        var root = MessageHeaders.NewRoot();
+        var child = MessageHeaders.Follow(root);
+
+        child.CorrelationId.Should().Be(root.CorrelationId);
+        child.CausationId.Should().Be(root.MsgId);
+        child.Generation.Should().Be(1);
+        child.ExceedsGenerationLimit.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MessageHeaders_NewRoot_MakesItsOwnCorrelation()
+    {
+        var root = MessageHeaders.NewRoot();
+        root.CorrelationId.Should().Be(root.MsgId);
+        root.CausationId.Should().BeNull();
+        root.Generation.Should().Be(0);
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Messaging/OutboxDispatcherTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Messaging/OutboxDispatcherTests.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Messaging;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Messaging;
+
+public class OutboxDispatcherTests
+{
+    [Fact]
+    public async Task DrainOnceAsync_PublishesPendingRowsAndMarksThemPublished()
+    {
+        var (scopeFactory, bus, _) = BuildScope(nameof(DrainOnceAsync_PublishesPendingRowsAndMarksThemPublished));
+
+        using (var scope = scopeFactory.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<Andy.Containers.Infrastructure.Data.ContainersDbContext>();
+            db.OutboxEntries.AddRange(
+                new OutboxEntry { Id = Guid.NewGuid(), Subject = "andy.containers.events.run.1.finished", PayloadJson = """{"runId":"1"}""" },
+                new OutboxEntry { Id = Guid.NewGuid(), Subject = "andy.containers.events.run.2.finished", PayloadJson = """{"runId":"2"}""" });
+            await db.SaveChangesAsync();
+        }
+
+        var dispatcher = new OutboxDispatcher(
+            scopeFactory,
+            NullLogger<OutboxDispatcher>.Instance,
+            Options.Create(new OutboxDispatcherOptions()));
+
+        var drained = await dispatcher.DrainOnceAsync(CancellationToken.None);
+
+        drained.Should().Be(2);
+        using (var scope = scopeFactory.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<Andy.Containers.Infrastructure.Data.ContainersDbContext>();
+            var entries = await db.OutboxEntries.ToListAsync();
+            entries.Should().AllSatisfy(e => e.PublishedAt.Should().NotBeNull());
+        }
+        bus.Published.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task DrainOnceAsync_ReturnsZeroWhenNoPending()
+    {
+        var (scopeFactory, _, _) = BuildScope(nameof(DrainOnceAsync_ReturnsZeroWhenNoPending));
+        var dispatcher = new OutboxDispatcher(
+            scopeFactory,
+            NullLogger<OutboxDispatcher>.Instance,
+            Options.Create(new OutboxDispatcherOptions()));
+
+        var drained = await dispatcher.DrainOnceAsync(CancellationToken.None);
+
+        drained.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task DrainOnceAsync_ProcessesInFifoOrder()
+    {
+        var (scopeFactory, bus, _) = BuildScope(nameof(DrainOnceAsync_ProcessesInFifoOrder));
+
+        using (var scope = scopeFactory.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<Andy.Containers.Infrastructure.Data.ContainersDbContext>();
+            db.OutboxEntries.AddRange(
+                new OutboxEntry { Id = Guid.NewGuid(), Subject = "s", PayloadJson = "{}", CreatedAt = DateTimeOffset.UtcNow.AddSeconds(-10) },
+                new OutboxEntry { Id = Guid.NewGuid(), Subject = "s", PayloadJson = "{}", CreatedAt = DateTimeOffset.UtcNow.AddSeconds(-5) },
+                new OutboxEntry { Id = Guid.NewGuid(), Subject = "s", PayloadJson = "{}", CreatedAt = DateTimeOffset.UtcNow });
+            await db.SaveChangesAsync();
+        }
+
+        var dispatcher = new OutboxDispatcher(scopeFactory,
+            NullLogger<OutboxDispatcher>.Instance,
+            Options.Create(new OutboxDispatcherOptions()));
+
+        await dispatcher.DrainOnceAsync(CancellationToken.None);
+
+        // FIFO order: published in ascending CreatedAt
+        bus.Published.Select(p => p.CreatedAt).Should().BeInAscendingOrder();
+    }
+
+    [Fact]
+    public async Task DrainOnceAsync_RecordsFailureAndLeavesRowPending()
+    {
+        var (scopeFactory, bus, _) = BuildScope(nameof(DrainOnceAsync_RecordsFailureAndLeavesRowPending));
+        bus.ThrowOnPublish = true;
+
+        Guid entryId;
+        using (var scope = scopeFactory.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<Andy.Containers.Infrastructure.Data.ContainersDbContext>();
+            var entry = new OutboxEntry { Id = Guid.NewGuid(), Subject = "s", PayloadJson = "{}" };
+            entryId = entry.Id;
+            db.OutboxEntries.Add(entry);
+            await db.SaveChangesAsync();
+        }
+
+        var dispatcher = new OutboxDispatcher(scopeFactory,
+            NullLogger<OutboxDispatcher>.Instance,
+            Options.Create(new OutboxDispatcherOptions()));
+
+        await dispatcher.DrainOnceAsync(CancellationToken.None);
+
+        using (var scope = scopeFactory.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<Andy.Containers.Infrastructure.Data.ContainersDbContext>();
+            var entry = await db.OutboxEntries.FindAsync(entryId);
+            entry.Should().NotBeNull();
+            entry!.PublishedAt.Should().BeNull();
+            entry.AttemptCount.Should().Be(1);
+            entry.LastError.Should().NotBeNull();
+        }
+    }
+
+    private static (IServiceScopeFactory, RecordingMessageBus, string dbName) BuildScope(string testName)
+    {
+        var dbName = $"{testName}-{Guid.NewGuid()}";
+        var bus = new RecordingMessageBus();
+
+        var services = new ServiceCollection();
+        services.AddDbContext<Andy.Containers.Infrastructure.Data.ContainersDbContext>(o =>
+            o.UseInMemoryDatabase(dbName));
+        services.AddSingleton<IMessageBus>(bus);
+        var provider = services.BuildServiceProvider();
+
+        return (provider.GetRequiredService<IServiceScopeFactory>(), bus, dbName);
+    }
+
+    private sealed class RecordingMessageBus : IMessageBus
+    {
+        public List<(string Subject, object Payload, MessageHeaders Headers, DateTimeOffset CreatedAt)> Published { get; } = new();
+        public bool ThrowOnPublish { get; set; }
+
+        public Task PublishAsync(string subject, object payload, MessageHeaders headers, CancellationToken ct = default)
+        {
+            if (ThrowOnPublish) throw new InvalidOperationException("simulated publish failure");
+            Published.Add((subject, payload, headers, DateTimeOffset.UtcNow));
+            return Task.CompletedTask;
+        }
+
+        public IAsyncEnumerable<IncomingMessage> SubscribeAsync(string subjectFilter, SubscriptionOptions options, CancellationToken ct = default) =>
+            throw new NotSupportedException("Recording bus does not support subscribe.");
+    }
+}


### PR DESCRIPTION
First of three PRs against #78. Functional change: zero. Lays the groundwork so publisher wiring and NATS provider can land as smaller, focused follow-ups.

## What's in

- **`docs/adr/0001-messaging.md`** — reference ADR pointing at the [andy-tasks authored version](https://github.com/rivoli-ai/andy-tasks/blob/main/docs/adr/0001-messaging.md). Enumerates what this service publishes (`andy.containers.events.run.<id>.{finished,failed,cancelled}`) and subscribes to (nothing, yet).
- **`Andy.Containers.Messaging`** — `IMessageBus`, `MessageHeaders`, `IncomingMessage`, `SubscriptionOptions`, `EventJson`. Shape-identical to andy-tasks so both services can eventually share a NuGet package.
- **`OutboxEntry`** entity + `ContainersDbContext` `DbSet` + composite `(PublishedAt, CreatedAt)` index covering the dispatcher's hot path.
- **EF migration `AddOutboxEntry`** — Postgres and SQLite safe.
- **`InMemoryMessageBus`** — full NATS wildcard semantics (`*` and `>`) + generation-cap circuit breaker.
- **`OutboxDispatcher`** `BackgroundService` — poll, batch, publish, mark, retry.
- **`AddContainersMessaging()`** DI extension. Currently only `Messaging:Provider=InMemory` works; `Nats` throws `NotSupportedException` with a pointer to the follow-up PR.

12 new unit tests (subject matching, publish/subscribe, generation cap, outbox drain happy path, FIFO order, failure recording). All pass.

## Migration scope note

`dotnet ef migrations add` also picked up pre-existing drift from commit `014f42d` which added `Architecture` / `LayerCount` / `ImageSizeBytes` / `ImageDigest` / `Os` / `ImageCreatedAt` to `ImageBuildRecord` but didn't create a migration. Those changes are bundled here.

Leaving the drift un-migrated means main stays uncompilable-at-runtime for anyone applying migrations to a Postgres DB — the model code queries columns the schema doesn't have. The bundled catch-up fixes that as a side effect.

**If you'd rather see a separate \"fix ImageBuildRecord migration\" PR land first and this rebased on top, that's ~30 seconds of `git checkout` — say the word.**

## Deliberate scope cut

`AddContainersMessaging` throws on `Messaging:Provider=Nats` rather than leaving the wiring half-done. Making the happy path explicit avoids the "why does NATS selection silently fall back to InMemory?" trap.

## Test plan

Automated:
- [x] `dotnet build` — green, zero warnings
- [x] `dotnet test --filter "FullyQualifiedName~Messaging"` — 12 new, 0 fail
- [x] Full suite — same pre-existing failures on `main` (ProvisioningWorker script ordering; AppleContainer integration tests needing a `container` binary). Unrelated to this PR.
- [x] `dotnet format --verify-no-changes` — clean on all new files

## Follow-ups (in this order)

- **PR B**: `NatsMessageBus` + `NatsStreamProvisioner` + `docker-compose.yml` `nats:2-alpine` service + integration tests env-gated by `ANDY_CONTAINERS_TEST_NATS`.
- **PR C**: Publisher wiring — hook `OrchestrationService` / `ProvisioningWorker` lifecycle transitions to emit `run.*` events via the outbox. Thread `storyId` through `CreateContainerRequest`.

Consumer side (andy-issues) lives in rivoli-ai/andy-issues Epic 15 (#67–#74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)