### PR TITLE
AP2: POST/GET/cancel run endpoints (#104)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/RunsController.cs
+++ b/src/Andy.Containers.Api/Controllers/RunsController.cs
@@ -1,0 +1,120 @@
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using Andy.Rbac.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Containers.Api.Controllers;
+
+/// <summary>
+/// AP2 (rivoli-ai/andy-containers#104). Entry point for agent runs:
+/// submit a run spec, observe its state, request cancellation. Container
+/// provisioning / selection is AP5's job — at AP2 the run lands as
+/// <see cref="RunStatus.Pending"/> with <see cref="Run.ContainerId"/> null,
+/// and the dispatcher (when it lands) takes over.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class RunsController : ControllerBase
+{
+    private readonly ContainersDbContext _db;
+
+    public RunsController(ContainersDbContext db)
+    {
+        _db = db;
+    }
+
+    [HttpPost]
+    [RequirePermission("run:write")]
+    public async Task<IActionResult> Create(
+        [FromBody] CreateRunRequest request,
+        CancellationToken ct)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        if (request.EnvironmentProfileId == Guid.Empty)
+        {
+            return BadRequest(new { error = "environmentProfileId must be a non-empty Guid." });
+        }
+
+        if (request.WorkspaceRef is { WorkspaceId: var wid } && wid == Guid.Empty)
+        {
+            return BadRequest(new { error = "workspaceRef.workspaceId must be a non-empty Guid when workspaceRef is provided." });
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = request.AgentId,
+            AgentRevision = request.AgentRevision,
+            Mode = request.Mode,
+            EnvironmentProfileId = request.EnvironmentProfileId,
+            WorkspaceRef = request.WorkspaceRef is null
+                ? new WorkspaceRef()
+                : new WorkspaceRef
+                {
+                    WorkspaceId = request.WorkspaceRef.WorkspaceId,
+                    Branch = request.WorkspaceRef.Branch,
+                },
+            PolicyId = request.PolicyId,
+            CorrelationId = request.CorrelationId ?? Guid.NewGuid(),
+            Status = RunStatus.Pending,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        _db.Runs.Add(run);
+        await _db.SaveChangesAsync(ct);
+
+        var dto = RunDto.FromEntity(run);
+        return CreatedAtAction(nameof(Get), new { id = run.Id }, dto);
+    }
+
+    [HttpGet("{id:guid}")]
+    [RequirePermission("run:read")]
+    public async Task<IActionResult> Get(Guid id, CancellationToken ct)
+    {
+        var run = await _db.Runs.FirstOrDefaultAsync(r => r.Id == id, ct);
+        if (run is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(RunDto.FromEntity(run));
+    }
+
+    [HttpPost("{id:guid}/cancel")]
+    [RequirePermission("run:execute")]
+    public async Task<IActionResult> Cancel(Guid id, CancellationToken ct)
+    {
+        var run = await _db.Runs.FirstOrDefaultAsync(r => r.Id == id, ct);
+        if (run is null)
+        {
+            return NotFound();
+        }
+
+        try
+        {
+            // Run.TransitionTo enforces the AP1 state-machine. Pending,
+            // Provisioning, and Running can all move to Cancelled; terminal
+            // states cannot — that's the 409 path below.
+            run.TransitionTo(RunStatus.Cancelled);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Conflict(new { error = ex.Message });
+        }
+
+        await _db.SaveChangesAsync(ct);
+
+        // AP3+ also needs to publish a cancel command so the running container
+        // actually stops; AP2 only flips the DB row. Document at the boundary.
+        return Ok(RunDto.FromEntity(run));
+    }
+}

--- a/src/Andy.Containers/Models/RunDtos.cs
+++ b/src/Andy.Containers/Models/RunDtos.cs
@@ -1,0 +1,114 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Andy.Containers.Models;
+
+/// <summary>
+/// Request body for <c>POST /api/runs</c>. Mirrors the subset of <see cref="Run"/>
+/// fields a caller can set at submission time — the entity owns lifecycle fields
+/// (<c>Status</c>, <c>StartedAt</c>, etc.) and AP5's mode dispatcher owns
+/// <c>ContainerId</c>, so neither lives on the request DTO.
+/// </summary>
+public class CreateRunRequest
+{
+    [Required]
+    public string AgentId { get; set; } = string.Empty;
+
+    public int? AgentRevision { get; set; }
+
+    [Required]
+    public RunMode Mode { get; set; }
+
+    [Required]
+    public Guid EnvironmentProfileId { get; set; }
+
+    public WorkspaceRefRequest? WorkspaceRef { get; set; }
+
+    public Guid? PolicyId { get; set; }
+
+    /// <summary>
+    /// Optional caller-supplied causation root per ADR-0001. When null the
+    /// controller mints a fresh root id so every Run still has a chain anchor.
+    /// </summary>
+    public Guid? CorrelationId { get; set; }
+}
+
+public class WorkspaceRefRequest
+{
+    public Guid WorkspaceId { get; set; }
+    public string? Branch { get; set; }
+}
+
+/// <summary>
+/// Response body for <c>POST /api/runs</c>, <c>GET /api/runs/{id}</c>, and
+/// <c>POST /api/runs/{id}/cancel</c>. Includes the four fields the AP2 spec
+/// names explicitly (<c>id</c>, <c>containerId</c>, <c>status</c>, <c>links</c>)
+/// plus the rest of the run record so callers don't need a follow-up fetch
+/// just to read what they posted.
+/// </summary>
+public class RunDto
+{
+    public Guid Id { get; set; }
+    public string AgentId { get; set; } = string.Empty;
+    public int? AgentRevision { get; set; }
+    public RunMode Mode { get; set; }
+    public Guid EnvironmentProfileId { get; set; }
+    public WorkspaceRefDto WorkspaceRef { get; set; } = new();
+    public Guid? PolicyId { get; set; }
+    public Guid? ContainerId { get; set; }
+    public RunStatus Status { get; set; }
+    public DateTimeOffset? StartedAt { get; set; }
+    public DateTimeOffset? EndedAt { get; set; }
+    public int? ExitCode { get; set; }
+    public string? Error { get; set; }
+    public Guid CorrelationId { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+    public RunLinks Links { get; set; } = new();
+
+    public static RunDto FromEntity(Run run)
+    {
+        var cancellable = !RunStatusTransitions.IsTerminal(run.Status);
+        return new RunDto
+        {
+            Id = run.Id,
+            AgentId = run.AgentId,
+            AgentRevision = run.AgentRevision,
+            Mode = run.Mode,
+            EnvironmentProfileId = run.EnvironmentProfileId,
+            WorkspaceRef = new WorkspaceRefDto
+            {
+                WorkspaceId = run.WorkspaceRef.WorkspaceId,
+                Branch = run.WorkspaceRef.Branch,
+            },
+            PolicyId = run.PolicyId,
+            ContainerId = run.ContainerId,
+            Status = run.Status,
+            StartedAt = run.StartedAt,
+            EndedAt = run.EndedAt,
+            ExitCode = run.ExitCode,
+            Error = run.Error,
+            CorrelationId = run.CorrelationId,
+            CreatedAt = run.CreatedAt,
+            UpdatedAt = run.UpdatedAt,
+            Links = new RunLinks
+            {
+                Self = $"/api/runs/{run.Id}",
+                Cancel = cancellable ? $"/api/runs/{run.Id}/cancel" : null,
+            },
+        };
+    }
+}
+
+public class WorkspaceRefDto
+{
+    public Guid WorkspaceId { get; set; }
+    public string? Branch { get; set; }
+}
+
+public class RunLinks
+{
+    public string Self { get; set; } = string.Empty;
+
+    /// <summary>Null once the run is in a terminal state.</summary>
+    public string? Cancel { get; set; }
+}

--- a/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
@@ -1,0 +1,196 @@
+using Andy.Containers.Api.Controllers;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Controllers;
+
+// AP2 (rivoli-ai/andy-containers#104). Verifies the three /api/runs endpoints
+// directly against an in-memory ContainersDbContext — no service mocks needed
+// because RunsController works on the DbContext directly. Cancellation
+// transition rules are owned by Run.TransitionTo (AP1); these tests assert
+// only the controller-level edge handling (404 on missing, 409 on illegal
+// transition, 200/201 on success).
+public class RunsControllerTests : IDisposable
+{
+    private readonly ContainersDbContext _db;
+    private readonly RunsController _controller;
+
+    public RunsControllerTests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+        _controller = new RunsController(_db);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+    }
+
+    [Fact]
+    public async Task Create_ValidRequest_PersistsRunAsPending_ReturnsCreated()
+    {
+        var request = new CreateRunRequest
+        {
+            AgentId = "triage-agent",
+            AgentRevision = 3,
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            WorkspaceRef = new WorkspaceRefRequest
+            {
+                WorkspaceId = Guid.NewGuid(),
+                Branch = "main",
+            },
+            PolicyId = Guid.NewGuid(),
+        };
+
+        var result = await _controller.Create(request, CancellationToken.None);
+
+        var created = result.Should().BeOfType<CreatedAtActionResult>().Subject;
+        created.ActionName.Should().Be(nameof(RunsController.Get));
+        var dto = created.Value.Should().BeOfType<RunDto>().Subject;
+
+        dto.Id.Should().NotBeEmpty();
+        dto.Status.Should().Be(RunStatus.Pending);
+        dto.ContainerId.Should().BeNull("AP5 mode dispatcher hasn't run yet");
+        dto.AgentId.Should().Be("triage-agent");
+        dto.WorkspaceRef.Branch.Should().Be("main");
+        dto.CorrelationId.Should().NotBeEmpty("controller mints a root id when caller doesn't supply one");
+        dto.Links.Self.Should().Be($"/api/runs/{dto.Id}");
+        dto.Links.Cancel.Should().Be($"/api/runs/{dto.Id}/cancel", "non-terminal runs expose a cancel link");
+
+        var persisted = await _db.Runs.FindAsync(dto.Id);
+        persisted.Should().NotBeNull();
+        persisted!.Status.Should().Be(RunStatus.Pending);
+        persisted.AgentRevision.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Create_PreservesCallerSuppliedCorrelationId()
+    {
+        var caller = Guid.NewGuid();
+        var request = new CreateRunRequest
+        {
+            AgentId = "x",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = caller,
+        };
+
+        var result = await _controller.Create(request, CancellationToken.None);
+
+        var dto = result.Should().BeOfType<CreatedAtActionResult>().Subject.Value
+            .Should().BeOfType<RunDto>().Subject;
+        dto.CorrelationId.Should().Be(caller);
+    }
+
+    [Fact]
+    public async Task Create_EmptyEnvironmentProfileId_ReturnsBadRequest()
+    {
+        var request = new CreateRunRequest
+        {
+            AgentId = "x",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.Empty,
+        };
+
+        var result = await _controller.Create(request, CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Create_WorkspaceRefWithEmptyId_ReturnsBadRequest()
+    {
+        var request = new CreateRunRequest
+        {
+            AgentId = "x",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            WorkspaceRef = new WorkspaceRefRequest { WorkspaceId = Guid.Empty },
+        };
+
+        var result = await _controller.Create(request, CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Get_ExistingRun_ReturnsOk()
+    {
+        var run = SeedRun(RunStatus.Running);
+
+        var result = await _controller.Get(run.Id, CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<RunDto>().Subject;
+        dto.Id.Should().Be(run.Id);
+        dto.Status.Should().Be(RunStatus.Running);
+        dto.Links.Cancel.Should().NotBeNull("Running is a non-terminal state");
+    }
+
+    [Fact]
+    public async Task Get_NonexistentRun_ReturnsNotFound()
+    {
+        var result = await _controller.Get(Guid.NewGuid(), CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Cancel_PendingRun_TransitionsToCancelled_ReturnsOk()
+    {
+        var run = SeedRun(RunStatus.Pending);
+
+        var result = await _controller.Cancel(run.Id, CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<RunDto>().Subject;
+        dto.Status.Should().Be(RunStatus.Cancelled);
+        dto.EndedAt.Should().NotBeNull("terminal transition stamps EndedAt");
+        dto.Links.Cancel.Should().BeNull("terminal runs cannot be cancelled again");
+
+        var persisted = await _db.Runs.FindAsync(run.Id);
+        persisted!.Status.Should().Be(RunStatus.Cancelled);
+    }
+
+    [Fact]
+    public async Task Cancel_TerminalRun_ReturnsConflict()
+    {
+        var run = SeedRun(RunStatus.Succeeded);
+
+        var result = await _controller.Cancel(run.Id, CancellationToken.None);
+
+        result.Should().BeOfType<ConflictObjectResult>(
+            "Run.TransitionTo throws on illegal transitions and the controller maps to 409");
+    }
+
+    [Fact]
+    public async Task Cancel_NonexistentRun_ReturnsNotFound()
+    {
+        var result = await _controller.Cancel(Guid.NewGuid(), CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    private Run SeedRun(RunStatus status)
+    {
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "seed-agent",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            Status = status,
+        };
+        // Terminal states need EndedAt for invariants downstream; the test
+        // doesn't depend on that, so leaving it null is fine.
+        _db.Runs.Add(run);
+        _db.SaveChanges();
+        return run;
+    }
+}


### PR DESCRIPTION
Closes #104.

## Summary

Adds the `/api/runs` surface on top of AP1's `Run` entity:

- `POST /api/runs` — create a run, persists as `Pending`, returns the full `RunDto` (the four spec-named fields `id`/`containerId`/`status`/`links` plus the rest of the record).
- `GET /api/runs/{id}` — fetch by id, 404 if missing.
- `POST /api/runs/{id}/cancel` — transition to `Cancelled`, 409 if the run is in a terminal state.

Container provisioning / selection is AP5's job; AP2 deliberately stops at `Pending` with `ContainerId` null. The controller writes to `ContainersDbContext.Runs` directly — no premature `IRunDispatcher` abstraction, since AP5 isn't built and inventing the boundary ahead of time would just guess at it.

Cancellation defers entirely to `Run.TransitionTo` (AP1 state machine). `Pending` / `Provisioning` / `Running` move to `Cancelled` cleanly; terminal states throw `InvalidOperationException`, which the controller maps to `409 Conflict`. AP3+ still has to publish the cancel command so the running container actually stops; AP2 only flips the DB row.

DTOs live next to `Run.cs` in `Andy.Containers/Models/RunDtos.cs` so cross-repo clients can import them without dragging in the API project. The `Links.Cancel` field is null once the run is terminal.

RBAC: `run:write` / `run:read` / `run:execute`, matching the existing `ContainersController`'s `container:*` scheme.

## Test plan

9 new controller tests in `tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs` covering:
- [x] `Create_ValidRequest_PersistsRunAsPending_ReturnsCreated`
- [x] `Create_PreservesCallerSuppliedCorrelationId`
- [x] `Create_EmptyEnvironmentProfileId_ReturnsBadRequest`
- [x] `Create_WorkspaceRefWithEmptyId_ReturnsBadRequest`
- [x] `Get_ExistingRun_ReturnsOk`
- [x] `Get_NonexistentRun_ReturnsNotFound`
- [x] `Cancel_PendingRun_TransitionsToCancelled_ReturnsOk`
- [x] `Cancel_TerminalRun_ReturnsConflict`
- [x] `Cancel_NonexistentRun_ReturnsNotFound`
- [x] Whole `Andy.Containers.Api.Tests` suite: **573 / 574 pass**. The one failure (`ContainerProvisioningWorkerTests.ProcessJob_PostCreateAndCodeAssistant_ShouldRunInOrder`) reproduces on clean main and is **not introduced by this change** — pre-existing.

## Out of scope

- Container provisioning / selection (AP5).
- Publishing the cancel command so the container actually stops (AP3+).
- `OwnerId` / per-tenant isolation on `Run` — AP1 didn't add it; revisit when/if downstream stories need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)