### PR TITLE
[CRITICAL] Pass git ls-remote URL via ArgumentList with `--` separator (#124)

### DIFF
--- a/src/Andy.Containers.Api/Services/GitRepositoryProbeService.cs
+++ b/src/Andy.Containers.Api/Services/GitRepositoryProbeService.cs
@@ -107,16 +107,26 @@ public class GitRepositoryProbeService : IGitRepositoryProbeService
             var psi = new ProcessStartInfo
             {
                 FileName = "git",
-                // --heads limits output to branch refs only (faster, less output)
-                Arguments = $"ls-remote --exit-code --heads \"{probeUrl}\"",
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
             };
+            // Build argv explicitly. `--` ends git's option parsing so a URL
+            // starting with `-` cannot be mis-parsed as a flag (CVE-2017-1000117
+            // class). ArgumentList also avoids the Win32-style quote parsing
+            // that ProcessStartInfo.Arguments performs.
+            psi.ArgumentList.Add("ls-remote");
+            psi.ArgumentList.Add("--exit-code");
+            psi.ArgumentList.Add("--heads");
+            psi.ArgumentList.Add("--");
+            psi.ArgumentList.Add(probeUrl);
             // Prevent git from prompting for credentials
             psi.Environment["GIT_TERMINAL_PROMPT"] = "0";
             psi.Environment["GIT_ASKPASS"] = "echo";
+            // Belt and suspenders: also disable any user-configured protocol
+            // helpers that could be triggered by a crafted URL host.
+            psi.Environment["GIT_PROTOCOL_FROM_USER"] = "0";
 
             using var process = Process.Start(psi);
             if (process is null)


### PR DESCRIPTION
Closes #124.

## Summary

`GitRepositoryProbeService.RunGitLsRemoteAsync` built its argv from a quoted format string:

\`\`\`csharp
Arguments = $\"ls-remote --exit-code --heads \\\"{probeUrl}\\\"\"
\`\`\`

`GitRepositoryValidator` only checks the URL scheme — it does not block a URL whose path or host starts with `-`. .NET's `ProcessStartInfo.Arguments` parser is Win32-style and strips the surrounding double-quotes before exec, so the host-side `git` would receive the URL as its own argv element. A crafted URL could land in git's option-as-URL parser (CVE-2017-1000117 class) on the API's host machine.

Two changes:

- Build argv explicitly with `psi.ArgumentList`, prepending `--` so git treats every following token as a positional URL argument. This also avoids the Win32-style quote parsing entirely.
- Set `GIT_PROTOCOL_FROM_USER=0` as a belt-and-suspenders block against any user-configured protocol helpers that a crafted host could trigger.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test tests/Andy.Containers.Api.Tests` — 574/574 pass
- [ ] Smoke: probe a normal `https://github.com/owner/repo` URL — still works
- [ ] Smoke: probe a flag-shaped URL (e.g. `https://-evil.example.com/repo`) — git should error on the URL itself, never interpret it as a flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)