### PR TITLE
AP1: Run entity + EF migration

### DIFF
--- a/config/registration.json
+++ b/config/registration.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "../../andy-service-template/docs/registration.schema.json",
+  "service": {
+    "name": "andy-containers",
+    "displayName": "Andy Containers",
+    "description": "Container orchestration — workspaces, templates, runtime lifecycle.",
+    "embeddedProxyPrefix": "/containers",
+    "ports": {
+      "dotnetHttps": 5200,
+      "dotnetHttp":  5201,
+      "dotnetPostgres": 5434,
+      "dotnetClient": 4200,
+      "dockerHttps": 7200,
+      "dockerHttp":  7201,
+      "dockerPostgres": 7434,
+      "dockerClient": 6200,
+      "embeddedProxy": 9100
+    }
+  },
+  "auth": {
+    "audience": "urn:andy-containers-api",
+    "webClient": {
+      "clientId": "andy-containers-web",
+      "clientType": "public",
+      "displayName": "Andy Containers Web",
+      "description": "Angular SPA for container management",
+      "grantTypes": ["authorization_code", "refresh_token"],
+      "scopes": ["email", "profile", "roles", "scp:urn:andy-containers-api"],
+      "redirectUris": [
+        "https://localhost:4200/callback",
+        "https://localhost:6200/callback",
+        "http://localhost:9100/containers/callback"
+      ],
+      "postLogoutRedirectUris": [
+        "https://localhost:4200/",
+        "https://localhost:6200/",
+        "http://localhost:9100/containers/"
+      ]
+    },
+    "cliClient": {
+      "clientId": "andy-containers-cli",
+      "clientType": "public",
+      "displayName": "Andy Containers CLI",
+      "description": "Command-line client using device authorization flow",
+      "grantTypes": ["device_code", "refresh_token"],
+      "scopes": ["email", "profile", "roles", "scp:urn:andy-containers-api"]
+    }
+  },
+  "rbac": {
+    "applicationCode": "andy-containers",
+    "applicationName": "Andy Containers",
+    "description": "Container management platform",
+    "resourceTypes": [
+      { "code": "workspace", "name": "Workspace", "supportsInstances": true  },
+      { "code": "template",  "name": "Template",  "supportsInstances": true  },
+      { "code": "runtime",   "name": "Runtime",   "supportsInstances": true  }
+    ],
+    "roles": [
+      { "code": "admin",  "name": "Administrator", "description": "Full access to containers",  "isSystem": true },
+      { "code": "user",   "name": "User",          "description": "Standard user",              "isSystem": true },
+      { "code": "viewer", "name": "Viewer",        "description": "Read-only access",           "isSystem": true }
+    ],
+    "testUserRole": "admin"
+  },
+  "settings": {
+    "definitions": [
+      { "key": "andy.containers.defaultProvider",    "displayName": "Default Provider",   "description": "Default infrastructure provider",            "category": "General",      "dataType": "String",  "defaultValue": "docker", "allowedScopes": ["Machine","Application","User","Team"] },
+      { "key": "andy.containers.maxCpuCores",        "displayName": "Max CPU Cores",      "description": "Maximum CPU cores per container",            "category": "Resources",    "dataType": "Integer", "defaultValue": 4 },
+      { "key": "andy.containers.maxMemoryMb",        "displayName": "Max Memory (MB)",    "description": "Maximum memory per container in MB",         "category": "Resources",    "dataType": "Integer", "defaultValue": 8192 },
+      { "key": "andy.containers.sshTimeoutSeconds",  "displayName": "SSH Timeout",        "description": "SSH connection timeout in seconds",          "category": "Connectivity", "dataType": "Integer", "defaultValue": 30 }
+    ]
+  }
+}

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -230,11 +230,26 @@ try
 
     var app = builder.Build();
 
-    // Auto-create DB (if missing) and seed
+    // Auto-migrate (PostgreSQL) or auto-create (SQLite) and seed.
+    //
+    // EnsureCreated only creates the DB if missing — it does NOT apply
+    // migrations to an existing DB. For PostgreSQL that silently drops
+    // schema changes (e.g. the `AddContainerStoryId` migration would
+    // never take effect). Use Migrate there instead.
+    //
+    // SQLite migrations in this project use Npgsql-specific types
+    // (`type: "uuid"`) and are not portable, so keep the EnsureCreated
+    // shortcut for the embedded path. When the model changes, the
+    // existing SQLite file must be deleted (Conductor ships it under
+    // `Application Support/ai.rivoli.conductor/db/`) or patched
+    // manually; there is no in-place upgrade path on SQLite today.
     using (var scope = app.Services.CreateScope())
     {
         var db = scope.ServiceProvider.GetRequiredService<ContainersDbContext>();
-        await db.Database.EnsureCreatedAsync();
+        if (db.Database.IsNpgsql())
+            await db.Database.MigrateAsync();
+        else
+            await db.Database.EnsureCreatedAsync();
         await DataSeeder.SeedAsync(db);
     }
 

--- a/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
+++ b/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
@@ -24,6 +24,7 @@ public class ContainersDbContext : DbContext
     public DbSet<Team> Teams => Set<Team>();
     public DbSet<ImageBuildRecord> ImageBuildRecords => Set<ImageBuildRecord>();
     public DbSet<OutboxEntry> OutboxEntries => Set<OutboxEntry>();
+    public DbSet<Run> Runs => Set<Run>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -243,6 +244,35 @@ public class ContainersDbContext : DbContext
             e.Property(o => o.PayloadJson).IsRequired();
             e.HasIndex(o => new { o.PublishedAt, o.CreatedAt });
             e.HasIndex(o => o.Subject);
+        });
+
+        // Run — agent-run execution entity (AP1, rivoli-ai/andy-containers#103).
+        // A Run represents one invocation of an Agent (from andy-agents) against
+        // a delegation contract inside a container. Hot paths: "list active runs"
+        // (indexed on Status) and causation tracing (indexed on CorrelationId).
+        modelBuilder.Entity<Run>(e =>
+        {
+            e.HasKey(r => r.Id);
+            e.Property(r => r.AgentId).IsRequired().HasMaxLength(100);
+            e.Property(r => r.Error).HasMaxLength(4000);
+            // Enums as strings for stability across migrations + readability in
+            // database tools. Matches the existing pattern elsewhere in the
+            // schema (status columns are already string-typed in Container etc.
+            // via EF's default enum-to-int mapping — Run is explicit here so
+            // debugging via psql/sqlite-cli is friction-free from day one).
+            e.Property(r => r.Mode).HasConversion<string>().HasMaxLength(16);
+            e.Property(r => r.Status).HasConversion<string>().HasMaxLength(16);
+            e.HasIndex(r => r.Status);
+            e.HasIndex(r => r.CorrelationId);
+            e.HasIndex(r => r.AgentId);
+            // WorkspaceRef as an owned value object — inlined columns prefixed
+            // `WorkspaceRef_*` (EF default). Keeps Run self-contained without
+            // introducing a separate table.
+            e.OwnsOne(r => r.WorkspaceRef, wr =>
+            {
+                wr.Property(w => w.WorkspaceId).HasColumnName("WorkspaceRef_WorkspaceId");
+                wr.Property(w => w.Branch).HasColumnName("WorkspaceRef_Branch").HasMaxLength(200);
+            });
         });
     }
 }

--- a/src/Andy.Containers.Infrastructure/Migrations/20260420232544_AddRuns.Designer.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260420232544_AddRuns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Andy.Containers.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Containers.Infrastructure.Migrations
 {
     [DbContext(typeof(ContainersDbContext))]
-    partial class ContainersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260420232544_AddRuns")]
+    partial class AddRuns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Containers.Infrastructure/Migrations/20260420232544_AddRuns.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260420232544_AddRuns.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Containers.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRuns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Runs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AgentId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    AgentRevision = table.Column<int>(type: "integer", nullable: true),
+                    Mode = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    EnvironmentProfileId = table.Column<Guid>(type: "uuid", nullable: false),
+                    WorkspaceRef_WorkspaceId = table.Column<Guid>(type: "uuid", nullable: false),
+                    WorkspaceRef_Branch = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    PolicyId = table.Column<Guid>(type: "uuid", nullable: true),
+                    ContainerId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Status = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    StartedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    EndedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    ExitCode = table.Column<int>(type: "integer", nullable: true),
+                    Error = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    CorrelationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Runs", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Runs_AgentId",
+                table: "Runs",
+                column: "AgentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Runs_CorrelationId",
+                table: "Runs",
+                column: "CorrelationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Runs_Status",
+                table: "Runs",
+                column: "Status");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Runs");
+        }
+    }
+}

--- a/src/Andy.Containers/Models/Run.cs
+++ b/src/Andy.Containers/Models/Run.cs
@@ -1,0 +1,141 @@
+namespace Andy.Containers.Models;
+
+/// <summary>
+/// An agent run — the execution of an Agent (from andy-agents) against a delegation
+/// contract inside a provisioned container. Emits events on
+/// <c>andy.containers.events.run.{id}.*</c>.
+/// </summary>
+/// <remarks>
+/// Story AP1 (rivoli-ai/andy-containers#103). See Epic AP (#101) for the broader
+/// agent-run-execution design.
+/// </remarks>
+public class Run
+{
+    public Guid Id { get; set; }
+
+    /// <summary>Agent slug from andy-agents (e.g. "triage-agent").</summary>
+    public required string AgentId { get; set; }
+
+    /// <summary>Optional pin to a specific agent revision; null = head.</summary>
+    public int? AgentRevision { get; set; }
+
+    public RunMode Mode { get; set; }
+
+    /// <summary>
+    /// FK to andy-containers Epic X <c>EnvironmentProfile</c>. Stored without FK
+    /// constraint until X lands.
+    /// </summary>
+    public Guid EnvironmentProfileId { get; set; }
+
+    /// <summary>Owned value object pinning workspace + branch.</summary>
+    public WorkspaceRef WorkspaceRef { get; set; } = new();
+
+    /// <summary>Policy from andy-rbac Epic V. Nullable until V lands platform-wide.</summary>
+    public Guid? PolicyId { get; set; }
+
+    /// <summary>Set once AP5 mode dispatcher provisions or selects a container.</summary>
+    public Guid? ContainerId { get; set; }
+
+    public RunStatus Status { get; set; } = RunStatus.Pending;
+
+    public DateTimeOffset? StartedAt { get; set; }
+
+    public DateTimeOffset? EndedAt { get; set; }
+
+    public int? ExitCode { get; set; }
+
+    public string? Error { get; set; }
+
+    /// <summary>Root causation id per ADR-0001 header semantics.</summary>
+    public Guid CorrelationId { get; set; }
+
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Transition the run to <paramref name="next"/> according to AP1's state-machine
+    /// invariants. Throws <see cref="InvalidOperationException"/> for illegal
+    /// transitions so callers cannot silently corrupt history.
+    /// </summary>
+    public void TransitionTo(RunStatus next, DateTimeOffset? at = null)
+    {
+        if (!RunStatusTransitions.CanTransition(Status, next))
+        {
+            throw new InvalidOperationException(
+                $"Illegal run status transition: {Status} -> {next}.");
+        }
+
+        var now = at ?? DateTimeOffset.UtcNow;
+
+        // Side-effects tied to specific transitions.
+        if (Status == RunStatus.Pending && next == RunStatus.Provisioning)
+        {
+            // no-op; enter provisioning
+        }
+        else if (Status == RunStatus.Provisioning && next == RunStatus.Running)
+        {
+            StartedAt ??= now;
+        }
+        else if (RunStatusTransitions.IsTerminal(next))
+        {
+            EndedAt ??= now;
+        }
+
+        Status = next;
+        UpdatedAt = now;
+    }
+}
+
+public enum RunMode
+{
+    Headless,
+    Terminal,
+    Desktop
+}
+
+public enum RunStatus
+{
+    Pending,
+    Provisioning,
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+    Timeout
+}
+
+/// <summary>
+/// Owned value object on <see cref="Run"/>: pins workspace id + branch.
+/// </summary>
+public class WorkspaceRef
+{
+    public Guid WorkspaceId { get; set; }
+    public string? Branch { get; set; }
+}
+
+/// <summary>
+/// Centralised transition rules for <see cref="RunStatus"/>. Kept separate from the
+/// enum so callers can query allowed edges without a full entity instance.
+/// </summary>
+public static class RunStatusTransitions
+{
+    private static readonly Dictionary<RunStatus, HashSet<RunStatus>> Allowed = new()
+    {
+        [RunStatus.Pending] = new() { RunStatus.Provisioning, RunStatus.Cancelled, RunStatus.Failed },
+        [RunStatus.Provisioning] = new() { RunStatus.Running, RunStatus.Cancelled, RunStatus.Failed, RunStatus.Timeout },
+        [RunStatus.Running] = new() { RunStatus.Succeeded, RunStatus.Failed, RunStatus.Cancelled, RunStatus.Timeout },
+        // Terminal states cannot transition further.
+        [RunStatus.Succeeded] = new(),
+        [RunStatus.Failed] = new(),
+        [RunStatus.Cancelled] = new(),
+        [RunStatus.Timeout] = new(),
+    };
+
+    public static bool CanTransition(RunStatus from, RunStatus to)
+        => Allowed.TryGetValue(from, out var next) && next.Contains(to);
+
+    public static bool IsTerminal(RunStatus status)
+        => status is RunStatus.Succeeded or RunStatus.Failed
+            or RunStatus.Cancelled or RunStatus.Timeout;
+}

--- a/tests/Andy.Containers.Integration.Tests/Data/RunRepositoryTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/Data/RunRepositoryTests.cs
@@ -1,0 +1,225 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.Containers.Integration.Tests.Data;
+
+// AP1 integration tests: verify the Run entity + its EF configuration survive a
+// full round-trip through a real EF Core stack (SQLite in-memory). These
+// exercise column mapping, owned-value-object (WorkspaceRef) serialization,
+// enum-as-string conversions, and the indexes that the schema declares.
+//
+// We use SQLite in-memory because it's the one provider that's available
+// everywhere (including CI) without extra infrastructure. The Postgres path
+// goes through the same EF model and is exercised by the migration that
+// `dotnet ef migrations add AddRuns` produced — the migration file itself is
+// reviewed as part of the AP1 PR.
+public class RunRepositoryTests : IAsyncLifetime
+{
+    private SqliteConnection _conn = null!;
+    private ContainersDbContext _db = null!;
+
+    public async Task InitializeAsync()
+    {
+        _conn = new SqliteConnection("DataSource=:memory:");
+        await _conn.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<ContainersDbContext>()
+            .UseSqlite(_conn)
+            .Options;
+
+        _db = new ContainersDbContext(options);
+        await _db.Database.EnsureCreatedAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _db.DisposeAsync();
+        await _conn.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Run_RoundTrip_PersistsAllScalarFields()
+    {
+        var runId = Guid.NewGuid();
+        var run = new Run
+        {
+            Id = runId,
+            AgentId = "triage-agent",
+            AgentRevision = 3,
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            WorkspaceRef = new WorkspaceRef
+            {
+                WorkspaceId = Guid.NewGuid(),
+                Branch = "main"
+            },
+            PolicyId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            Status = RunStatus.Pending
+        };
+
+        _db.Runs.Add(run);
+        await _db.SaveChangesAsync();
+
+        // New DbContext so we read fresh state, not the tracked entity.
+        using var otherDb = new ContainersDbContext(
+            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).Options);
+        var reloaded = await otherDb.Runs.SingleAsync(r => r.Id == runId);
+
+        reloaded.Should().BeEquivalentTo(run, options => options
+            .Excluding(r => r.CreatedAt)
+            .Excluding(r => r.UpdatedAt));
+    }
+
+    [Fact]
+    public async Task Run_EnumsRoundTripAsStrings()
+    {
+        var run = new Run
+        {
+            AgentId = "coding-agent",
+            Mode = RunMode.Terminal,
+            Status = RunStatus.Running,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid()
+        };
+
+        _db.Runs.Add(run);
+        await _db.SaveChangesAsync();
+
+        // Read the raw string value straight from the column to prove the
+        // conversion is string-based (not an int cast). This is the invariant
+        // that keeps psql/sqlite-cli debugging readable. Match "any row" (we
+        // only inserted one) to sidestep SQLite Guid-storage quirks.
+        var cmd = _conn.CreateCommand();
+        cmd.CommandText = "SELECT Mode, Status FROM Runs";
+        using var reader = await cmd.ExecuteReaderAsync();
+        (await reader.ReadAsync()).Should().BeTrue();
+        reader.GetString(0).Should().Be("Terminal");
+        reader.GetString(1).Should().Be("Running");
+    }
+
+    [Fact]
+    public async Task Run_OwnedWorkspaceRef_StoredAsInlinedColumns()
+    {
+        var workspaceId = Guid.NewGuid();
+        var run = new Run
+        {
+            AgentId = "planning-agent",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            WorkspaceRef = new WorkspaceRef
+            {
+                WorkspaceId = workspaceId,
+                Branch = "feature/x"
+            }
+        };
+
+        _db.Runs.Add(run);
+        await _db.SaveChangesAsync();
+
+        // The owned value object should have mapped to WorkspaceRef_WorkspaceId
+        // and WorkspaceRef_Branch columns (not a separate table). Column
+        // names are the invariant we assert — the values go through EF's
+        // Guid conversion which differs subtly across providers.
+        var cmd = _conn.CreateCommand();
+        cmd.CommandText =
+            "SELECT name FROM pragma_table_info('Runs') ORDER BY cid";
+        using var reader = await cmd.ExecuteReaderAsync();
+        var columns = new List<string>();
+        while (await reader.ReadAsync())
+        {
+            columns.Add(reader.GetString(0));
+        }
+
+        columns.Should().Contain("WorkspaceRef_WorkspaceId");
+        columns.Should().Contain("WorkspaceRef_Branch");
+
+        // And verify EF round-trips the owned value object end-to-end.
+        using var otherDb = new ContainersDbContext(
+            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).Options);
+        var reloaded = await otherDb.Runs.SingleAsync(r => r.Id == run.Id);
+        reloaded.WorkspaceRef.WorkspaceId.Should().Be(workspaceId);
+        reloaded.WorkspaceRef.Branch.Should().Be("feature/x");
+    }
+
+    [Fact]
+    public async Task Run_IndexOnStatus_Exists()
+    {
+        // SQLite exposes its indexes via sqlite_master; verifying the declared
+        // IX_Runs_Status index made it through EnsureCreated ensures the EF
+        // configuration didn't silently drop it.
+        var cmd = _conn.CreateCommand();
+        cmd.CommandText =
+            "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'Runs' ORDER BY name";
+        using var reader = await cmd.ExecuteReaderAsync();
+        var indexes = new List<string>();
+        while (await reader.ReadAsync())
+        {
+            indexes.Add(reader.GetString(0));
+        }
+
+        indexes.Should().Contain(i => i.Contains("IX_Runs_Status", StringComparison.Ordinal));
+        indexes.Should().Contain(i => i.Contains("IX_Runs_CorrelationId", StringComparison.Ordinal));
+        indexes.Should().Contain(i => i.Contains("IX_Runs_AgentId", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Run_TransitionPersistsThroughSaveChanges()
+    {
+        var run = new Run
+        {
+            AgentId = "review-agent",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid()
+        };
+        _db.Runs.Add(run);
+        await _db.SaveChangesAsync();
+
+        run.TransitionTo(RunStatus.Provisioning);
+        run.TransitionTo(RunStatus.Running);
+        await _db.SaveChangesAsync();
+
+        using var otherDb = new ContainersDbContext(
+            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).Options);
+        var reloaded = await otherDb.Runs.SingleAsync(r => r.Id == run.Id);
+
+        reloaded.Status.Should().Be(RunStatus.Running);
+        reloaded.StartedAt.Should().NotBeNull();
+        reloaded.EndedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Run_QueryByStatus_UsesIndexedColumn()
+    {
+        // Not verifying the query plan (SQLite quirks), but proving the
+        // materializer recognises the string-backed enum in a WHERE clause.
+        for (var i = 0; i < 3; i++)
+        {
+            _db.Runs.Add(new Run
+            {
+                AgentId = $"agent-{i}",
+                Mode = RunMode.Headless,
+                EnvironmentProfileId = Guid.NewGuid(),
+                CorrelationId = Guid.NewGuid(),
+                Status = i == 0 ? RunStatus.Running : RunStatus.Succeeded
+            });
+        }
+        await _db.SaveChangesAsync();
+
+        var active = await _db.Runs
+            .Where(r => r.Status == RunStatus.Running)
+            .ToListAsync();
+
+        active.Should().HaveCount(1);
+        active[0].AgentId.Should().Be("agent-0");
+    }
+}

--- a/tests/Andy.Containers.Tests/Models/RunTests.cs
+++ b/tests/Andy.Containers.Tests/Models/RunTests.cs
@@ -1,0 +1,161 @@
+using Andy.Containers.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Tests.Models;
+
+public class RunTests
+{
+    [Fact]
+    public void NewRun_HasPendingStatus_ByDefault()
+    {
+        var run = new Run { AgentId = "triage-agent" };
+
+        run.Status.Should().Be(RunStatus.Pending);
+    }
+
+    [Fact]
+    public void NewRun_SetsCreatedAndUpdatedAt()
+    {
+        var before = DateTimeOffset.UtcNow;
+
+        var run = new Run { AgentId = "triage-agent" };
+
+        run.CreatedAt.Should().BeOnOrAfter(before);
+        run.UpdatedAt.Should().BeOnOrAfter(before);
+    }
+
+    [Fact]
+    public void TransitionTo_FollowsHappyPath_Pending_Provisioning_Running_Succeeded()
+    {
+        var run = new Run { AgentId = "triage-agent" };
+
+        run.TransitionTo(RunStatus.Provisioning);
+        run.Status.Should().Be(RunStatus.Provisioning);
+
+        run.TransitionTo(RunStatus.Running);
+        run.Status.Should().Be(RunStatus.Running);
+        run.StartedAt.Should().NotBeNull("entering Running stamps StartedAt");
+
+        run.TransitionTo(RunStatus.Succeeded);
+        run.Status.Should().Be(RunStatus.Succeeded);
+        run.EndedAt.Should().NotBeNull("terminal state stamps EndedAt");
+    }
+
+    [Theory]
+    [InlineData(RunStatus.Pending, RunStatus.Provisioning)]
+    [InlineData(RunStatus.Pending, RunStatus.Cancelled)]
+    [InlineData(RunStatus.Pending, RunStatus.Failed)]
+    [InlineData(RunStatus.Provisioning, RunStatus.Running)]
+    [InlineData(RunStatus.Provisioning, RunStatus.Cancelled)]
+    [InlineData(RunStatus.Provisioning, RunStatus.Failed)]
+    [InlineData(RunStatus.Provisioning, RunStatus.Timeout)]
+    [InlineData(RunStatus.Running, RunStatus.Succeeded)]
+    [InlineData(RunStatus.Running, RunStatus.Failed)]
+    [InlineData(RunStatus.Running, RunStatus.Cancelled)]
+    [InlineData(RunStatus.Running, RunStatus.Timeout)]
+    public void CanTransition_AllowsLegalEdges(RunStatus from, RunStatus to)
+    {
+        RunStatusTransitions.CanTransition(from, to).Should().BeTrue(
+            $"{from} → {to} is part of the documented state machine");
+    }
+
+    [Theory]
+    // Non-terminal reverse edges
+    [InlineData(RunStatus.Running, RunStatus.Pending)]
+    [InlineData(RunStatus.Running, RunStatus.Provisioning)]
+    [InlineData(RunStatus.Provisioning, RunStatus.Pending)]
+    // Skipping states
+    [InlineData(RunStatus.Pending, RunStatus.Running)]
+    [InlineData(RunStatus.Pending, RunStatus.Succeeded)]
+    // Terminal → anything (terminal states are absorbing)
+    [InlineData(RunStatus.Succeeded, RunStatus.Running)]
+    [InlineData(RunStatus.Failed, RunStatus.Running)]
+    [InlineData(RunStatus.Cancelled, RunStatus.Running)]
+    [InlineData(RunStatus.Timeout, RunStatus.Running)]
+    [InlineData(RunStatus.Succeeded, RunStatus.Failed)]
+    [InlineData(RunStatus.Cancelled, RunStatus.Succeeded)]
+    public void CanTransition_RejectsIllegalEdges(RunStatus from, RunStatus to)
+    {
+        RunStatusTransitions.CanTransition(from, to).Should().BeFalse(
+            $"{from} → {to} violates the state machine");
+    }
+
+    [Fact]
+    public void TransitionTo_ThrowsOnIllegalEdge()
+    {
+        var run = new Run { AgentId = "triage-agent" }; // Pending
+        var act = () => run.TransitionTo(RunStatus.Succeeded);
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*Pending -> Succeeded*");
+    }
+
+    [Fact]
+    public void TransitionTo_ThrowsFromTerminalState()
+    {
+        var run = new Run { AgentId = "triage-agent" };
+        run.TransitionTo(RunStatus.Provisioning);
+        run.TransitionTo(RunStatus.Running);
+        run.TransitionTo(RunStatus.Succeeded);
+
+        var act = () => run.TransitionTo(RunStatus.Running);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void IsTerminal_IdentifiesTerminalStates()
+    {
+        RunStatusTransitions.IsTerminal(RunStatus.Pending).Should().BeFalse();
+        RunStatusTransitions.IsTerminal(RunStatus.Provisioning).Should().BeFalse();
+        RunStatusTransitions.IsTerminal(RunStatus.Running).Should().BeFalse();
+        RunStatusTransitions.IsTerminal(RunStatus.Succeeded).Should().BeTrue();
+        RunStatusTransitions.IsTerminal(RunStatus.Failed).Should().BeTrue();
+        RunStatusTransitions.IsTerminal(RunStatus.Cancelled).Should().BeTrue();
+        RunStatusTransitions.IsTerminal(RunStatus.Timeout).Should().BeTrue();
+    }
+
+    [Fact]
+    public void TransitionTo_UsesExplicitTimestamp_WhenProvided()
+    {
+        var fixedAt = new DateTimeOffset(2026, 4, 20, 12, 0, 0, TimeSpan.Zero);
+        var run = new Run { AgentId = "triage-agent" };
+
+        run.TransitionTo(RunStatus.Provisioning, fixedAt);
+        run.TransitionTo(RunStatus.Running, fixedAt);
+
+        run.StartedAt.Should().Be(fixedAt);
+        run.UpdatedAt.Should().Be(fixedAt);
+    }
+
+    [Fact]
+    public void TransitionTo_DoesNotOverwriteExistingStartedAt()
+    {
+        var run = new Run { AgentId = "triage-agent" };
+        run.TransitionTo(RunStatus.Provisioning);
+        var firstRun = new DateTimeOffset(2026, 4, 20, 12, 0, 0, TimeSpan.Zero);
+        run.TransitionTo(RunStatus.Running, firstRun);
+
+        var storedStart = run.StartedAt;
+
+        // A no-op re-entry into Running would violate the state machine anyway,
+        // but the invariant is: once StartedAt is set, transitioning through
+        // further states (e.g. terminal) must not reset it.
+        run.TransitionTo(RunStatus.Succeeded, firstRun.AddSeconds(30));
+
+        run.StartedAt.Should().Be(storedStart, "StartedAt is set once");
+        run.EndedAt.Should().Be(firstRun.AddSeconds(30));
+    }
+
+    [Fact]
+    public void WorkspaceRef_DefaultsToEmpty()
+    {
+        var run = new Run { AgentId = "triage-agent" };
+
+        run.WorkspaceRef.Should().NotBeNull();
+        run.WorkspaceRef.WorkspaceId.Should().Be(Guid.Empty);
+        run.WorkspaceRef.Branch.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces the `Run` domain entity for agent-run execution (Epic AP, #101)
- Adds `RunMode` + `RunStatus` enums, owned `WorkspaceRef` value object, and `TransitionTo(next)` state-machine method
- Wires into `ContainersDbContext` with indexes on Status / CorrelationId / AgentId; enums stored as strings
- EF migration `20260420232544_AddRuns` generated via `dotnet ef migrations add`

Closes rivoli-ai/andy-containers#103.

## Test plan
- [x] 12 unit tests in `Andy.Containers.Tests/Models/RunTests.cs` — state-machine transitions, terminal absorption, timestamp semantics
- [x] 6 integration tests in `Andy.Containers.Integration.Tests/Data/RunRepositoryTests.cs` — SQLite round-trip, enum-as-string, owned-value-object column mapping, declared indexes
- [x] All 299 existing unit tests still pass
- [x] Full solution builds cleanly (0 warnings, 0 errors)

## Deferred to follow-up stories
- FK to `EnvironmentProfile` — lands with Epic X
- `PolicyId` required-vs-nullable — nullable until Epic V lands
- Outbox wiring for `andy.containers.events.run.*` — lands with AP2/AP6

🤖 Generated with [Claude Code](https://claude.com/claude-code)