### PR TITLE
NATS provider for messaging (#78 PR B/3)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,6 +66,8 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.11.2" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1" />
+    <!-- Messaging (ADR 0001) — version-aligned with andy-tasks -->
+    <PackageVersion Include="NATS.Net" Version="2.7.3" />
     <!-- Testing -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="xunit" Version="2.9.2" />

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,24 @@ services:
       timeout: 5s
       retries: 5
 
+  # NATS JetStream broker for inter-service messaging (ADR 0001).
+  # -js enables JetStream; -m 8222 exposes the HTTP monitoring endpoint
+  # used by the healthcheck and for local observability.
+  nats:
+    image: nats:2-alpine
+    container_name: andy-containers-nats
+    command: ["-js", "-m", "8222"]
+    ports:
+      - "4222:4222"
+      - "8222:8222"
+    volumes:
+      - nats_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8222/healthz || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   api:
     build:
       context: .
@@ -35,6 +53,8 @@ services:
       - Cors__Origins__0=https://localhost:5280
       - Cors__Origins__1=https://localhost:4200
       - Cors__Origins__2=https://localhost:3000
+      - Messaging__Provider=Nats
+      - Messaging__Nats__Url=nats://nats:4222
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:
@@ -49,6 +69,8 @@ services:
       - dataprotection_keys:/root/.aspnet/DataProtection-Keys
     depends_on:
       postgres:
+        condition: service_healthy
+      nats:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-fk", "https://localhost:8443/health"]
@@ -97,3 +119,4 @@ services:
 volumes:
   postgres_data:
   dataprotection_keys:
+  nats_data:

--- a/src/Andy.Containers.Infrastructure/Andy.Containers.Infrastructure.csproj
+++ b/src/Andy.Containers.Infrastructure/Andy.Containers.Infrastructure.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Andy.Containers.Api.Tests" />
     <InternalsVisibleTo Include="Andy.Containers.Tests" />
+    <InternalsVisibleTo Include="Andy.Containers.Integration.Tests" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,6 +31,7 @@
     <PackageReference Include="Google.Cloud.Run.V2" />
     <PackageReference Include="AWSSDK.ECS" />
     <PackageReference Include="AWSSDK.EC2" />
+    <PackageReference Include="NATS.Net" />
   </ItemGroup>
 
 </Project>

--- a/src/Andy.Containers.Infrastructure/Messaging/MessagingServiceCollectionExtensions.cs
+++ b/src/Andy.Containers.Infrastructure/Messaging/MessagingServiceCollectionExtensions.cs
@@ -25,13 +25,16 @@ public static class MessagingServiceCollectionExtensions
 
         if (string.Equals(provider, "Nats", StringComparison.OrdinalIgnoreCase))
         {
-            throw new NotSupportedException(
-                "Messaging:Provider=Nats is not wired yet. Follow-up PR to " +
-                "this repo's #78 adds NatsMessageBus + NatsStreamProvisioner. " +
-                "For now use Messaging:Provider=InMemory (the default).");
+            services.Configure<NatsOptions>(
+                configuration.GetSection(NatsOptions.SectionName));
+            services.AddSingleton<NatsMessageBus>();
+            services.AddSingleton<IMessageBus>(sp => sp.GetRequiredService<NatsMessageBus>());
+            services.AddHostedService<NatsStreamProvisioner>();
         }
-
-        services.TryAddSingleton<IMessageBus, InMemoryMessageBus>();
+        else
+        {
+            services.TryAddSingleton<IMessageBus, InMemoryMessageBus>();
+        }
 
         services.Configure<OutboxDispatcherOptions>(
             configuration.GetSection(OutboxDispatcherOptions.SectionName));

--- a/src/Andy.Containers.Infrastructure/Messaging/NatsMessageBus.cs
+++ b/src/Andy.Containers.Infrastructure/Messaging/NatsMessageBus.cs
@@ -1,0 +1,228 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Andy.Containers.Messaging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NATS.Client.Core;
+using NATS.Client.JetStream;
+using NATS.Client.JetStream.Models;
+
+namespace Andy.Containers.Infrastructure.Messaging;
+
+// IMessageBus backed by NATS JetStream per ADR 0001. The connection is
+// created once at construction and disposed when the DI container shuts
+// down. Stream provisioning (CreateOrUpdateStream) is handled by the
+// separate NatsStreamProvisioner hosted service which runs before any
+// BackgroundService, guaranteeing the stream exists before the
+// OutboxDispatcher starts publishing.
+public sealed class NatsMessageBus : IMessageBus, IAsyncDisposable
+{
+    private readonly NatsOptions _options;
+    private readonly ILogger<NatsMessageBus> _logger;
+    private readonly NatsConnection _connection;
+    private readonly INatsJSContext _jsContext;
+
+    public NatsMessageBus(IOptions<NatsOptions> options, ILogger<NatsMessageBus> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+        _connection = new NatsConnection(new NatsOpts { Url = _options.Url });
+        _jsContext = new NatsJSContext(_connection);
+    }
+
+    internal INatsJSContext JetStream => _jsContext;
+    internal NatsConnection Connection => _connection;
+
+    // Eagerly connect the underlying TCP socket. Called by
+    // NatsStreamProvisioner.StartAsync before any publish/subscribe so
+    // we don't pay the lazy-connect cost on the first hot-path
+    // operation.
+    internal async Task ConnectAsync(CancellationToken ct = default)
+    {
+        await _connection.ConnectAsync();
+    }
+
+    public async Task PublishAsync(
+        string subject,
+        object payload,
+        MessageHeaders headers,
+        CancellationToken ct = default)
+    {
+        if (headers.ExceedsGenerationLimit)
+        {
+            _logger.LogError(
+                "Dropping message {MsgId} on {Subject} — generation {Gen} exceeds limit {Max}. " +
+                "Correlation: {CorrId} Causation: {CausedBy}",
+                headers.MsgId, subject, headers.Generation, MessageHeaders.MaxGeneration,
+                headers.CorrelationId, headers.CausationId);
+            return;
+        }
+
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(payload, EventJson.Options);
+        var natsHeaders = ToNatsHeaders(headers);
+
+        var ack = await _jsContext.PublishAsync(subject, bytes, headers: natsHeaders, cancellationToken: ct);
+
+        if (ack.Error is not null)
+        {
+            throw new InvalidOperationException(
+                $"NATS JetStream publish rejected on {subject}: {ack.Error.Code} {ack.Error.Description}");
+        }
+    }
+
+    public async IAsyncEnumerable<IncomingMessage> SubscribeAsync(
+        string subjectFilter,
+        SubscriptionOptions options,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        // NATS 2.10+ embeds the consumer name in the subject for the
+        // CREATE API ($JS.API.CONSUMER.CREATE.<stream>.<name>). Dots in
+        // the name break subject parsing. Sanitize to dashes.
+        var safeDurableName = options.DurableName.Replace('.', '-');
+
+        var consumerConfig = new ConsumerConfig(safeDurableName)
+        {
+            FilterSubject = options.SubjectFilter ?? subjectFilter,
+            AckPolicy = options.ManualAck
+                ? ConsumerConfigAckPolicy.Explicit
+                : ConsumerConfigAckPolicy.None,
+            MaxDeliver = options.MaxDeliver
+        };
+
+        var consumer = await _jsContext.CreateOrUpdateConsumerAsync(
+            _options.StreamName, consumerConfig, ct);
+
+        _logger.LogDebug(
+            "Subscription opened on {Filter} durable {Durable}",
+            subjectFilter, options.DurableName);
+
+        await foreach (var jsMsg in consumer.ConsumeAsync<byte[]>(cancellationToken: ct))
+        {
+            var parsed = TryParseHeaders(jsMsg);
+            if (parsed is null)
+            {
+                _logger.LogWarning(
+                    "Dropping message on {Subject} — missing or malformed required headers. " +
+                    "Acking to prevent redelivery loop",
+                    jsMsg.Subject);
+                await PublishToDlqAsync(jsMsg.Subject, jsMsg.Data, jsMsg.Headers, ct);
+                await jsMsg.AckAsync(cancellationToken: ct);
+                continue;
+            }
+
+            if (parsed.ExceedsGenerationLimit)
+            {
+                _logger.LogError(
+                    "Dropping message {MsgId} on {Subject} — generation {Gen} exceeds limit {Max}. " +
+                    "Correlation: {CorrId} Causation: {CausedBy}",
+                    parsed.MsgId, jsMsg.Subject, parsed.Generation, MessageHeaders.MaxGeneration,
+                    parsed.CorrelationId, parsed.CausationId);
+                await PublishToDlqAsync(jsMsg.Subject, jsMsg.Data, jsMsg.Headers, ct);
+                await jsMsg.AckAsync(cancellationToken: ct);
+                continue;
+            }
+
+            yield return new NatsIncomingMessage(jsMsg)
+            {
+                Headers = parsed,
+                Subject = jsMsg.Subject,
+                Payload = jsMsg.Data ?? ReadOnlyMemory<byte>.Empty,
+                ReceivedAt = DateTimeOffset.UtcNow
+            };
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _connection.DisposeAsync();
+    }
+
+    private static NatsHeaders ToNatsHeaders(MessageHeaders headers)
+    {
+        return new NatsHeaders
+        {
+            { "Nats-Msg-Id", headers.MsgId.ToString() },
+            { "Andy-Correlation-Id", headers.CorrelationId.ToString() },
+            { "Andy-Causation-Id", headers.CausationId?.ToString() ?? "" },
+            { "Andy-Generation", headers.Generation.ToString() }
+        };
+    }
+
+    private static MessageHeaders? TryParseHeaders(INatsJSMsg<byte[]> jsMsg)
+    {
+        if (jsMsg.Headers is null)
+            return null;
+
+        var h = jsMsg.Headers;
+
+        if (!h.TryGetValue("Nats-Msg-Id", out var msgIdValues)
+            || !Guid.TryParse(msgIdValues.ToString(), out var msgId))
+            return null;
+
+        if (!h.TryGetValue("Andy-Correlation-Id", out var corrValues)
+            || !Guid.TryParse(corrValues.ToString(), out var correlationId))
+            return null;
+
+        if (!h.TryGetValue("Andy-Generation", out var genValues)
+            || !int.TryParse(genValues.ToString(), out var generation))
+            return null;
+
+        Guid? causationId = null;
+        if (h.TryGetValue("Andy-Causation-Id", out var causValues))
+        {
+            var raw = causValues.ToString();
+            if (!string.IsNullOrEmpty(raw) && Guid.TryParse(raw, out var parsed))
+                causationId = parsed;
+        }
+
+        return new MessageHeaders(msgId, correlationId, causationId, generation);
+    }
+
+    private async Task PublishToDlqAsync(
+        string originalSubject,
+        byte[]? payload,
+        NatsHeaders? originalHeaders,
+        CancellationToken ct)
+    {
+        try
+        {
+            var dlqSubject = $"{_options.DlqPrefix}.{originalSubject}";
+            await _jsContext.PublishAsync(
+                dlqSubject,
+                payload ?? [],
+                headers: originalHeaders,
+                cancellationToken: ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to publish to DLQ for {OriginalSubject} — message is lost",
+                originalSubject);
+        }
+    }
+}
+
+// Wraps an INatsJSMsg<byte[]> so consumers call Ack/Nack through the
+// IncomingMessage abstraction without knowing about the NATS client.
+internal sealed class NatsIncomingMessage : IncomingMessage
+{
+    private readonly INatsJSMsg<byte[]> _jsMsg;
+
+    internal NatsIncomingMessage(INatsJSMsg<byte[]> jsMsg)
+    {
+        _jsMsg = jsMsg;
+    }
+
+    public override async Task AckAsync(CancellationToken ct = default)
+    {
+        await _jsMsg.AckAsync(cancellationToken: ct);
+    }
+
+    public override async Task NackAsync(CancellationToken ct = default)
+    {
+        await _jsMsg.NakAsync(cancellationToken: ct);
+    }
+}

--- a/src/Andy.Containers.Infrastructure/Messaging/NatsOptions.cs
+++ b/src/Andy.Containers.Infrastructure/Messaging/NatsOptions.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Containers.Infrastructure.Messaging;
+
+public sealed class NatsOptions
+{
+    public const string SectionName = "Messaging:Nats";
+
+    public string Url { get; set; } = "nats://localhost:4222";
+    public string StreamName { get; set; } = "ANDY";
+    public string[] StreamSubjects { get; set; } = ["andy.>"];
+    public TimeSpan MaxAge { get; set; } = TimeSpan.FromDays(7);
+    public string DlqPrefix { get; set; } = "andy.containers.dlq";
+}

--- a/src/Andy.Containers.Infrastructure/Messaging/NatsStreamProvisioner.cs
+++ b/src/Andy.Containers.Infrastructure/Messaging/NatsStreamProvisioner.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NATS.Client.JetStream.Models;
+
+namespace Andy.Containers.Infrastructure.Messaging;
+
+// Ensures the JetStream stream exists before any BackgroundService
+// (OutboxDispatcher, future consumers) starts publishing or
+// subscribing. IHostedService.StartAsync runs before BackgroundService
+// .ExecuteAsync, so the ordering guarantee is built into the host.
+// CreateOrUpdateStreamAsync is idempotent — safe on every boot.
+public sealed class NatsStreamProvisioner(
+    NatsMessageBus bus,
+    IOptions<NatsOptions> options,
+    ILogger<NatsStreamProvisioner> logger) : IHostedService
+{
+    public async Task StartAsync(CancellationToken ct)
+    {
+        await bus.ConnectAsync(ct);
+
+        var opts = options.Value;
+        var config = new StreamConfig(opts.StreamName, opts.StreamSubjects)
+        {
+            MaxAge = opts.MaxAge
+        };
+
+        await bus.JetStream.CreateOrUpdateStreamAsync(config, ct);
+
+        logger.LogInformation(
+            "NATS JetStream stream {Stream} provisioned with subjects [{Subjects}]",
+            opts.StreamName, string.Join(", ", opts.StreamSubjects));
+    }
+
+    public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+}

--- a/tests/Andy.Containers.Integration.Tests/Messaging/NatsFactAttribute.cs
+++ b/tests/Andy.Containers.Integration.Tests/Messaging/NatsFactAttribute.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Xunit;
+
+namespace Andy.Containers.Integration.Tests.Messaging;
+
+// Fact attribute that skips when NATS is not available. Set
+// ANDY_CONTAINERS_TEST_NATS=true and point Messaging__Nats__Url (or
+// NATS_URL) at a running JetStream server to run these tests — same
+// gating pattern andy-tasks uses for its own NATS integration tests.
+public sealed class NatsFactAttribute : FactAttribute
+{
+    private const string EnvVar = "ANDY_CONTAINERS_TEST_NATS";
+
+    public NatsFactAttribute()
+    {
+        if (!string.Equals(
+                Environment.GetEnvironmentVariable(EnvVar),
+                "true",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            Skip = $"NATS integration tests require {EnvVar}=true and a running NATS server with JetStream";
+        }
+    }
+}

--- a/tests/Andy.Containers.Integration.Tests/Messaging/NatsMessageBusTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/Messaging/NatsMessageBusTests.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Messaging;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NATS.Client.JetStream.Models;
+using Xunit;
+
+namespace Andy.Containers.Integration.Tests.Messaging;
+
+// End-to-end publish/subscribe tests against a real NATS JetStream
+// server. Each test uses a randomized subject under andy.containers.>
+// and a randomized durable consumer name so runs don't cross-pollinate.
+//
+// Run locally with:
+//   docker compose up -d nats
+//   ANDY_CONTAINERS_TEST_NATS=true dotnet test tests/Andy.Containers.Integration.Tests
+public class NatsMessageBusTests
+{
+    private static readonly TimeSpan MessageTimeout = TimeSpan.FromSeconds(10);
+
+    private static string NatsUrl =>
+        Environment.GetEnvironmentVariable("NATS_URL")
+        ?? Environment.GetEnvironmentVariable("Messaging__Nats__Url")
+        ?? "nats://localhost:4222";
+
+    // Each test gets a unique stream name + subject prefix so concurrent
+    // tests don't hit "subjects overlap with an existing stream" from
+    // JetStream when running in parallel, and leftover state from a
+    // previous run can't leak in.
+    private static async Task<(NatsMessageBus Bus, string SubjectPrefix)> CreateAndConnectAsync()
+    {
+        var testId = Guid.NewGuid().ToString("N");
+        var subjectPrefix = $"andy.test-{testId}";
+
+        var opts = Options.Create(new NatsOptions
+        {
+            Url = NatsUrl,
+            StreamName = $"ANDY_TEST_{testId}",
+            StreamSubjects = [$"{subjectPrefix}.>"]
+        });
+
+        var bus = new NatsMessageBus(opts, NullLogger<NatsMessageBus>.Instance);
+        await bus.ConnectAsync();
+
+        var streamConfig = new StreamConfig(opts.Value.StreamName, opts.Value.StreamSubjects)
+        {
+            MaxAge = TimeSpan.FromMinutes(5)
+        };
+        await bus.JetStream.CreateOrUpdateStreamAsync(streamConfig);
+
+        return (bus, subjectPrefix);
+    }
+
+    [NatsFact]
+    public async Task PublishAndSubscribe_RoundTripWithHeaders()
+    {
+        var (bus, prefix) = await CreateAndConnectAsync();
+        await using var _ = bus;
+
+        var headers = MessageHeaders.NewRoot();
+        var subject = $"{prefix}.events.run.{Guid.NewGuid():N}.finished";
+        var payload = new { runId = "abc", status = "success", schema_version = 1 };
+
+        await bus.PublishAsync(subject, payload, headers);
+
+        var options = new SubscriptionOptions(
+            DurableName: $"test-roundtrip-{Guid.NewGuid():N}");
+
+        using var cts = new CancellationTokenSource(MessageTimeout);
+        IncomingMessage? received = null;
+
+        await foreach (var msg in bus.SubscribeAsync(subject, options, cts.Token))
+        {
+            received = msg;
+            await msg.AckAsync(cts.Token);
+            break;
+        }
+
+        received.Should().NotBeNull();
+        received!.Subject.Should().Be(subject);
+        received.Headers.MsgId.Should().Be(headers.MsgId);
+        received.Headers.CorrelationId.Should().Be(headers.CorrelationId);
+        received.Headers.CausationId.Should().BeNull();
+        received.Headers.Generation.Should().Be(0);
+
+        var body = JsonSerializer.Deserialize<JsonElement>(received.Payload.Span);
+        body.GetProperty("run_id").GetString().Should().Be("abc");
+        body.GetProperty("status").GetString().Should().Be("success");
+    }
+
+    [NatsFact]
+    public async Task Publish_GenerationExceeded_DropsMessage()
+    {
+        var (bus, prefix) = await CreateAndConnectAsync();
+        await using var _ = bus;
+
+        var subject = $"{prefix}.events.run.{Guid.NewGuid():N}.finished";
+        var headers = new MessageHeaders(
+            MsgId: Guid.NewGuid(),
+            CorrelationId: Guid.NewGuid(),
+            CausationId: Guid.NewGuid(),
+            Generation: MessageHeaders.MaxGeneration + 1);
+
+        // ADR 0001 circuit breaker: silently dropped, no exception.
+        await bus.PublishAsync(subject, new { }, headers);
+
+        // Subscribe and verify nothing arrives within a short window.
+        var options = new SubscriptionOptions(
+            DurableName: $"test-genlimit-{Guid.NewGuid():N}");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var count = 0;
+
+        try
+        {
+            await foreach (var msg in bus.SubscribeAsync(subject, options, cts.Token))
+            {
+                count++;
+                await msg.AckAsync(cts.Token);
+            }
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            // Expected — timed out with no messages.
+        }
+
+        count.Should().Be(0);
+    }
+
+    [NatsFact]
+    public async Task SubscribeAsync_DurableWithDottedName_SanitizesToDashes()
+    {
+        // NATS 2.10+ rejects consumer names with '.' because the CREATE
+        // API embeds them in a subject. NatsMessageBus sanitizes
+        // internally; verify a dotted DurableName still works.
+        var (bus, prefix) = await CreateAndConnectAsync();
+        await using var _ = bus;
+
+        var subject = $"{prefix}.events.run.{Guid.NewGuid():N}.finished";
+        await bus.PublishAsync(subject, new { runId = "x" }, MessageHeaders.NewRoot());
+
+        var options = new SubscriptionOptions(
+            DurableName: $"andy.containers.test.{Guid.NewGuid():N}");
+
+        using var cts = new CancellationTokenSource(MessageTimeout);
+        IncomingMessage? received = null;
+
+        await foreach (var msg in bus.SubscribeAsync(subject, options, cts.Token))
+        {
+            received = msg;
+            await msg.AckAsync(cts.Token);
+            break;
+        }
+
+        received.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
Second of three PRs against #78. Functional change for existing callers: zero — still no publisher wiring (that's PR C). Adds the NATS transport so `Messaging:Provider=Nats` now works end-to-end.

## What's in

- **NATS.Net 2.7.3** added to `Directory.Packages.props`, version-aligned with andy-tasks for eventual shared-package extraction.
- **`NatsOptions`** — `Messaging:Nats` section: `Url`, `StreamName=ANDY` (shared ecosystem stream), `StreamSubjects=[andy.>]`, `MaxAge=7d`, `DlqPrefix=andy.containers.dlq`.
- **`NatsMessageBus`** — `IMessageBus` backed by JetStream. Snake-case payloads. Four-header envelope (`Nats-Msg-Id`, `Andy-Correlation-Id`, `Andy-Causation-Id`, `Andy-Generation`) on every publish. Consumer-side: missing/malformed headers and generation-cap overflow both route to the DLQ + ack to prevent redelivery loops. Consumer name sanitized (`.` → `-`) for NATS 2.10+.
- **`NatsStreamProvisioner`** — `IHostedService`, eagerly connects and `CreateOrUpdateStreamAsync` on boot. Runs before `OutboxDispatcher.ExecuteAsync`.
- **`MessagingServiceCollectionExtensions`** — `Messaging:Provider=Nats` now registers the NATS bits instead of throwing; `InMemory` stays the default.
- **`docker-compose.yml`** — `nats:2-alpine` service with JetStream + HTTP monitoring. API container wires `Messaging__Provider=Nats` by default.
- **3 integration tests** env-gated by `ANDY_CONTAINERS_TEST_NATS=true`:
  - `PublishAndSubscribe_RoundTripWithHeaders`
  - `Publish_GenerationExceeded_DropsMessage`
  - `SubscribeAsync_DurableWithDottedName_SanitizesToDashes`
  Each uses a unique stream + subject prefix so runs don't hit "subjects overlap" in JetStream.

## Test plan

- [x] `dotnet build` — green, zero warnings
- [x] Full unit suite — 12 messaging unit tests from PR A still pass; no regressions
- [x] `dotnet format --verify-no-changes` — clean
- [x] NATS integration tests against live broker:
  ```
  docker compose up -d nats
  ANDY_CONTAINERS_TEST_NATS=true dotnet test tests/Andy.Containers.Integration.Tests --filter "FullyQualifiedName~Messaging"
  # → Passed! Failed: 0, Passed: 3
  ```
- [x] Skip behavior: when `ANDY_CONTAINERS_TEST_NATS` is not set, the 3 NATS tests cleanly skip (no flaky failures on CI workers without a broker).

## CI suggestion (not in this PR)

A follow-up CI workflow would:
1. `docker compose up -d nats` before tests
2. `ANDY_CONTAINERS_TEST_NATS=true dotnet test` to run the gated tests
3. Surface failures as part of normal PR checks

Holding off on that until PR C lands so CI covers the full publisher-through-NATS-to-consumer path in one go.

## Follow-up

- **PR C** (last in this #78 sequence): hook `OrchestrationService` / `ProvisioningWorker` lifecycle transitions to emit `andy.containers.events.run.{id}.{finished|failed|cancelled}` via the outbox. Thread `storyId` through `CreateContainerRequest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)