### PR TITLE
Align ports to the three-mode registry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: andy_containers
     ports:
-      - "5434:5432"
+      - "7434:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -24,8 +24,8 @@ services:
     container_name: andy-containers-nats
     command: ["-js", "-m", "8222"]
     ports:
-      - "4222:4222"
-      - "8222:8222"
+      - "7422:4222"
+      - "7223:8222"
     volumes:
       - nats_data:/data
     healthcheck:
@@ -58,9 +58,9 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:
-      - "5200:8443"
-      - "5201:8080"
-      - "4200:8443"
+      - "7200:8443"
+      - "7201:8080"
+      - "6200:8443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./certs:/usr/local/share/ca-certificates/custom:ro

--- a/src/Andy.Containers.Api/Properties/launchSettings.json
+++ b/src/Andy.Containers.Api/Properties/launchSettings.json
@@ -1,10 +1,19 @@
 {
   "profiles": {
-    "Andy.Containers.Api": {
+    "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "https://localhost:5200",
+      "applicationUrl": "https://localhost:5200;http://localhost:5201",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5201",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/Andy.Containers.Api/appsettings.Development.json
+++ b/src/Andy.Containers.Api/appsettings.Development.json
@@ -1,6 +1,10 @@
 {
+  "//": "Dev-override for `dotnet run + docker compose up deps` — points at Mode 2 docker host ports (Mode 1 + 2000). See andy-service-template/docs/ports.md.",
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=7434;Database=andy_containers;Username=postgres;Password=postgres"
+  },
   "AndyAuth": {
-    "Authority": "https://localhost:5001",
+    "Authority": "https://localhost:7001",
     "Audience": "urn:andy-containers-api"
   },
   "Rbac": {

--- a/src/Andy.Containers.Api/appsettings.json
+++ b/src/Andy.Containers.Api/appsettings.json
@@ -31,7 +31,7 @@
     "IntervalSeconds": 60
   },
   "Rbac": {
-    "ApiBaseUrl": "https://localhost:7003",
+    "ApiBaseUrl": "https://localhost:5003",
     "ApplicationCode": "containers"
   },
   "Serilog": {


### PR DESCRIPTION
Per rivoli-ai/andy-service-template#2. Mode 1 5200/5201/5434/4200, Mode 2 7200/7201/7434/6200.

Changes:
- `appsettings.json`: Rbac:ApiBaseUrl 7003 → 5003 (Mode 1 canonical)
- `appsettings.Development.json`: pg 5434 → 7434, Rbac 5003 → 7003, AndyAuth 5001 → 7001 (Mode 2 docker override for common dev setup)
- `docker-compose.yml`: pg 5434 → 7434, nats 4222/8222 → 7422/7223, api 5200/5201 → 7200/7201 plus the 4200 binding → 6200

launchSettings already at canonical 5200/5201. angular.json already pins port 4200+ssl.

Reviewer note: `docker compose down && docker compose up -d` after merge. Consumers pointing at `:5200` (the API) will need to switch to `:7200` (docker mode) or run native at `:5200`. The Angular dev server on `4200` continues working for native `ng serve`; docker-mode Angular moves to `6200`.

Related: rivoli-ai/andy-service-template#2, rivoli-ai/andy-tasks#9.