### PR TITLE
[CRITICAL] Inject env secrets via ContainerSpec, not world-readable files (#123)

### DIFF
--- a/src/Andy.Containers.Api/Services/ContainerProvisioningWorker.cs
+++ b/src/Andy.Containers.Api/Services/ContainerProvisioningWorker.cs
@@ -104,7 +104,11 @@ public class ContainerProvisioningWorker : BackgroundService
                 Command = string.Equals(job.GuiType, "vnc", StringComparison.OrdinalIgnoreCase)
                     ? "/start.sh" : null,
                 // Always expose SSH (port 22) with a dynamic host port
-                PortMappings = portMappings
+                PortMappings = portMappings,
+                // Inject env vars (incl. API keys) at creation time so they propagate
+                // to every `docker exec` without being persisted to world-readable files
+                // inside the container (/etc/environment, /etc/profile.d, etc).
+                EnvironmentVariables = job.EnvironmentVariables
             };
 
             // Use a timeout so we don't hang forever
@@ -201,53 +205,6 @@ public class ContainerProvisioningWorker : BackgroundService
                 {
                     _logger.LogWarning(userEx, "Failed to create user {User} in container {ContainerId}",
                         job.ContainerUser, job.ContainerId);
-                }
-            }
-
-            // Inject environment variables (including API keys) into the container
-            if (job.EnvironmentVariables is { Count: > 0 })
-            {
-                try
-                {
-                    var containerService = scope.ServiceProvider.GetRequiredService<IContainerService>();
-                    // Set env vars via export commands — values are not logged
-                    var exportCommands = string.Join(" && ",
-                        job.EnvironmentVariables.Select(kv => $"export {kv.Key}='{kv.Value.Replace("'", "'\\''")}'"));
-                    // Write to /etc/environment, .bashrc, and .profile for persistence across all session types
-                    var persistCmd = string.Join(" && ",
-                        job.EnvironmentVariables.Select(kv =>
-                        {
-                            var escaped = kv.Value.Replace("'", "'\\''");
-                            return $"echo '{kv.Key}={escaped}' >> /etc/environment && " +
-                                   $"echo 'export {kv.Key}=\"{escaped}\"' >> /root/.bashrc && " +
-                                   $"echo 'export {kv.Key}=\"{escaped}\"' >> /root/.profile && " +
-                                   $"echo 'export {kv.Key}=\"{escaped}\"' >> /etc/profile && " +
-                                   $"mkdir -p /etc/profile.d && echo 'export {kv.Key}=\"{escaped}\"' >> /etc/profile.d/andy-env.sh";
-                        }));
-                    await containerService.ExecAsync(job.ContainerId, $"{exportCommands} && {persistCmd}", stoppingToken);
-
-                    // Also persist to user's home directory
-                    if (job.ContainerUser != "root")
-                    {
-                        var userHome = $"/home/{job.ContainerUser}";
-                        var userPersistCmd = string.Join(" && ",
-                            job.EnvironmentVariables.Select(kv =>
-                            {
-                                var escaped = kv.Value.Replace("'", "'\\''");
-                                return $"echo 'export {kv.Key}=\"{escaped}\"' >> {userHome}/.bashrc && " +
-                                       $"echo 'export {kv.Key}=\"{escaped}\"' >> {userHome}/.profile && " +
-                                       $"chown {job.ContainerUser}:{job.ContainerUser} {userHome}/.bashrc {userHome}/.profile";
-                            }));
-                        await containerService.ExecAsync(job.ContainerId, userPersistCmd, stoppingToken);
-                    }
-
-                    _logger.LogInformation("Injected {Count} environment variable(s) into container {ContainerId}",
-                        job.EnvironmentVariables.Count, job.ContainerId);
-                }
-                catch (Exception envEx)
-                {
-                    _logger.LogWarning(envEx, "Failed to inject environment variables into container {ContainerId}",
-                        job.ContainerId);
                 }
             }
 

--- a/src/Andy.Containers.Infrastructure/Providers/Apple/AppleContainerProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Apple/AppleContainerProvider.cs
@@ -101,6 +101,28 @@ public class AppleContainerProvider : IInfrastructureProvider
                 args += $" -m {spec.Resources.MemoryMb}M";
         }
 
+        // Pass env vars at creation time so secrets reach `container exec` without
+        // being persisted to world-readable files inside the container.
+        // ProcessStartInfo.Arguments is parsed by .NET (Win32-style: pairs of double
+        // quotes, no shell interpretation). API key values in practice contain no
+        // whitespace or quotes; reject anything that would tokenize incorrectly so
+        // we never silently truncate a secret. Tighter quoting arrives with #127.
+        if (spec.EnvironmentVariables is { Count: > 0 })
+        {
+            foreach (var (key, value) in spec.EnvironmentVariables)
+            {
+                var v = value ?? string.Empty;
+                if (v.Any(c => char.IsWhiteSpace(c) || c == '"' || c == '\''))
+                {
+                    _logger.LogWarning(
+                        "Skipping env var {Key} for Apple Container {Name}: value contains whitespace or quote",
+                        key, name);
+                    continue;
+                }
+                args += $" -e {key}={v}";
+            }
+        }
+
         args += $" -d {spec.ImageReference}";
 
         // Add command if specified, otherwise default to sleep infinity to keep the container alive

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerProvisioningWorkerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerProvisioningWorkerTests.cs
@@ -546,12 +546,17 @@ public class ContainerProvisioningWorkerTests : IDisposable
     }
 
     [Fact]
-    public async Task ProcessJob_WithEnvVars_ShouldExecExportCommands()
+    public async Task ProcessJob_WithEnvVars_PassesThemViaContainerSpec()
     {
+        // Regression test for #123: secrets must be passed via the provider's
+        // CreateContainer Env, not exec'd as `echo … >> /etc/environment` which
+        // wrote API keys to world-readable files inside the container.
         using var db = CreateDb();
         var (container, provider) = SeedContainerAndProvider(db);
 
+        ContainerSpec? capturedSpec = null;
         _mockProvider.Setup(p => p.CreateContainerAsync(It.IsAny<ContainerSpec>(), It.IsAny<CancellationToken>()))
+            .Callback<ContainerSpec, CancellationToken>((spec, _) => capturedSpec = spec)
             .ReturnsAsync(new ContainerProvisionResult { ExternalId = "ext-1", Status = ContainerStatus.Running });
 
         var envVars = new Dictionary<string, string> { ["ANTHROPIC_API_KEY"] = "sk-test-123" };
@@ -570,11 +575,18 @@ public class ContainerProvisioningWorkerTests : IDisposable
         cts.Cancel();
         try { await workerTask; } catch (OperationCanceledException) { }
 
-        // Verify ExecAsync was called with export and persist commands containing the key
+        // Env vars travel via the spec to the provider…
+        capturedSpec.Should().NotBeNull();
+        capturedSpec!.EnvironmentVariables.Should().ContainKey("ANTHROPIC_API_KEY");
+        capturedSpec.EnvironmentVariables!["ANTHROPIC_API_KEY"].Should().Be("sk-test-123");
+
+        // …and are NEVER exec'd as `echo … >> /etc/environment` or similar.
         _mockContainerService.Verify(s => s.ExecAsync(
             container.Id,
-            It.Is<string>(cmd => cmd.Contains("ANTHROPIC_API_KEY") && cmd.Contains("export")),
-            It.IsAny<CancellationToken>()), Times.Once);
+            It.Is<string>(cmd =>
+                cmd.Contains("ANTHROPIC_API_KEY") &&
+                (cmd.Contains("/etc/environment") || cmd.Contains(".bashrc") || cmd.Contains(".profile"))),
+            It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #123.

## Summary

`ContainerProvisioningWorker` was exec'ing `echo 'KEY=value' >> /etc/environment` plus appends to `/root/.bashrc`, `/root/.profile`, `/etc/profile`, `/etc/profile.d/andy-env.sh`, and the container-user's `~/.bashrc` / `~/.profile` for every env var the orchestrator passed in — including `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`. Those files are world-readable (0644), the keys also leaked into `docker exec` argv, and the persistence command itself was visible in shell history.

The fix moves env injection up into the provider create call:

- **`ContainerProvisioningWorker`** — set `spec.EnvironmentVariables = job.EnvironmentVariables` on the existing `ContainerSpec` and drop the post-creation echo block entirely. Docker, SSH, Azure ACI, GCP Cloud Run, Fly.io, and AWS Fargate providers already honor `spec.EnvironmentVariables`, so secrets reach every `docker exec` automatically without ever touching disk.
- **`AppleContainerProvider`** — was the only provider that didn't pass env at create time, so I added `-e KEY=VALUE` flags to the `container run` invocation so the same path works on Apple Silicon. Values containing whitespace or quotes are skipped with a warning — `ProcessStartInfo.Arguments` parsing on .NET would otherwise tokenize them incorrectly. Stricter quoting arrives with #127.
- **Test updated** — `ProcessJob_WithEnvVars` now asserts the spec carries the env var AND that no `ExecAsync` writes `ANTHROPIC_API_KEY` into a profile / bashrc / `/etc/environment` file.

## Tradeoff (accepted)

Env vars remain visible in `docker inspect`. That's strictly less bad than world-readable files inside the container, and matches the issue text's primary recommendation. Finer-grained secret delivery (tmpfs files with 0600 + chown) is left as a follow-up.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test tests/Andy.Containers.Api.Tests` — 574/574 pass
- [ ] Smoke (Docker): create a container with an `ANTHROPIC_API_KEY`; verify `printenv` inside the container shows it; verify `cat /etc/environment` does NOT contain it; verify no exec writes happen for it
- [ ] Smoke (Apple Container): same on Apple Silicon

🤖 Generated with [Claude Code](https://claude.com/claude-code)