### PR TITLE
Use MigrateAsync on PostgreSQL so schema changes actually apply

### DIFF
--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -230,11 +230,26 @@ try
 
     var app = builder.Build();
 
-    // Auto-create DB (if missing) and seed
+    // Auto-migrate (PostgreSQL) or auto-create (SQLite) and seed.
+    //
+    // EnsureCreated only creates the DB if missing — it does NOT apply
+    // migrations to an existing DB. For PostgreSQL that silently drops
+    // schema changes (e.g. the `AddContainerStoryId` migration would
+    // never take effect). Use Migrate there instead.
+    //
+    // SQLite migrations in this project use Npgsql-specific types
+    // (`type: "uuid"`) and are not portable, so keep the EnsureCreated
+    // shortcut for the embedded path. When the model changes, the
+    // existing SQLite file must be deleted (Conductor ships it under
+    // `Application Support/ai.rivoli.conductor/db/`) or patched
+    // manually; there is no in-place upgrade path on SQLite today.
     using (var scope = app.Services.CreateScope())
     {
         var db = scope.ServiceProvider.GetRequiredService<ContainersDbContext>();
-        await db.Database.EnsureCreatedAsync();
+        if (db.Database.IsNpgsql())
+            await db.Database.MigrateAsync();
+        else
+            await db.Database.EnsureCreatedAsync();
         await DataSeeder.SeedAsync(db);
     }
 


### PR DESCRIPTION
## Summary

- `Program.cs:237` called `Database.EnsureCreatedAsync()` unconditionally. EnsureCreated creates the DB only when missing and never applies migrations to existing DBs — so the `AddContainerStoryId` migration silently did nothing on upgraded instances.
- Symptom: `GET /api/containers` returns HTTP 500 with `SQLite Error 1: 'no such column: c.StoryId'` under Conductor's embedded SQLite path. A Postgres deployment would hit the same class of drift.
- Adopt the andy-agents pattern: `MigrateAsync()` on PostgreSQL, `EnsureCreatedAsync()` on SQLite. SQLite stays on the shortcut because migrations in this project use Npgsql-specific types (`type: "uuid"`) and are not currently portable.

## Follow-ups (out of scope)

- Users on SQLite with an existing DB from before this migration still need to delete their file or `ALTER TABLE Containers ADD COLUMN StoryId TEXT NULL` manually. A proper long-term fix is either portable migrations or a SQLite-specific schema-diff step at startup.

## Test plan

- [x] `dotnet build src/Andy.Containers.Api/Andy.Containers.Api.csproj` — green, 0 warnings
- [ ] Restart Conductor with the rebuilt embedded binary and confirm container list + add succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)