### PR TITLE
[CRITICAL] Authenticate + authorize Terminal WebSocket; validate Origin (#119)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/TerminalController.cs
+++ b/src/Andy.Containers.Api/Controllers/TerminalController.cs
@@ -1,7 +1,10 @@
 using System.Diagnostics;
 using System.Net.WebSockets;
+using Andy.Containers.Api.Services;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Models;
+using Andy.Rbac.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -9,24 +12,45 @@ namespace Andy.Containers.Api.Controllers;
 
 [ApiController]
 [Route("api/containers/{id}/terminal")]
+[Authorize]
 public class TerminalController : ControllerBase
 {
     private readonly ContainersDbContext _db;
+    private readonly ICurrentUserService _currentUser;
+    private readonly IConfiguration _configuration;
     private readonly ILogger<TerminalController> _logger;
 
-    public TerminalController(ContainersDbContext db, ILogger<TerminalController> logger)
+    public TerminalController(
+        ContainersDbContext db,
+        ICurrentUserService currentUser,
+        IConfiguration configuration,
+        ILogger<TerminalController> logger)
     {
         _db = db;
+        _currentUser = currentUser;
+        _configuration = configuration;
         _logger = logger;
     }
 
     [HttpGet]
+    [RequirePermission("container:execute")]
     public async Task Connect(Guid id)
     {
         if (!HttpContext.WebSockets.IsWebSocketRequest)
         {
             HttpContext.Response.StatusCode = 400;
             await HttpContext.Response.WriteAsync("WebSocket connection required");
+            return;
+        }
+
+        // CSWSH defense: browsers always send Origin on WebSocket upgrade requests.
+        // Reject anything not on the configured Cors:Origins allowlist.
+        var origin = HttpContext.Request.Headers.Origin.ToString();
+        if (!IsOriginAllowed(origin))
+        {
+            _logger.LogWarning("Terminal WebSocket rejected — Origin '{Origin}' not in Cors:Origins allowlist", origin);
+            HttpContext.Response.StatusCode = 403;
+            await HttpContext.Response.WriteAsync("Origin not allowed");
             return;
         }
 
@@ -38,6 +62,13 @@ public class TerminalController : ControllerBase
         {
             HttpContext.Response.StatusCode = 404;
             await HttpContext.Response.WriteAsync("Container not found");
+            return;
+        }
+
+        if (!CanAccess(container))
+        {
+            HttpContext.Response.StatusCode = 403;
+            await HttpContext.Response.WriteAsync("Forbidden");
             return;
         }
 
@@ -385,6 +416,22 @@ public class TerminalController : ControllerBase
 
         process.Dispose();
         _logger.LogInformation("Terminal session ended for container {Name}", container.Name);
+    }
+
+    internal bool CanAccess(Container container)
+    {
+        if (_currentUser.IsAdmin()) return true;
+        return container.OwnerId == _currentUser.GetUserId();
+    }
+
+    internal bool IsOriginAllowed(string origin)
+    {
+        if (string.IsNullOrEmpty(origin))
+            return false;
+        var allowed = _configuration.GetSection("Cors:Origins").Get<string[]>();
+        if (allowed is null || allowed.Length == 0)
+            return false;
+        return Array.Exists(allowed, a => string.Equals(a, origin, StringComparison.OrdinalIgnoreCase));
     }
 
     private static bool IsResizeMessage(byte[] buffer, int count, out int cols, out int rows)

--- a/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
@@ -1,10 +1,12 @@
 using Andy.Containers.Api.Controllers;
+using Andy.Containers.Api.Services;
 using Andy.Containers.Api.Tests.Helpers;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -23,15 +25,28 @@ public class TerminalControllerTests : IDisposable
 
     public void Dispose() => _db.Dispose();
 
-    private TerminalController CreateController(DefaultHttpContext? httpContext = null)
+    private TerminalController CreateController(
+        DefaultHttpContext? httpContext = null,
+        Mock<ICurrentUserService>? currentUser = null,
+        IConfiguration? configuration = null)
     {
         httpContext ??= new DefaultHttpContext();
         var logger = new Mock<ILogger<TerminalController>>();
+        currentUser ??= new Mock<ICurrentUserService>();
+        configuration ??= new ConfigurationBuilder().Build();
         // Use a fresh context with the same DB name so EF tracks entities correctly
         var db = InMemoryDbHelper.CreateContext(_dbName);
-        var controller = new TerminalController(db, logger.Object);
+        var controller = new TerminalController(db, currentUser.Object, configuration, logger.Object);
         controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
         return controller;
+    }
+
+    private static IConfiguration ConfigWithOrigins(params string[] origins)
+    {
+        var dict = new Dictionary<string, string?>();
+        for (var i = 0; i < origins.Length; i++)
+            dict[$"Cors:Origins:{i}"] = origins[i];
+        return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
     }
 
     private InfrastructureProvider CreateProvider()
@@ -129,11 +144,87 @@ public class TerminalControllerTests : IDisposable
     {
         var db = InMemoryDbHelper.CreateContext();
         var logger = new Mock<ILogger<TerminalController>>();
+        var currentUser = new Mock<ICurrentUserService>();
+        var configuration = new ConfigurationBuilder().Build();
 
-        var controller = new TerminalController(db, logger.Object);
+        var controller = new TerminalController(db, currentUser.Object, configuration, logger.Object);
 
         controller.Should().NotBeNull();
         db.Dispose();
+    }
+
+    [Fact]
+    public void IsOriginAllowed_EmptyOrigin_ReturnsFalse()
+    {
+        var controller = CreateController(configuration: ConfigWithOrigins("https://localhost:5280"));
+        controller.IsOriginAllowed(string.Empty).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsOriginAllowed_NoAllowlistConfigured_ReturnsFalse()
+    {
+        // Fail-closed when Cors:Origins is missing or empty — preventing CSWSH
+        // from a misconfigured deployment.
+        var controller = CreateController(configuration: new ConfigurationBuilder().Build());
+        controller.IsOriginAllowed("https://localhost:5280").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsOriginAllowed_OriginInAllowlist_ReturnsTrue()
+    {
+        var controller = CreateController(configuration: ConfigWithOrigins("https://localhost:5280", "https://localhost:3000"));
+        controller.IsOriginAllowed("https://localhost:5280").Should().BeTrue();
+        controller.IsOriginAllowed("https://localhost:3000").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsOriginAllowed_OriginNotInAllowlist_ReturnsFalse()
+    {
+        var controller = CreateController(configuration: ConfigWithOrigins("https://localhost:5280"));
+        controller.IsOriginAllowed("https://evil.example.com").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsOriginAllowed_OriginMatchesCaseInsensitive()
+    {
+        var controller = CreateController(configuration: ConfigWithOrigins("https://localhost:5280"));
+        controller.IsOriginAllowed("HTTPS://LOCALHOST:5280").Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanAccess_Admin_AlwaysTrue()
+    {
+        var currentUser = new Mock<ICurrentUserService>();
+        currentUser.Setup(u => u.IsAdmin()).Returns(true);
+        currentUser.Setup(u => u.GetUserId()).Returns("admin-user");
+        var controller = CreateController(currentUser: currentUser);
+
+        var container = new Container { OwnerId = "someone-else", Name = "c", ProviderId = Guid.NewGuid() };
+        controller.CanAccess(container).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanAccess_OwnerMatches_True()
+    {
+        var currentUser = new Mock<ICurrentUserService>();
+        currentUser.Setup(u => u.IsAdmin()).Returns(false);
+        currentUser.Setup(u => u.GetUserId()).Returns("user-1");
+        var controller = CreateController(currentUser: currentUser);
+
+        var container = new Container { OwnerId = "user-1", Name = "c", ProviderId = Guid.NewGuid() };
+        controller.CanAccess(container).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanAccess_NonOwnerNonAdmin_False()
+    {
+        var currentUser = new Mock<ICurrentUserService>();
+        currentUser.Setup(u => u.IsAdmin()).Returns(false);
+        currentUser.Setup(u => u.GetUserId()).Returns("user-1");
+        var controller = CreateController(currentUser: currentUser);
+
+        var container = new Container { OwnerId = "user-2", Name = "c", ProviderId = Guid.NewGuid() };
+        controller.CanAccess(container).Should().BeFalse();
     }
 
     [Theory]


### PR DESCRIPTION
Closes #119.

## Summary

`TerminalController` previously had no `[Authorize]`, no permission attribute, no ownership check, and no Origin validation. Combined with the API mounting `/var/run/docker.sock`, an unauthenticated WebSocket request opened `docker exec -it bash` on any container — a container-to-host escape. A cross-origin attacker page could also drive the upgrade (CSWSH).

The fix is the same gate stack that `ContainersController` already uses, plus an Origin allowlist:

- `[Authorize]` on the class
- `[RequirePermission(\"container:execute\")]` on `Connect`
- `CanAccess(container)` — admin OR `OwnerId == current user`
- `IsOriginAllowed(origin)` — exact-match allowlist read from `Cors:Origins`. Fails closed when Origin is missing or the allowlist is unset.

The Origin check sits **after** the WebSocket-required check (so non-WS callers still get a clear 400) and **before** the DB lookup (so we don't leak existence of containers to off-origin callers).

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test tests/Andy.Containers.Api.Tests` — 582/582 (8 new tests for `IsOriginAllowed` + `CanAccess`)
- [ ] Smoke: anonymous WS upgrade → 401
- [ ] Smoke: authenticated WS upgrade from non-allowlisted Origin → 403
- [ ] Smoke: authenticated WS upgrade from allowlisted Origin to a container the user does not own → 403
- [ ] Smoke: authenticated WS upgrade from allowlisted Origin to a container the user owns, container Running → connects

## Notes

`IsOriginAllowed` and `CanAccess` are exposed as `internal` so they can be unit-tested directly — `InternalsVisibleTo` for the test assembly was already configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)