### PR TITLE
[CRITICAL] Fail startup when AndyAuth:Authority is unset in non-Development (#120)

### DIFF
--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -126,7 +126,16 @@ try
     var authority = builder.Configuration["AndyAuth:Authority"] ?? "";
     if (string.IsNullOrEmpty(authority))
     {
-        // No authority configured — permissive fallback for local dev
+        if (!builder.Environment.IsDevelopment())
+        {
+            throw new InvalidOperationException(
+                "AndyAuth:Authority is not configured. Authentication is required outside the " +
+                "Development environment — set AndyAuth:Authority in appsettings.json or via the " +
+                "AndyAuth__Authority environment variable.");
+        }
+
+        // Development only: no remote token validation. The dev-identity middleware below
+        // synthesizes an admin ClaimsPrincipal when no bearer token is presented.
         builder.Services.AddAuthentication("Bearer")
             .AddJwtBearer("Bearer", options =>
             {
@@ -134,9 +143,6 @@ try
             });
         builder.Services.AddAuthorization(options =>
         {
-            options.FallbackPolicy = new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder()
-                .RequireAssertion(_ => true)
-                .Build();
             options.AddPolicy("Admin", policy => policy.RequireClaim("role", "admin"));
         });
     }


### PR DESCRIPTION
Closes #120.

## Summary

- `appsettings.json` ships with `AndyAuth:Authority = ""`. The previous code treated an empty Authority as \"local dev\" and installed a fallback authorization policy of `RequireAssertion(_ => true)` — which opened every controller endpoint to unauthenticated callers in **every** non-Development deployment, not just local dev.
- Fail-closed: throw at startup in non-Development when `Authority` is empty, with a message naming the config key.
- Drop the allow-all `FallbackPolicy`. Development still works unchanged: the existing dev-identity middleware (`Program.cs:290–314`) synthesizes an admin `ClaimsPrincipal` when no bearer token is presented, and `app.MapControllers().RequireAuthorization()` is satisfied by that synthesized identity.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test tests/Andy.Containers.Api.Tests` — 574/574 pass
- [ ] Smoke: in Development (`ASPNETCORE_ENVIRONMENT=Development`, empty Authority), the API still starts and anonymous requests are handled by the dev-identity middleware
- [ ] Smoke: outside Development with empty Authority, startup throws with the new message
- [ ] Smoke: outside Development with a configured Authority, no behavior change vs. `main`

## Notes

No existing `WebApplicationFactory` scaffolding in this repo, so no automated regression test is added. The change is a single conditional; risk is low and surfaces loudly (startup exception) if broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)