### PR TITLE
Fix OutboxDispatcher crash on SQLite from DateTimeOffset ORDER BY

### DIFF
--- a/src/Andy.Containers.Infrastructure/Messaging/OutboxDispatcher.cs
+++ b/src/Andy.Containers.Infrastructure/Messaging/OutboxDispatcher.cs
@@ -76,11 +76,34 @@ public sealed class OutboxDispatcher : BackgroundService
         var db = scope.ServiceProvider.GetRequiredService<ContainersDbContext>();
         var bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
 
-        var pending = await db.Set<OutboxEntry>()
+        // SQLite's EF Core provider can't translate `DateTimeOffset`
+        // in `ORDER BY`, so a server-side
+        // `OrderBy(e => e.CreatedAt)` crashes the dispatcher
+        // (`SqliteQueryableMethodTranslatingExpressionVisitor`:
+        // "SQLite does not support expressions of type
+        // 'DateTimeOffset' in ORDER BY clauses. Convert the values
+        // to a supported type, or use LINQ to Objects to order the
+        // results on the client side."). Before this fix, every
+        // dispatcher tick threw that exception, the background
+        // service backed off, and under Conductor's embedded
+        // service host the continued failures eventually took the
+        // whole service down.
+        //
+        // We pull a bounded batch of pending entries server-side
+        // (filtering only by `PublishedAt == null`, which SQLite
+        // handles fine), then order + trim client-side. The cap is
+        // generous enough that the FIFO property of the outbox is
+        // preserved in practice — if more than `_drainWindow`
+        // entries are pending we'd have bigger problems than
+        // ordering accuracy — and it keeps memory bounded.
+        var drainWindow = Math.Max(_batchSize * 4, 256);
+        var pending = (await db.Set<OutboxEntry>()
             .Where(e => e.PublishedAt == null)
+            .Take(drainWindow)
+            .ToListAsync(ct))
             .OrderBy(e => e.CreatedAt)
             .Take(_batchSize)
-            .ToListAsync(ct);
+            .ToList();
 
         if (pending.Count == 0)
         {

--- a/tests/Andy.Containers.Api.Tests/Messaging/OutboxDispatcherTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Messaging/OutboxDispatcherTests.cs
@@ -132,6 +132,72 @@ public class OutboxDispatcherTests
         return (provider.GetRequiredService<IServiceScopeFactory>(), bus, dbName);
     }
 
+    /// <summary>
+    /// Regression guard for the production crash observed under the
+    /// embedded SQLite provider: the dispatcher used to
+    /// <c>OrderBy(e =&gt; e.CreatedAt)</c> against a
+    /// <see cref="DateTimeOffset"/> column, and the SQLite EF Core
+    /// translator rejects that with
+    /// &quot;SQLite does not support expressions of type
+    /// 'DateTimeOffset' in ORDER BY clauses&quot;. The in-memory
+    /// provider masks the bug (it can order any CLR type), so we
+    /// re-run the dispatcher against a real SQLite database here.
+    /// </summary>
+    [Fact]
+    public async Task DrainOnceAsync_DoesNotCrashUnderSqlite()
+    {
+        var connection = new Microsoft.Data.Sqlite.SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddDbContext<Andy.Containers.Infrastructure.Data.ContainersDbContext>(o =>
+                o.UseSqlite(connection));
+            var bus = new RecordingMessageBus();
+            services.AddSingleton<IMessageBus>(bus);
+            using var provider = services.BuildServiceProvider();
+
+            using (var scope = provider.CreateScope())
+            {
+                var db = scope.ServiceProvider.GetRequiredService<Andy.Containers.Infrastructure.Data.ContainersDbContext>();
+                await db.Database.EnsureCreatedAsync();
+                db.OutboxEntries.AddRange(
+                    new OutboxEntry
+                    {
+                        Id = Guid.NewGuid(),
+                        Subject = "s",
+                        PayloadJson = "{}",
+                        CreatedAt = DateTimeOffset.UtcNow.AddSeconds(-10),
+                    },
+                    new OutboxEntry
+                    {
+                        Id = Guid.NewGuid(),
+                        Subject = "s",
+                        PayloadJson = "{}",
+                        CreatedAt = DateTimeOffset.UtcNow,
+                    });
+                await db.SaveChangesAsync();
+            }
+
+            var dispatcher = new OutboxDispatcher(
+                provider.GetRequiredService<IServiceScopeFactory>(),
+                NullLogger<OutboxDispatcher>.Instance,
+                Options.Create(new OutboxDispatcherOptions()));
+
+            // Pre-fix this call threw
+            // `System.NotSupportedException: SQLite does not support
+            // expressions of type 'DateTimeOffset' in ORDER BY
+            // clauses` and tore down the background service.
+            var drained = await dispatcher.DrainOnceAsync(CancellationToken.None);
+            drained.Should().Be(2);
+            bus.Published.Should().HaveCount(2);
+        }
+        finally
+        {
+            await connection.CloseAsync();
+        }
+    }
+
     private sealed class RecordingMessageBus : IMessageBus
     {
         public List<(string Subject, object Payload, MessageHeaders Headers, DateTimeOffset CreatedAt)> Published { get; } = new();


### PR DESCRIPTION
## Summary

- The SQLite EF Core provider can't translate `DateTimeOffset` in `ORDER BY`. The dispatcher's server-side `OrderBy(e => e.CreatedAt)` therefore threw `NotSupportedException` on every tick under SQLite, which is the provider Conductor uses in its embedded service host. Repeated failures eventually took the service down.
- PostgreSQL is unaffected (its provider translates the expression), and the in-memory provider used by the existing `OutboxDispatcherTests` masked the bug — which is why nothing caught it pre-merge.
- Fix: pull a bounded batch (`Take(_batchSize * 4, min 256)`) server-side filtered only by `PublishedAt == null` (SQLite handles that fine), then order + trim client-side. The cap preserves FIFO in practice while keeping memory bounded.

## Test plan

- [x] New `DrainOnceAsync_DoesNotCrashUnderSqlite` test in `OutboxDispatcherTests` runs the dispatcher against a real `:memory:` SQLite connection so this regression class can no longer hide behind the in-memory provider.
- [x] Local `dotnet test --filter OutboxDispatcherTests` — 5/5 pass.
- [ ] Smoke under embedded host (Conductor) once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)