### PR TITLE
Publisher wiring for container run events (#78 PR C/3, final)

### DIFF
--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -3,6 +3,7 @@ using Andy.Containers.Abstractions;
 using Andy.Containers.Api.Data;
 using Andy.Containers.Api.Services;
 using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Infrastructure.Messaging;
 using Microsoft.EntityFrameworkCore;
 using Andy.Containers.Api.Telemetry;
 using Andy.Rbac.Client;
@@ -222,6 +223,10 @@ try
 
     // OpenTelemetry
     builder.Services.AddAndyTelemetry(builder.Configuration);
+
+    // Messaging (ADR 0001) — registers IMessageBus (InMemory by default,
+    // Nats when Messaging:Provider=Nats) and the OutboxDispatcher.
+    builder.Services.AddContainersMessaging(builder.Configuration);
 
     var app = builder.Build();
 

--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -3,6 +3,8 @@ using System.Text.Json;
 using Andy.Containers.Abstractions;
 using Andy.Containers.Api.Telemetry;
 using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -90,6 +92,7 @@ public class ContainerOrchestrationService : IContainerService
             Status = ContainerStatus.Pending,
             CreationSource = request.Source,
             ClientInfo = request.ClientInfo,
+            StoryId = request.StoryId,
             ExpiresAt = request.ExpiresAfter.HasValue
                 ? DateTime.UtcNow.Add(request.ExpiresAfter.Value)
                 : null
@@ -434,6 +437,11 @@ public class ContainerOrchestrationService : IContainerService
         container.Status = ContainerStatus.Stopped;
         container.StoppedAt = DateTime.UtcNow;
         _db.Events.Add(new ContainerEvent { ContainerId = containerId, EventType = ContainerEventType.Stopped });
+        // Emit andy.containers.events.run.<id>.finished — clean stop.
+        var durationSeconds = (container.StartedAt.HasValue && container.StoppedAt.HasValue)
+            ? (container.StoppedAt.Value - container.StartedAt.Value).TotalSeconds
+            : (double?)null;
+        _db.AppendRunEvent(container, RunEventKind.Finished, exitCode: null, durationSeconds: durationSeconds);
         await _db.SaveChangesAsync(ct);
     }
 
@@ -451,6 +459,11 @@ public class ContainerOrchestrationService : IContainerService
 
         container.Status = ContainerStatus.Destroyed;
         _db.Events.Add(new ContainerEvent { ContainerId = containerId, EventType = ContainerEventType.Destroyed });
+        // Emit andy.containers.events.run.<id>.cancelled — explicit teardown.
+        var destroyedDuration = (container.StartedAt.HasValue)
+            ? (DateTime.UtcNow - container.StartedAt.Value).TotalSeconds
+            : (double?)null;
+        _db.AppendRunEvent(container, RunEventKind.Cancelled, exitCode: null, durationSeconds: destroyedDuration);
         await _db.SaveChangesAsync(ct);
 
         Meters.ContainersDeleted.Add(1);

--- a/src/Andy.Containers.Api/Services/ContainerProvisioningWorker.cs
+++ b/src/Andy.Containers.Api/Services/ContainerProvisioningWorker.cs
@@ -2,6 +2,8 @@ using System.Diagnostics;
 using Andy.Containers.Abstractions;
 using Andy.Containers.Api.Telemetry;
 using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -353,6 +355,8 @@ public class ContainerProvisioningWorker : BackgroundService
                     EventType = ContainerEventType.Failed,
                     Details = System.Text.Json.JsonSerializer.Serialize(new { error = errorMessage })
                 });
+                // Emit andy.containers.events.run.<id>.failed — provisioning failure.
+                db.AppendRunEvent(container, RunEventKind.Failed, exitCode: null, durationSeconds: null);
                 await db.SaveChangesAsync();
             }
         }
@@ -386,6 +390,7 @@ public class ContainerProvisioningWorker : BackgroundService
                     EventType = ContainerEventType.Failed,
                     Details = System.Text.Json.JsonSerializer.Serialize(new { error = "Recovered from stuck state on worker restart" })
                 });
+                db.AppendRunEvent(container, RunEventKind.Failed, exitCode: null, durationSeconds: null);
             }
 
             if (stuckContainers.Count > 0)

--- a/src/Andy.Containers.Infrastructure/Messaging/RunEventOutbox.cs
+++ b/src/Andy.Containers.Infrastructure/Messaging/RunEventOutbox.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Messaging;
+using Andy.Containers.Messaging.Events;
+using Andy.Containers.Models;
+
+namespace Andy.Containers.Infrastructure.Messaging;
+
+// Helper for appending a run.* OutboxEntry to the DbContext in the same
+// unit of work as the container's status transition. Caller controls
+// SaveChangesAsync — the outbox row lands with whatever else is pending,
+// so dual-write consistency is preserved by EF's transaction scope.
+public static class RunEventOutbox
+{
+    // Build and attach a run event outbox row. Does not SaveChanges.
+    public static void AppendRunEvent(
+        this ContainersDbContext db,
+        Container container,
+        RunEventKind kind,
+        int? exitCode = null,
+        double? durationSeconds = null)
+    {
+        var payload = new RunEventPayload(
+            RunId: container.Id,
+            StoryId: container.StoryId,
+            Status: container.Status.ToString(),
+            ExitCode: exitCode,
+            DurationSeconds: durationSeconds);
+
+        var subject = $"andy.containers.events.run.{container.Id}.{kind.ToSubjectKind()}";
+
+        var correlationId = container.StoryId ?? container.Id;
+
+        db.OutboxEntries.Add(new OutboxEntry
+        {
+            Id = Guid.NewGuid(),
+            Subject = subject,
+            PayloadType = typeof(RunEventPayload).FullName,
+            PayloadJson = JsonSerializer.Serialize(payload, EventJson.Options),
+            CorrelationId = correlationId,
+            CausationId = null,
+            Generation = 0,
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+    }
+}

--- a/src/Andy.Containers.Infrastructure/Migrations/20260414234228_AddContainerStoryId.Designer.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260414234228_AddContainerStoryId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Andy.Containers.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Containers.Infrastructure.Migrations
 {
     [DbContext(typeof(ContainersDbContext))]
-    partial class ContainersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414234228_AddContainerStoryId")]
+    partial class AddContainerStoryId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Containers.Infrastructure/Migrations/20260414234228_AddContainerStoryId.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260414234228_AddContainerStoryId.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Containers.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddContainerStoryId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "StoryId",
+                table: "Containers",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StoryId",
+                table: "Containers");
+        }
+    }
+}

--- a/src/Andy.Containers/Abstractions/IContainerService.cs
+++ b/src/Andy.Containers/Abstractions/IContainerService.cs
@@ -46,6 +46,11 @@ public class CreateContainerRequest
     public string? ClientInfo { get; set; }
     public string? OwnerEmail { get; set; }
     public string? OwnerPreferredUsername { get; set; }
+
+    // Optional correlation to a backlog story. When set, the container's
+    // run.* lifecycle events (finished/failed/cancelled) carry this id so
+    // the caller (e.g. andy-issues) can tie the run back to a UserStory.
+    public Guid? StoryId { get; set; }
 }
 
 public class GitRepositoryConfig

--- a/src/Andy.Containers/Messaging/Events/RunEvents.cs
+++ b/src/Andy.Containers/Messaging/Events/RunEvents.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Containers.Messaging.Events;
+
+// Payload for andy.containers.events.run.{runId}.{kind} events, per
+// ADR 0001 and the Story 15.6 contract in andy-issues. Serialised with
+// EventJson.Options (snake_case) when written to the outbox.
+//
+// RunId is the Container.Id. StoryId is the optional correlation field
+// stamped by the caller (andy-issues' SandboxService) at create time.
+// Status mirrors the Container's terminal state so consumers don't
+// need to parse the subject's trailing kind token.
+public sealed record RunEventPayload(
+    Guid RunId,
+    Guid? StoryId,
+    string Status,
+    int? ExitCode,
+    double? DurationSeconds)
+{
+    public const int SchemaVersion = 1;
+
+    public int Schema_Version => SchemaVersion;
+}
+
+// Three terminal-lifecycle kinds are published. Mapping to container
+// status transitions:
+//   Finished  — StopContainerAsync (clean shutdown)
+//   Failed    — MarkFailedAsync in ProvisioningWorker (provision failure)
+//   Cancelled — DestroyContainerAsync (explicit teardown)
+public enum RunEventKind
+{
+    Finished,
+    Failed,
+    Cancelled
+}
+
+public static class RunEventKindExtensions
+{
+    public static string ToSubjectKind(this RunEventKind kind) => kind switch
+    {
+        RunEventKind.Finished => "finished",
+        RunEventKind.Failed => "failed",
+        RunEventKind.Cancelled => "cancelled",
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
+    };
+}

--- a/src/Andy.Containers/Models/Container.cs
+++ b/src/Andy.Containers/Models/Container.cs
@@ -31,6 +31,12 @@ public class Container
     public string? ContainerUser { get; set; }
     public string? Metadata { get; set; }
 
+    // Optional correlation to a backlog story. Stamped by the caller
+    // (typically andy-issues' SandboxService) at create time. Propagated
+    // into run.* event payloads so andy-issues' Story 15.6 consumer can
+    // transition the linked UserStory's state on run completion.
+    public Guid? StoryId { get; set; }
+
     public ICollection<ContainerSession> Sessions { get; set; } = new List<ContainerSession>();
     public ICollection<ContainerEvent> Events { get; set; } = new List<ContainerEvent>();
     public ICollection<ContainerGitRepository> GitRepositories { get; set; } = new List<ContainerGitRepository>();

--- a/tests/Andy.Containers.Api.Tests/Messaging/RunEventOutboxTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Messaging/RunEventOutboxTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Messaging.Events;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Messaging;
+
+public class RunEventOutboxTests
+{
+    [Fact]
+    public async Task AppendRunEvent_WritesRowWithExpectedSubjectAndPayload()
+    {
+        using var db = InMemoryDbHelper.CreateContext();
+
+        var storyId = Guid.NewGuid();
+        var container = new Container
+        {
+            Id = Guid.NewGuid(),
+            Name = "test-container",
+            OwnerId = "tester",
+            StoryId = storyId,
+            Status = ContainerStatus.Stopped
+        };
+
+        db.AppendRunEvent(container, RunEventKind.Finished, exitCode: 0, durationSeconds: 42.5);
+        await db.SaveChangesAsync();
+
+        var entry = await db.OutboxEntries.SingleAsync();
+        entry.Subject.Should().Be($"andy.containers.events.run.{container.Id}.finished");
+        entry.PublishedAt.Should().BeNull();
+        entry.CorrelationId.Should().Be(storyId);
+        entry.Generation.Should().Be(0);
+
+        using var doc = JsonDocument.Parse(entry.PayloadJson);
+        var root = doc.RootElement;
+        root.GetProperty("run_id").GetString().Should().Be(container.Id.ToString());
+        root.GetProperty("story_id").GetString().Should().Be(storyId.ToString());
+        root.GetProperty("status").GetString().Should().Be("Stopped");
+        root.GetProperty("exit_code").GetInt32().Should().Be(0);
+        root.GetProperty("duration_seconds").GetDouble().Should().Be(42.5);
+        root.GetProperty("schema_version").GetInt32().Should().Be(RunEventPayload.SchemaVersion);
+    }
+
+    [Fact]
+    public async Task AppendRunEvent_WithoutStoryId_OmitsStoryIdAndCorrelatesToRunId()
+    {
+        using var db = InMemoryDbHelper.CreateContext();
+
+        var container = new Container
+        {
+            Id = Guid.NewGuid(),
+            Name = "no-story",
+            OwnerId = "tester",
+            StoryId = null,
+            Status = ContainerStatus.Failed
+        };
+
+        db.AppendRunEvent(container, RunEventKind.Failed);
+        await db.SaveChangesAsync();
+
+        var entry = await db.OutboxEntries.SingleAsync();
+        entry.Subject.Should().Be($"andy.containers.events.run.{container.Id}.failed");
+        entry.CorrelationId.Should().Be(container.Id);
+
+        using var doc = JsonDocument.Parse(entry.PayloadJson);
+        var root = doc.RootElement;
+        root.TryGetProperty("story_id", out _).Should().BeFalse(
+            "story_id should be omitted when null (EventJson ignores nulls on write)");
+        root.GetProperty("status").GetString().Should().Be("Failed");
+    }
+
+    [Theory]
+    [InlineData(RunEventKind.Finished, "finished")]
+    [InlineData(RunEventKind.Failed, "failed")]
+    [InlineData(RunEventKind.Cancelled, "cancelled")]
+    public async Task AppendRunEvent_SubjectKindMatchesEnum(RunEventKind kind, string expectedSuffix)
+    {
+        using var db = InMemoryDbHelper.CreateContext();
+        var container = new Container
+        {
+            Id = Guid.NewGuid(),
+            Name = "x",
+            OwnerId = "t",
+            Status = ContainerStatus.Destroyed
+        };
+
+        db.AppendRunEvent(container, kind);
+        await db.SaveChangesAsync();
+
+        var entry = await db.OutboxEntries.SingleAsync();
+        entry.Subject.Should().EndWith($".{expectedSuffix}");
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTests.cs
@@ -208,6 +208,62 @@ public class ContainerOrchestrationServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task StopContainer_EmitsRunFinishedOutboxRow()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+        var storyId = Guid.NewGuid();
+        var container = new Container
+        {
+            Name = "to-stop",
+            OwnerId = "user1",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            ExternalId = "ext-stop-1",
+            Status = ContainerStatus.Running,
+            StartedAt = DateTime.UtcNow.AddSeconds(-10),
+            StoryId = storyId
+        };
+        _db.Containers.Add(container);
+        await _db.SaveChangesAsync();
+
+        _mockInfraProvider.Setup(p => p.StopContainerAsync("ext-stop-1", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await _service.StopContainerAsync(container.Id, CancellationToken.None);
+
+        var outbox = await _db.OutboxEntries.SingleAsync();
+        outbox.Subject.Should().Be($"andy.containers.events.run.{container.Id}.finished");
+        outbox.PublishedAt.Should().BeNull();
+        outbox.CorrelationId.Should().Be(storyId);
+        outbox.PayloadJson.Should().Contain("\"duration_seconds\"");
+    }
+
+    [Fact]
+    public async Task DestroyContainer_EmitsRunCancelledOutboxRow()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+        var container = new Container
+        {
+            Name = "to-destroy-evt",
+            OwnerId = "user1",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            ExternalId = "ext-destroy-evt",
+            Status = ContainerStatus.Running
+        };
+        _db.Containers.Add(container);
+        await _db.SaveChangesAsync();
+
+        _mockInfraProvider.Setup(p => p.DestroyContainerAsync("ext-destroy-evt", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await _service.DestroyContainerAsync(container.Id, CancellationToken.None);
+
+        var outbox = await _db.OutboxEntries.SingleAsync();
+        outbox.Subject.Should().Be($"andy.containers.events.run.{container.Id}.cancelled");
+    }
+
+    [Fact]
     public async Task DestroyContainer_WithoutExternalId_ShouldNotCallProviderButStillDestroy()
     {
         var (template, provider) = await SeedTemplateAndProvider();


### PR DESCRIPTION
Third and final PR against #78. Hooks the container lifecycle transitions to emit `andy.containers.events.run.<id>.{finished|failed|cancelled}` through the outbox. Completes the publisher side of the [andy-issues Story 15.6](https://github.com/rivoli-ai/andy-issues/issues/72) consumer contract.

## Subject + payload contract

Per andy-tasks ADR 0001:

```
andy.containers.events.run.{runId}.finished
andy.containers.events.run.{runId}.failed
andy.containers.events.run.{runId}.cancelled

payload: { run_id, story_id?, status, exit_code?, duration_seconds?, schema_version: 1 }
```

## Lifecycle → event mapping

| Source | Event |
|---|---|
| `ContainerOrchestrationService.StopContainerAsync` (clean shutdown) | `run.<id>.finished` |
| `ContainerProvisioningWorker.MarkFailedAsync` + `RecoverStuckContainersAsync` | `run.<id>.failed` |
| `ContainerOrchestrationService.DestroyContainerAsync` (explicit teardown) | `run.<id>.cancelled` |
| Create | no event (per issue AC — only terminal transitions) |

Each hook appends the `OutboxEntry` in the same `DbContext` transaction as the status change, so the `OutboxDispatcher` from PR A drains it at the next tick. **Correlation id is `StoryId` when set**, so consumers can trace the run back to a backlog story; otherwise it defaults to the run id itself.

## Changes

- **`Container.StoryId`** (nullable Guid) + single-column EF migration. No drift.
- **`CreateContainerRequest.StoryId`**; `ContainerOrchestrationService` persists it at create time. No proto change — the gRPC `CreateContainer` endpoint is unimplemented (base class only), so no wire contract to update. REST callers (`andy-issues` `SandboxService`) can start sending `StoryId` immediately.
- **`Andy.Containers.Messaging.Events`** — `RunEventPayload` record, `RunEventKind` enum, `ToSubjectKind` extension.
- **`RunEventOutbox.AppendRunEvent`** `DbContext` extension — builds the `OutboxEntry` with correct subject, payload, and correlation id.
- **`Program.cs`** now wires `AddContainersMessaging`. (PR A intentionally left it unwired to keep that PR behaviorless.)

## Tests

7 new unit tests, all passing:

- `AppendRunEvent_WritesRowWithExpectedSubjectAndPayload`
- `AppendRunEvent_WithoutStoryId_OmitsStoryIdAndCorrelatesToRunId`
- `AppendRunEvent_SubjectKindMatchesEnum` (theory × 3 kinds)
- `StopContainer_EmitsRunFinishedOutboxRow`
- `DestroyContainer_EmitsRunCancelledOutboxRow`

Total messaging tests in the repo now: 17 (12 from PR A + 5 new). Full suite: same pre-existing failures as `main` (`ContainerProvisioningWorkerTests.ProcessJob_PostCreateAndCodeAssistant_ShouldRunInOrder`; AppleContainer integration tests). Not addressed here.

## What merging this unlocks

With PR A, PR B (both merged) and this PR on `main`:

- `Messaging:Provider=InMemory` (default): containers emit run events into a local outbox; dispatcher drains them to an in-process bus. Fine for dev.
- `Messaging:Provider=Nats`: same outbox drain target is now NATS JetStream. Any service subscribed to `andy.containers.events.run.*` receives events.
- andy-issues Story 15.6 can now build its `ContainerRunEventConsumer` and consume against a real publisher.

## Follow-ups (not in this PR)

- CI workflow spinning up the compose `nats` service before tests (decision deferred on PR B pending this lifetime landing so CI covers the full publish-through-NATS-to-consume path in one go).
- Richer event kinds (`session.*`, `agent.stdout`, `build.progress`) — straightforward additions using the same outbox helper; add subjects as use cases land.

Closes #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)