### PR TITLE
Fix ProcessJob_PostCreateAndCodeAssistant_ShouldRunInOrder false positive

### DIFF
--- a/tests/Andy.Containers.Api.Tests/Services/ContainerProvisioningWorkerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerProvisioningWorkerTests.cs
@@ -591,8 +591,14 @@ public class ContainerProvisioningWorkerTests : IDisposable
             .Returns("npm install -g @anthropic-ai/claude-code");
 
         var callOrder = new List<string>();
+        // Match the specific PostCreateScript payload rather than any command
+        // containing "apt-get". The welcome-banner script (worker line 302,
+        // added in commit 8102a15 for fastfetch) also runs `apt-get install
+        // -qq fastfetch`, so the old `Contains("apt-get")` matcher fired
+        // twice and produced a false-positive `{post_create, code_assistant,
+        // post_create}` order. See rivoli-ai/andy-containers#134.
         _mockContainerService.Setup(s => s.ExecAsync(
-                It.IsAny<Guid>(), It.Is<string>(cmd => cmd.Contains("apt-get")),
+                It.IsAny<Guid>(), It.Is<string>(cmd => cmd.Contains("apt-get install -y python3")),
                 It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
             .Callback(() => callOrder.Add("post_create"))
             .ReturnsAsync(new ExecResult { ExitCode = 0 });


### PR DESCRIPTION
Closes #134.

## Summary

- Narrow the mock matcher from `cmd.Contains("apt-get")` to `cmd.Contains("apt-get install -y python3")` so it only fires on the specific `PostCreateScript` payload and not on the welcome-banner script (which runs `apt-get install -qq fastfetch` since [`8102a15`](https://github.com/rivoli-ai/andy-containers/commit/8102a15)).

## Root cause

Three calls passed the old loose filter:
1. `PostCreateScripts[0]` = `apt-get install -y python3` — worker line 149
2. Code-assistant install — worker line 265 — matches the *other* mock
3. `GenerateWelcomeBannerScript(job)` — worker line 302 — contains `apt-get install -y -qq fastfetch`

So `callOrder.Add("post_create")` fired twice and the Equal assertion failed with `{post_create, code_assistant, post_create}`. Full triage in #134.

## Test plan

- [x] `dotnet test --filter ProcessJob_PostCreateAndCodeAssistant_ShouldRunInOrder` — **passes** (was failing on clean main).
- [x] Full `Andy.Containers.Api.Tests` suite: **574/574 pass** (was 573/574).
- [x] Production code unchanged — test-matcher tightening only.

## Note

`ProcessJob_WithPostCreateScripts_ShouldStayCreatingDuringScripts` at line 682 uses the same loose `Contains("apt-get")` matcher and currently passes by accident — its assertion is "status during *any* apt-get call was Creating" which holds whether the matcher fires once or twice (both calls happen pre-`Running`). Left as-is to keep this PR scoped; flagged in #134 as a latent weakness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)