### PR TITLE
AP3: configurator (Agent spec → andy-cli headless config) (#105)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/RunsController.cs
+++ b/src/Andy.Containers.Api/Controllers/RunsController.cs
@@ -1,3 +1,4 @@
+using Andy.Containers.Configurator;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Models;
 using Andy.Rbac.Authorization;
@@ -20,10 +21,17 @@ namespace Andy.Containers.Api.Controllers;
 public class RunsController : ControllerBase
 {
     private readonly ContainersDbContext _db;
+    private readonly IRunConfigurator _configurator;
+    private readonly ILogger<RunsController> _logger;
 
-    public RunsController(ContainersDbContext db)
+    public RunsController(
+        ContainersDbContext db,
+        IRunConfigurator configurator,
+        ILogger<RunsController> logger)
     {
         _db = db;
+        _configurator = configurator;
+        _logger = logger;
     }
 
     [HttpPost]
@@ -71,6 +79,19 @@ public class RunsController : ControllerBase
 
         _db.Runs.Add(run);
         await _db.SaveChangesAsync(ct);
+
+        // AP3 (rivoli-ai/andy-containers#105). Build + write the andy-cli
+        // headless config now so AP6's runner has a file path the moment it
+        // wakes up. Failures here do NOT roll back the Run — the row stays
+        // Pending and AP5/AP6 can retry the configurator on the next pass
+        // (or surface a transition to Failed once that policy is decided).
+        var configResult = await _configurator.ConfigureAsync(run, ct);
+        if (!configResult.IsSuccess)
+        {
+            _logger.LogWarning(
+                "Run {RunId} persisted as Pending but configurator failed: {Error}. AP5/AP6 will retry.",
+                run.Id, configResult.Error);
+        }
 
         var dto = RunDto.FromEntity(run);
         return CreatedAtAction(nameof(Get), new { id = run.Id }, dto);

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Andy.Containers.Abstractions;
 using Andy.Containers.Api.Data;
 using Andy.Containers.Api.Services;
+using Andy.Containers.Configurator;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Infrastructure.Messaging;
 using Microsoft.EntityFrameworkCore;
@@ -227,6 +228,15 @@ try
     // Messaging (ADR 0001) — registers IMessageBus (InMemory by default,
     // Nats when Messaging:Provider=Nats) and the OutboxDispatcher.
     builder.Services.AddContainersMessaging(builder.Configuration);
+
+    // AP3 (rivoli-ai/andy-containers#105). Configurator pipeline:
+    // andy-agents lookup (stubbed until Epic W lands) → headless-config
+    // builder → on-disk writer. RunsController invokes the facade after
+    // persisting a Pending Run. AP6 picks the file up to spawn andy-cli.
+    builder.Services.AddSingleton<IAndyAgentsClient, StubAndyAgentsClient>();
+    builder.Services.AddSingleton<IHeadlessConfigBuilder, HeadlessConfigBuilder>();
+    builder.Services.AddSingleton<IHeadlessConfigWriter, HeadlessConfigWriter>();
+    builder.Services.AddScoped<IRunConfigurator, RunConfigurator>();
 
     var app = builder.Build();
 

--- a/src/Andy.Containers.Api/Services/HeadlessConfigWriter.cs
+++ b/src/Andy.Containers.Api/Services/HeadlessConfigWriter.cs
@@ -1,0 +1,53 @@
+using Andy.Containers.Configurator;
+using Microsoft.Extensions.Hosting;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// AP3 (rivoli-ai/andy-containers#105) writer. Uses
+/// <see cref="HostEnvironmentExtensions.IsEmbedded"/> to choose the on-disk
+/// root: hosted/Docker writes under <c>/var/run/andy/runs</c>, embedded
+/// (Conductor) writes under the OS temp dir so the unsandboxed Mac binary
+/// doesn't try to mkdir under <c>/var</c>.
+/// </summary>
+public sealed class HeadlessConfigWriter : IHeadlessConfigWriter
+{
+    private const string HostedRoot = "/var/run/andy/runs";
+    private const string ConfigFileName = "config.json";
+
+    private readonly IHostEnvironment _environment;
+
+    public HeadlessConfigWriter(IHostEnvironment environment)
+    {
+        _environment = environment;
+    }
+
+    public async Task<string> WriteAsync(HeadlessRunConfig config, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        if (config.RunId == Guid.Empty)
+        {
+            throw new ArgumentException("HeadlessRunConfig.RunId must be set before writing.", nameof(config));
+        }
+
+        var root = _environment.IsEmbedded()
+            ? Path.Combine(Path.GetTempPath(), "andy-containers", "runs")
+            : HostedRoot;
+
+        var runDir = Path.Combine(root, config.RunId.ToString());
+        Directory.CreateDirectory(runDir);
+
+        var path = Path.Combine(runDir, ConfigFileName);
+        var json = HeadlessConfigJson.Serialize(config);
+
+        // Atomic write via tmp + rename — the AQ1 runtime spec calls out
+        // the same pattern for output.file. AP6 may pick up the path the
+        // moment we return, so a half-written file on a crash would be
+        // worse than no file at all.
+        var tmpPath = path + ".tmp";
+        await File.WriteAllTextAsync(tmpPath, json, ct);
+        File.Move(tmpPath, path, overwrite: true);
+
+        return path;
+    }
+}

--- a/src/Andy.Containers.Api/Services/HostEnvironmentExtensions.cs
+++ b/src/Andy.Containers.Api/Services/HostEnvironmentExtensions.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Hosting;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// Named accessors for the three deployment modes (Development /
+/// Docker / Embedded). See andy-service-template/docs/ports.md.
+/// Duplicated across every andy-* service (no shared library yet);
+/// keep the <c>EmbeddedEnvironmentName</c> constant in sync with
+/// <c>ServiceEnvironment.embeddedEnvironmentName</c> on the Swift side.
+/// </summary>
+public static class HostEnvironmentExtensions
+{
+    public const string EmbeddedEnvironmentName = "Embedded";
+    public const string DockerEnvironmentName = "Docker";
+
+    public static bool IsEmbedded(this IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        return environment.IsEnvironment(EmbeddedEnvironmentName);
+    }
+
+    public static bool IsDocker(this IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        return environment.IsEnvironment(DockerEnvironmentName);
+    }
+
+    public static bool IsLocalOrEmbedded(this IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        return !environment.IsProduction();
+    }
+}

--- a/src/Andy.Containers.Api/Services/StubAndyAgentsClient.cs
+++ b/src/Andy.Containers.Api/Services/StubAndyAgentsClient.cs
@@ -1,0 +1,107 @@
+using Andy.Containers.Configurator;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// AP3 (rivoli-ai/andy-containers#105) placeholder client. The real
+/// andy-agents service does not exist yet (Epic W); this stub returns
+/// reasonable fixture specs keyed off the agent slug so AP3 + AP6 can
+/// run end-to-end. Replace with an HTTP client once andy-agents is up.
+/// </summary>
+/// <remarks>
+/// TODO(andy-agents): Swap for an HTTP-backed implementation that calls
+/// <c>GET /api/agents/{slug}?revision=N</c> on the andy-agents service.
+/// Fixture data here intentionally tracks the AQ1 sample configs so the
+/// configurator output stays close to the canonical shapes during local dev.
+/// </remarks>
+public sealed class StubAndyAgentsClient : IAndyAgentsClient
+{
+    private static readonly Dictionary<string, AgentSpec> Fixtures = new(StringComparer.Ordinal)
+    {
+        ["triage-agent"] = new AgentSpec
+        {
+            Slug = "triage-agent",
+            Revision = 1,
+            Instructions = "You are the triage agent. Classify incoming issues against the Rivoli template set.",
+            OutputFormat = "json-triage-output-v1",
+            Model = new AgentSpecModel
+            {
+                Provider = "anthropic",
+                Id = "claude-sonnet-4-6",
+                ApiKeyRef = "env:ANDY_MODEL_KEY",
+            },
+            Tools = new[]
+            {
+                new AgentSpecTool { Name = "issues.get", Transport = "mcp", Endpoint = "https://mcp.internal/tools/issues.get" },
+            },
+            Boundaries = new[] { "read-only" },
+            Limits = new AgentSpecLimits { MaxIterations = 50, TimeoutSeconds = 300 },
+        },
+        ["planning-agent"] = new AgentSpec
+        {
+            Slug = "planning-agent",
+            Instructions = "You are the planning agent. Decompose the triaged issue into TaskNodes.",
+            OutputFormat = "json-plan-v1",
+            Model = new AgentSpecModel
+            {
+                Provider = "anthropic",
+                Id = "claude-opus-4-7",
+                ApiKeyRef = "env:ANDY_MODEL_KEY",
+            },
+            Tools = new[]
+            {
+                new AgentSpecTool { Name = "docs.put", Transport = "mcp", Endpoint = "https://mcp.internal/tools/docs.put" },
+            },
+            Boundaries = new[] { "draft-only" },
+            Limits = new AgentSpecLimits { MaxIterations = 120, TimeoutSeconds = 900 },
+        },
+        ["coding-agent"] = new AgentSpec
+        {
+            Slug = "coding-agent",
+            Instructions = "You are the coding agent. Implement the assigned TaskNode against the delegation contract.",
+            OutputFormat = "plain",
+            Model = new AgentSpecModel
+            {
+                Provider = "anthropic",
+                Id = "claude-sonnet-4-6",
+                ApiKeyRef = "env:ANDY_MODEL_KEY",
+            },
+            Tools = new[]
+            {
+                new AgentSpecTool { Name = "fs.patch", Transport = "mcp", Endpoint = "https://mcp.internal/tools/fs.patch" },
+                new AgentSpecTool
+                {
+                    Name = "git",
+                    Transport = "cli",
+                    Binary = "git",
+                    Command = new[] { "git" },
+                },
+            },
+            Boundaries = new[] { "write-branch", "sandboxed" },
+            Limits = new AgentSpecLimits { MaxIterations = 400, TimeoutSeconds = 3600 },
+        },
+    };
+
+    public Task<AgentSpec?> GetAgentAsync(string agentSlug, int? revision, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(agentSlug))
+        {
+            return Task.FromResult<AgentSpec?>(null);
+        }
+
+        if (!Fixtures.TryGetValue(agentSlug, out var spec))
+        {
+            return Task.FromResult<AgentSpec?>(null);
+        }
+
+        // Revision pinning is best-effort against the stub: if the caller
+        // asks for a specific revision, echo it back rather than the
+        // fixture's default so AP6 sees the pin propagated end-to-end.
+        if (revision.HasValue)
+        {
+            spec = spec with { Revision = revision };
+        }
+
+        return Task.FromResult<AgentSpec?>(spec);
+    }
+}

--- a/src/Andy.Containers/Configurator/AgentSpec.cs
+++ b/src/Andy.Containers/Configurator/AgentSpec.cs
@@ -1,0 +1,53 @@
+namespace Andy.Containers.Configurator;
+
+/// <summary>
+/// AP3 (rivoli-ai/andy-containers#105) view of the resolved agent spec the
+/// configurator consumes. The shape mirrors what andy-agents will eventually
+/// return over HTTP — once that service exists, swap the
+/// <see cref="IAndyAgentsClient"/> implementation but keep this type stable.
+/// </summary>
+/// <remarks>
+/// "Resolved" means skills have already been expanded to concrete tool
+/// bindings; the configurator does not re-walk skill graphs. Boundaries and
+/// limits come from the policy engine + agent metadata server-side.
+/// </remarks>
+public sealed record AgentSpec
+{
+    public required string Slug { get; init; }
+    public int? Revision { get; init; }
+    public required string Instructions { get; init; }
+    public string? OutputFormat { get; init; }
+    public required AgentSpecModel Model { get; init; }
+    public IReadOnlyList<AgentSpecTool> Tools { get; init; } = [];
+    public IReadOnlyDictionary<string, string>? EnvVars { get; init; }
+    public IReadOnlyList<string>? Boundaries { get; init; }
+    public AgentSpecLimits Limits { get; init; } = new();
+}
+
+public sealed record AgentSpecModel
+{
+    public required string Provider { get; init; }
+    public required string Id { get; init; }
+    public string? ApiKeyRef { get; init; }
+}
+
+/// <summary>
+/// Discriminated by <see cref="Transport"/> ("mcp" or "cli"). MCP bindings set
+/// <see cref="Endpoint"/>; CLI bindings set <see cref="Binary"/> (and optionally
+/// <see cref="Command"/>). The headless schema enforces the oneOf shape — the
+/// builder validates the same invariant before emitting the config.
+/// </summary>
+public sealed record AgentSpecTool
+{
+    public required string Name { get; init; }
+    public required string Transport { get; init; }
+    public string? Endpoint { get; init; }
+    public string? Binary { get; init; }
+    public IReadOnlyList<string>? Command { get; init; }
+}
+
+public sealed record AgentSpecLimits
+{
+    public int MaxIterations { get; init; } = 100;
+    public int TimeoutSeconds { get; init; } = 900;
+}

--- a/src/Andy.Containers/Configurator/HeadlessConfigBuilder.cs
+++ b/src/Andy.Containers/Configurator/HeadlessConfigBuilder.cs
@@ -1,0 +1,143 @@
+using Andy.Containers.Models;
+
+namespace Andy.Containers.Configurator;
+
+/// <summary>
+/// Default <see cref="IHeadlessConfigBuilder"/>. Lives in the core lib (not
+/// the API project) so AP6's runner — which will live in a separate process
+/// once it's spun out — can reuse the same mapper without dragging the API
+/// host along.
+/// </summary>
+public sealed class HeadlessConfigBuilder : IHeadlessConfigBuilder
+{
+    // Schema enum closures. Kept private and local rather than reading the
+    // schema file at runtime — the schema lives in a sibling repo and bumps
+    // are deliberate version events, not silent extensions.
+    private static readonly HashSet<string> AllowedProviders = new(StringComparer.Ordinal)
+    {
+        "anthropic", "openai", "google", "cerebras", "local",
+    };
+
+    private const string DefaultWorkspaceRoot = "/workspace";
+    private const string DefaultOutputFile = "/workspace/.andy-run/output.json";
+    private const string DefaultStream = "stdout";
+
+    public HeadlessRunConfig Build(Run run, AgentSpec agent)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        ArgumentNullException.ThrowIfNull(agent);
+
+        if (run.Id == Guid.Empty)
+        {
+            throw new ArgumentException("Run.Id must be set before building a headless config.", nameof(run));
+        }
+
+        if (string.IsNullOrWhiteSpace(agent.Instructions))
+        {
+            throw new ArgumentException("AgentSpec.Instructions is required (schema minLength 1).", nameof(agent));
+        }
+
+        if (string.IsNullOrWhiteSpace(agent.Model.Provider) || !AllowedProviders.Contains(agent.Model.Provider))
+        {
+            throw new ArgumentException(
+                $"AgentSpec.Model.Provider '{agent.Model.Provider}' is not one of: {string.Join(", ", AllowedProviders)}.",
+                nameof(agent));
+        }
+
+        if (string.IsNullOrWhiteSpace(agent.Model.Id))
+        {
+            throw new ArgumentException("AgentSpec.Model.Id is required.", nameof(agent));
+        }
+
+        var tools = agent.Tools.Select(MapTool).ToList();
+
+        return new HeadlessRunConfig
+        {
+            SchemaVersion = 1,
+            RunId = run.Id,
+            Agent = new HeadlessAgent
+            {
+                Slug = agent.Slug,
+                Revision = agent.Revision,
+                Instructions = agent.Instructions,
+                OutputFormat = agent.OutputFormat,
+            },
+            Model = new HeadlessModel
+            {
+                Provider = agent.Model.Provider,
+                Id = agent.Model.Id,
+                ApiKeyRef = agent.Model.ApiKeyRef,
+            },
+            Tools = tools,
+            Workspace = new HeadlessWorkspace
+            {
+                Root = DefaultWorkspaceRoot,
+                Branch = run.WorkspaceRef.Branch,
+            },
+            EnvVars = agent.EnvVars is { Count: > 0 } ? agent.EnvVars : null,
+            Output = new HeadlessOutput
+            {
+                File = DefaultOutputFile,
+                Stream = DefaultStream,
+            },
+            EventSink = new HeadlessEventSink
+            {
+                // Matches the andy.containers.events.run.{id}.{event} fan-out
+                // AP6 will subscribe; ".progress" is the topic the runner
+                // emits structured progress on. Other event topics under the
+                // same prefix get configured at fan-in time.
+                NatsSubject = $"andy.containers.events.run.{run.Id}.progress",
+            },
+            PolicyId = run.PolicyId,
+            Boundaries = agent.Boundaries is { Count: > 0 } ? agent.Boundaries : null,
+            Limits = new HeadlessLimits
+            {
+                MaxIterations = agent.Limits.MaxIterations,
+                TimeoutSeconds = agent.Limits.TimeoutSeconds,
+            },
+        };
+    }
+
+    private static HeadlessTool MapTool(AgentSpecTool tool)
+    {
+        if (string.IsNullOrWhiteSpace(tool.Name))
+        {
+            throw new ArgumentException("AgentSpecTool.Name is required.", nameof(tool));
+        }
+
+        switch (tool.Transport)
+        {
+            case "mcp":
+                if (string.IsNullOrWhiteSpace(tool.Endpoint))
+                {
+                    throw new ArgumentException(
+                        $"MCP tool '{tool.Name}' requires an Endpoint.", nameof(tool));
+                }
+                return new HeadlessTool
+                {
+                    Name = tool.Name,
+                    Transport = "mcp",
+                    Endpoint = tool.Endpoint,
+                };
+
+            case "cli":
+                if (string.IsNullOrWhiteSpace(tool.Binary))
+                {
+                    throw new ArgumentException(
+                        $"CLI tool '{tool.Name}' requires a Binary.", nameof(tool));
+                }
+                return new HeadlessTool
+                {
+                    Name = tool.Name,
+                    Transport = "cli",
+                    Binary = tool.Binary,
+                    Command = tool.Command is { Count: > 0 } ? tool.Command : null,
+                };
+
+            default:
+                throw new ArgumentException(
+                    $"Tool '{tool.Name}' has unsupported transport '{tool.Transport}'. Expected 'mcp' or 'cli'.",
+                    nameof(tool));
+        }
+    }
+}

--- a/src/Andy.Containers/Configurator/HeadlessConfigJson.cs
+++ b/src/Andy.Containers/Configurator/HeadlessConfigJson.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Andy.Containers.Configurator;
+
+/// <summary>
+/// Serialization policy shared by writer + tests. Snake-case property names
+/// match the AQ1 schema; nulls are skipped so optional fields like
+/// <c>api_key_ref</c> or <c>boundaries</c> don't appear when unset (the
+/// schema treats absent and null differently for some properties).
+/// </summary>
+public static class HeadlessConfigJson
+{
+    public static JsonSerializerOptions Options { get; } = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DictionaryKeyPolicy = null,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true,
+    };
+
+    public static string Serialize(HeadlessRunConfig config)
+        => JsonSerializer.Serialize(config, Options);
+}

--- a/src/Andy.Containers/Configurator/HeadlessRunConfig.cs
+++ b/src/Andy.Containers/Configurator/HeadlessRunConfig.cs
@@ -1,0 +1,80 @@
+namespace Andy.Containers.Configurator;
+
+/// <summary>
+/// C# mirror of the andy-cli AQ1 headless-config schema
+/// (<c>schemas/headless-config.v1.json</c> in rivoli-ai/andy-cli). Property
+/// names are PascalCase here; the configurator serializer applies
+/// <see cref="System.Text.Json.JsonNamingPolicy.SnakeCaseLower"/> so the
+/// emitted JSON matches the schema's snake_case wire names without
+/// per-property attributes.
+/// </summary>
+/// <remarks>
+/// AP3 (rivoli-ai/andy-containers#105). Re-defining the type here (rather
+/// than referencing andy-cli's <c>HeadlessRunConfig</c>) keeps the contract
+/// asymmetric in the right direction: andy-cli owns the canonical schema
+/// file, andy-containers owns the producer side. A schema bump (v2) means
+/// adding a sibling type, not a breaking change to v1 consumers.
+/// </remarks>
+public sealed record HeadlessRunConfig
+{
+    public int SchemaVersion { get; init; } = 1;
+    public Guid RunId { get; init; }
+    public HeadlessAgent Agent { get; init; } = new();
+    public HeadlessModel Model { get; init; } = new();
+    public IReadOnlyList<HeadlessTool> Tools { get; init; } = [];
+    public HeadlessWorkspace Workspace { get; init; } = new();
+    public IReadOnlyDictionary<string, string>? EnvVars { get; init; }
+    public HeadlessOutput Output { get; init; } = new();
+    public HeadlessEventSink? EventSink { get; init; }
+    public Guid? PolicyId { get; init; }
+    public IReadOnlyList<string>? Boundaries { get; init; }
+    public HeadlessLimits Limits { get; init; } = new();
+}
+
+public sealed record HeadlessAgent
+{
+    public string Slug { get; init; } = string.Empty;
+    public int? Revision { get; init; }
+    public string Instructions { get; init; } = string.Empty;
+    public string? OutputFormat { get; init; }
+}
+
+public sealed record HeadlessModel
+{
+    public string Provider { get; init; } = string.Empty;
+    public string Id { get; init; } = string.Empty;
+    public string? ApiKeyRef { get; init; }
+}
+
+public sealed record HeadlessTool
+{
+    public string Name { get; init; } = string.Empty;
+    public string Transport { get; init; } = string.Empty;
+    public string? Endpoint { get; init; }
+    public string? Binary { get; init; }
+    public IReadOnlyList<string>? Command { get; init; }
+}
+
+public sealed record HeadlessWorkspace
+{
+    public string Root { get; init; } = string.Empty;
+    public string? Branch { get; init; }
+}
+
+public sealed record HeadlessOutput
+{
+    public string File { get; init; } = string.Empty;
+    public string Stream { get; init; } = string.Empty;
+}
+
+public sealed record HeadlessEventSink
+{
+    public string? NatsSubject { get; init; }
+    public string? Path { get; init; }
+}
+
+public sealed record HeadlessLimits
+{
+    public int MaxIterations { get; init; }
+    public int TimeoutSeconds { get; init; }
+}

--- a/src/Andy.Containers/Configurator/IAndyAgentsClient.cs
+++ b/src/Andy.Containers/Configurator/IAndyAgentsClient.cs
@@ -1,0 +1,26 @@
+namespace Andy.Containers.Configurator;
+
+/// <summary>
+/// AP3 (rivoli-ai/andy-containers#105). Abstraction over the andy-agents
+/// service — the source of truth for agent specs (slug, instructions, model
+/// preference, allowed tools, boundaries, limits).
+/// </summary>
+/// <remarks>
+/// The real andy-agents HTTP service does not exist yet; the in-process
+/// <c>StubAndyAgentsClient</c> ships AP3-built fixtures so the configurator
+/// can be exercised end-to-end. Swap the implementation once andy-agents
+/// is reachable; the interface is intentionally narrow to keep the eventual
+/// HTTP client trivial.
+/// </remarks>
+public interface IAndyAgentsClient
+{
+    /// <summary>
+    /// Resolves the spec for <paramref name="agentSlug"/>, optionally pinned
+    /// to <paramref name="revision"/> (null = head). Returns null when the
+    /// agent is unknown so callers can map to a 404-equivalent.
+    /// </summary>
+    Task<AgentSpec?> GetAgentAsync(
+        string agentSlug,
+        int? revision,
+        CancellationToken ct = default);
+}

--- a/src/Andy.Containers/Configurator/IHeadlessConfigBuilder.cs
+++ b/src/Andy.Containers/Configurator/IHeadlessConfigBuilder.cs
@@ -1,0 +1,16 @@
+using Andy.Containers.Models;
+
+namespace Andy.Containers.Configurator;
+
+/// <summary>
+/// AP3 (rivoli-ai/andy-containers#105). Maps a <see cref="Run"/> + resolved
+/// <see cref="AgentSpec"/> into a <see cref="HeadlessRunConfig"/> shaped to
+/// the AQ1 schema. Throws <see cref="ArgumentException"/> when the inputs
+/// can't produce a schema-valid config (unknown provider, malformed tool
+/// binding, empty instructions) — caller decides whether to surface that
+/// as a 400 or a transition to <see cref="RunStatus.Failed"/>.
+/// </summary>
+public interface IHeadlessConfigBuilder
+{
+    HeadlessRunConfig Build(Run run, AgentSpec agent);
+}

--- a/src/Andy.Containers/Configurator/IHeadlessConfigWriter.cs
+++ b/src/Andy.Containers/Configurator/IHeadlessConfigWriter.cs
@@ -1,0 +1,19 @@
+namespace Andy.Containers.Configurator;
+
+/// <summary>
+/// AP3 (rivoli-ai/andy-containers#105). Persists a built
+/// <see cref="HeadlessRunConfig"/> to disk so AP6 can hand the file path to
+/// <c>andy-cli run --headless --config &lt;path&gt;</c>. AP3 only writes the
+/// file; AP6 owns process spawning.
+/// </summary>
+public interface IHeadlessConfigWriter
+{
+    /// <summary>
+    /// Serializes <paramref name="config"/> as snake_case JSON and writes it
+    /// to a per-run path under the configurator root. Returns the absolute
+    /// path written. Idempotent — overwrites any existing file for the same
+    /// <c>RunId</c> (re-runs of AP6 against the same Run are expected to pick
+    /// up updated config).
+    /// </summary>
+    Task<string> WriteAsync(HeadlessRunConfig config, CancellationToken ct = default);
+}

--- a/src/Andy.Containers/Configurator/IRunConfigurator.cs
+++ b/src/Andy.Containers/Configurator/IRunConfigurator.cs
@@ -1,0 +1,30 @@
+using Andy.Containers.Models;
+
+namespace Andy.Containers.Configurator;
+
+/// <summary>
+/// AP3 (rivoli-ai/andy-containers#105) facade: fetch agent spec → build
+/// headless config → write to disk. Single entry point so the AP2 controller
+/// (and future AP5 dispatcher) doesn't have to wire the three steps itself.
+/// </summary>
+public interface IRunConfigurator
+{
+    Task<RunConfiguratorResult> ConfigureAsync(Run run, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Outcome of a configurator pass. <see cref="Path"/> is the absolute config
+/// path on success; on failure it's null and <see cref="Error"/> explains why.
+/// AP3 does not throw on agent-lookup misses or builder validation errors —
+/// the caller decides whether to mark the Run as Failed or just log + skip.
+/// </summary>
+public sealed record RunConfiguratorResult
+{
+    public string? Path { get; init; }
+    public string? Error { get; init; }
+
+    public bool IsSuccess => Path is not null && Error is null;
+
+    public static RunConfiguratorResult Ok(string path) => new() { Path = path };
+    public static RunConfiguratorResult Fail(string error) => new() { Error = error };
+}

--- a/src/Andy.Containers/Configurator/RunConfigurator.cs
+++ b/src/Andy.Containers/Configurator/RunConfigurator.cs
@@ -1,0 +1,73 @@
+using Andy.Containers.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Containers.Configurator;
+
+public sealed class RunConfigurator : IRunConfigurator
+{
+    private readonly IAndyAgentsClient _agents;
+    private readonly IHeadlessConfigBuilder _builder;
+    private readonly IHeadlessConfigWriter _writer;
+    private readonly ILogger<RunConfigurator> _logger;
+
+    public RunConfigurator(
+        IAndyAgentsClient agents,
+        IHeadlessConfigBuilder builder,
+        IHeadlessConfigWriter writer,
+        ILogger<RunConfigurator> logger)
+    {
+        _agents = agents;
+        _builder = builder;
+        _writer = writer;
+        _logger = logger;
+    }
+
+    public async Task<RunConfiguratorResult> ConfigureAsync(Run run, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+
+        var spec = await _agents.GetAgentAsync(run.AgentId, run.AgentRevision, ct);
+        if (spec is null)
+        {
+            _logger.LogWarning(
+                "Configurator: agent '{AgentId}' (revision {Revision}) not found for run {RunId}.",
+                run.AgentId, run.AgentRevision, run.Id);
+            return RunConfiguratorResult.Fail($"Agent '{run.AgentId}' not found.");
+        }
+
+        HeadlessRunConfig config;
+        try
+        {
+            config = _builder.Build(run, spec);
+        }
+        catch (ArgumentException ex)
+        {
+            _logger.LogWarning(ex,
+                "Configurator: builder rejected agent '{AgentId}' for run {RunId}: {Message}",
+                run.AgentId, run.Id, ex.Message);
+            return RunConfiguratorResult.Fail(ex.Message);
+        }
+
+        try
+        {
+            var path = await _writer.WriteAsync(config, ct);
+            _logger.LogInformation(
+                "Configurator: wrote headless config for run {RunId} to {Path}.", run.Id, path);
+            return RunConfiguratorResult.Ok(path);
+        }
+        catch (IOException ex)
+        {
+            _logger.LogError(ex,
+                "Configurator: failed to write headless config for run {RunId}: {Message}",
+                run.Id, ex.Message);
+            return RunConfiguratorResult.Fail($"Failed to write config: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogError(ex,
+                "Configurator: permission denied writing headless config for run {RunId}: {Message}",
+                run.Id, ex.Message);
+            return RunConfiguratorResult.Fail($"Permission denied writing config: {ex.Message}");
+        }
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigBuilderTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigBuilderTests.cs
@@ -1,0 +1,216 @@
+using Andy.Containers.Configurator;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Configurator;
+
+// AP3 (rivoli-ai/andy-containers#105). Verifies the Run + AgentSpec ->
+// HeadlessRunConfig mapper enforces the AQ1 schema closures (provider enum,
+// transport oneOf, required string mins) up-front so AP6 never has to
+// load-and-reject a config it just wrote.
+public class HeadlessConfigBuilderTests
+{
+    private readonly HeadlessConfigBuilder _builder = new();
+
+    [Fact]
+    public void Build_HappyPath_ProducesSchemaConformingConfig()
+    {
+        var run = SeedRun();
+        var spec = TriageAgent();
+
+        var config = _builder.Build(run, spec);
+
+        config.SchemaVersion.Should().Be(1);
+        config.RunId.Should().Be(run.Id);
+
+        config.Agent.Slug.Should().Be("triage-agent");
+        config.Agent.Revision.Should().Be(3);
+        config.Agent.Instructions.Should().NotBeNullOrWhiteSpace();
+        config.Agent.OutputFormat.Should().Be("json-triage-output-v1");
+
+        config.Model.Provider.Should().Be("anthropic");
+        config.Model.Id.Should().Be("claude-sonnet-4-6");
+        config.Model.ApiKeyRef.Should().Be("env:ANDY_MODEL_KEY");
+
+        config.Tools.Should().HaveCount(2);
+        config.Tools[0].Transport.Should().Be("mcp");
+        config.Tools[0].Endpoint.Should().Be("https://mcp.internal/tools/issues.get");
+        config.Tools[1].Transport.Should().Be("cli");
+        config.Tools[1].Binary.Should().Be("andy-issues-cli");
+        config.Tools[1].Command.Should().Equal("andy-issues-cli", "search");
+
+        config.Workspace.Root.Should().Be("/workspace");
+        config.Workspace.Branch.Should().Be("main", "branch flows from Run.WorkspaceRef.Branch");
+
+        config.Output.File.Should().Be("/workspace/.andy-run/output.json");
+        config.Output.Stream.Should().Be("stdout");
+
+        config.EventSink!.NatsSubject.Should().Be(
+            $"andy.containers.events.run.{run.Id}.progress",
+            "subject must match the schema pattern andy.containers.events.run.{uuid}.{event}");
+
+        config.PolicyId.Should().Be(run.PolicyId);
+        config.Boundaries.Should().Equal("read-only");
+        config.Limits.MaxIterations.Should().Be(50);
+        config.Limits.TimeoutSeconds.Should().Be(300);
+    }
+
+    [Fact]
+    public void Build_EmptyInstructions_Throws()
+    {
+        var run = SeedRun();
+        var spec = TriageAgent() with { Instructions = "   " };
+
+        var act = () => _builder.Build(run, spec);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Instructions*", "schema requires minLength 1");
+    }
+
+    [Theory]
+    [InlineData("aws-bedrock")]
+    [InlineData("")]
+    [InlineData("ANTHROPIC")]
+    public void Build_UnknownProvider_Throws(string provider)
+    {
+        var run = SeedRun();
+        var spec = TriageAgent() with
+        {
+            Model = new AgentSpecModel { Provider = provider, Id = "claude-sonnet-4-6" },
+        };
+
+        var act = () => _builder.Build(run, spec);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Provider*", "schema enum closes at anthropic|openai|google|cerebras|local");
+    }
+
+    [Fact]
+    public void Build_McpToolMissingEndpoint_Throws()
+    {
+        var run = SeedRun();
+        var spec = TriageAgent() with
+        {
+            Tools = new[]
+            {
+                new AgentSpecTool { Name = "issues.get", Transport = "mcp", Endpoint = null },
+            },
+        };
+
+        var act = () => _builder.Build(run, spec);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Endpoint*");
+    }
+
+    [Fact]
+    public void Build_CliToolMissingBinary_Throws()
+    {
+        var run = SeedRun();
+        var spec = TriageAgent() with
+        {
+            Tools = new[]
+            {
+                new AgentSpecTool { Name = "git", Transport = "cli", Binary = null },
+            },
+        };
+
+        var act = () => _builder.Build(run, spec);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Binary*");
+    }
+
+    [Fact]
+    public void Build_UnknownTransport_Throws()
+    {
+        var run = SeedRun();
+        var spec = TriageAgent() with
+        {
+            Tools = new[]
+            {
+                new AgentSpecTool { Name = "weird", Transport = "grpc" },
+            },
+        };
+
+        var act = () => _builder.Build(run, spec);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*transport*");
+    }
+
+    [Fact]
+    public void Build_EmptyEnvVarsCollapseToNull()
+    {
+        var run = SeedRun();
+        var spec = TriageAgent() with { EnvVars = new Dictionary<string, string>() };
+
+        var config = _builder.Build(run, spec);
+
+        config.EnvVars.Should().BeNull(
+            "schema permits omission; emitting an empty object adds noise to the on-disk config");
+    }
+
+    [Fact]
+    public void Build_EmptyBoundariesCollapseToNull()
+    {
+        var run = SeedRun();
+        var spec = TriageAgent() with { Boundaries = Array.Empty<string>() };
+
+        var config = _builder.Build(run, spec);
+
+        config.Boundaries.Should().BeNull();
+    }
+
+    [Fact]
+    public void Build_RunWithoutId_Throws()
+    {
+        var run = SeedRun();
+        run.Id = Guid.Empty;
+        var spec = TriageAgent();
+
+        var act = () => _builder.Build(run, spec);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*Run.Id*");
+    }
+
+    private static Run SeedRun() => new()
+    {
+        Id = Guid.NewGuid(),
+        AgentId = "triage-agent",
+        AgentRevision = 3,
+        Mode = RunMode.Headless,
+        EnvironmentProfileId = Guid.NewGuid(),
+        WorkspaceRef = new WorkspaceRef { WorkspaceId = Guid.NewGuid(), Branch = "main" },
+        PolicyId = Guid.NewGuid(),
+        CorrelationId = Guid.NewGuid(),
+    };
+
+    private static AgentSpec TriageAgent() => new()
+    {
+        Slug = "triage-agent",
+        Revision = 3,
+        Instructions = "You are the triage agent.",
+        OutputFormat = "json-triage-output-v1",
+        Model = new AgentSpecModel
+        {
+            Provider = "anthropic",
+            Id = "claude-sonnet-4-6",
+            ApiKeyRef = "env:ANDY_MODEL_KEY",
+        },
+        Tools = new[]
+        {
+            new AgentSpecTool { Name = "issues.get", Transport = "mcp", Endpoint = "https://mcp.internal/tools/issues.get" },
+            new AgentSpecTool
+            {
+                Name = "repo.search",
+                Transport = "cli",
+                Binary = "andy-issues-cli",
+                Command = new[] { "andy-issues-cli", "search" },
+            },
+        },
+        Boundaries = new[] { "read-only" },
+        Limits = new AgentSpecLimits { MaxIterations = 50, TimeoutSeconds = 300 },
+    };
+}

--- a/tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigWriterTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigWriterTests.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Configurator;
+using FluentAssertions;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Configurator;
+
+// AP3 (rivoli-ai/andy-containers#105). Verifies the writer atomically
+// produces a snake_case JSON file under the embedded path. The hosted path
+// (/var/run/andy/runs) is not exercised here — it requires root on the
+// CI host and the path-selection branch is covered by HostEnvironment.
+public class HeadlessConfigWriterTests : IDisposable
+{
+    private readonly string _tempBase;
+
+    public HeadlessConfigWriterTests()
+    {
+        _tempBase = Path.Combine(Path.GetTempPath(), "andy-containers", "runs");
+    }
+
+    public void Dispose()
+    {
+        // Tests above write under the OS temp dir. Best-effort cleanup of
+        // run subdirs created during this run; intentionally narrow so we
+        // never blow away unrelated state if Path.GetTempPath shifts.
+        if (!Directory.Exists(_tempBase)) return;
+        foreach (var dir in Directory.EnumerateDirectories(_tempBase))
+        {
+            if (Guid.TryParse(Path.GetFileName(dir), out _))
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { /* ignore */ }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task WriteAsync_Embedded_WritesSnakeCaseJsonUnderTempRoot()
+    {
+        var writer = new HeadlessConfigWriter(new FakeEnv(HostEnvironmentExtensions.EmbeddedEnvironmentName));
+        var config = SampleConfig();
+
+        var path = await writer.WriteAsync(config);
+
+        path.Should().StartWith(_tempBase);
+        File.Exists(path).Should().BeTrue();
+
+        var json = await File.ReadAllTextAsync(path);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        root.GetProperty("schema_version").GetInt32().Should().Be(1);
+        root.GetProperty("run_id").GetGuid().Should().Be(config.RunId);
+        root.GetProperty("agent").GetProperty("slug").GetString().Should().Be("triage-agent");
+        root.GetProperty("model").GetProperty("provider").GetString().Should().Be("anthropic");
+        root.TryGetProperty("policy_id", out _).Should().BeFalse(
+            "null optional fields are skipped via DefaultIgnoreCondition.WhenWritingNull");
+    }
+
+    [Fact]
+    public async Task WriteAsync_OverwritesExistingFile()
+    {
+        var writer = new HeadlessConfigWriter(new FakeEnv(HostEnvironmentExtensions.EmbeddedEnvironmentName));
+        var config = SampleConfig();
+
+        var first = await writer.WriteAsync(config);
+        var updated = config with { Boundaries = new[] { "read-only" } };
+        var second = await writer.WriteAsync(updated);
+
+        second.Should().Be(first, "same RunId always resolves to the same on-disk path");
+        var json = await File.ReadAllTextAsync(second);
+        json.Should().Contain("read-only", "second write replaces the first atomically");
+    }
+
+    [Fact]
+    public async Task WriteAsync_LeavesNoTmpFileBehind()
+    {
+        var writer = new HeadlessConfigWriter(new FakeEnv(HostEnvironmentExtensions.EmbeddedEnvironmentName));
+        var config = SampleConfig();
+
+        var path = await writer.WriteAsync(config);
+
+        File.Exists(path + ".tmp").Should().BeFalse(
+            "atomic write renames the .tmp into place; leftover .tmp = a partial write");
+    }
+
+    [Fact]
+    public async Task WriteAsync_EmptyRunId_Throws()
+    {
+        var writer = new HeadlessConfigWriter(new FakeEnv(HostEnvironmentExtensions.EmbeddedEnvironmentName));
+        var config = SampleConfig() with { RunId = Guid.Empty };
+
+        var act = async () => await writer.WriteAsync(config);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*RunId*");
+    }
+
+    private static HeadlessRunConfig SampleConfig() => new()
+    {
+        SchemaVersion = 1,
+        RunId = Guid.NewGuid(),
+        Agent = new HeadlessAgent { Slug = "triage-agent", Instructions = "..." },
+        Model = new HeadlessModel { Provider = "anthropic", Id = "claude-sonnet-4-6" },
+        Workspace = new HeadlessWorkspace { Root = "/workspace" },
+        Output = new HeadlessOutput { File = "/workspace/.andy-run/output.json", Stream = "stdout" },
+        Limits = new HeadlessLimits { MaxIterations = 50, TimeoutSeconds = 300 },
+    };
+
+    private sealed class FakeEnv : IHostEnvironment
+    {
+        public FakeEnv(string name) { EnvironmentName = name; }
+        public string EnvironmentName { get; set; }
+        public string ApplicationName { get; set; } = "test";
+        public string ContentRootPath { get; set; } = "/";
+        public IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Configurator/RunConfiguratorTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Configurator/RunConfiguratorTests.cs
@@ -1,0 +1,117 @@
+using Andy.Containers.Configurator;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Configurator;
+
+// AP3 (rivoli-ai/andy-containers#105). Verifies the orchestrator returns
+// structured failure (rather than throwing) when any of the three legs fail,
+// so the AP2 controller can log + continue without rolling the Run back.
+public class RunConfiguratorTests
+{
+    private readonly Mock<IAndyAgentsClient> _agents = new();
+    private readonly Mock<IHeadlessConfigBuilder> _builder = new();
+    private readonly Mock<IHeadlessConfigWriter> _writer = new();
+
+    private RunConfigurator CreateSut() =>
+        new(_agents.Object, _builder.Object, _writer.Object, NullLogger<RunConfigurator>.Instance);
+
+    [Fact]
+    public async Task ConfigureAsync_HappyPath_WritesAndReturnsPath()
+    {
+        var run = SeedRun();
+        var spec = TriageAgent();
+        var config = SampleConfig(run.Id);
+        _agents.Setup(a => a.GetAgentAsync(run.AgentId, run.AgentRevision, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(spec);
+        _builder.Setup(b => b.Build(run, spec)).Returns(config);
+        _writer.Setup(w => w.WriteAsync(config, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("/tmp/runs/x/config.json");
+
+        var result = await CreateSut().ConfigureAsync(run);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Path.Should().Be("/tmp/runs/x/config.json");
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_AgentNotFound_ReturnsFailure()
+    {
+        var run = SeedRun();
+        _agents.Setup(a => a.GetAgentAsync(run.AgentId, run.AgentRevision, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AgentSpec?)null);
+
+        var result = await CreateSut().ConfigureAsync(run);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Contain(run.AgentId);
+        _builder.VerifyNoOtherCalls();
+        _writer.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_BuilderRejects_ReturnsFailure()
+    {
+        var run = SeedRun();
+        var spec = TriageAgent();
+        _agents.Setup(a => a.GetAgentAsync(run.AgentId, run.AgentRevision, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(spec);
+        _builder.Setup(b => b.Build(run, spec)).Throws(new ArgumentException("bad provider"));
+
+        var result = await CreateSut().ConfigureAsync(run);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Contain("bad provider");
+        _writer.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_WriterIoError_ReturnsFailure()
+    {
+        var run = SeedRun();
+        var spec = TriageAgent();
+        var config = SampleConfig(run.Id);
+        _agents.Setup(a => a.GetAgentAsync(run.AgentId, run.AgentRevision, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(spec);
+        _builder.Setup(b => b.Build(run, spec)).Returns(config);
+        _writer.Setup(w => w.WriteAsync(config, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("disk full"));
+
+        var result = await CreateSut().ConfigureAsync(run);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Contain("disk full");
+    }
+
+    private static Run SeedRun() => new()
+    {
+        Id = Guid.NewGuid(),
+        AgentId = "triage-agent",
+        AgentRevision = 1,
+        Mode = RunMode.Headless,
+        EnvironmentProfileId = Guid.NewGuid(),
+        WorkspaceRef = new WorkspaceRef { WorkspaceId = Guid.NewGuid(), Branch = "main" },
+        CorrelationId = Guid.NewGuid(),
+    };
+
+    private static AgentSpec TriageAgent() => new()
+    {
+        Slug = "triage-agent",
+        Instructions = "...",
+        Model = new AgentSpecModel { Provider = "anthropic", Id = "claude-sonnet-4-6" },
+        Limits = new AgentSpecLimits { MaxIterations = 10, TimeoutSeconds = 60 },
+    };
+
+    private static HeadlessRunConfig SampleConfig(Guid runId) => new()
+    {
+        RunId = runId,
+        Agent = new HeadlessAgent { Slug = "triage-agent", Instructions = "..." },
+        Model = new HeadlessModel { Provider = "anthropic", Id = "claude-sonnet-4-6" },
+        Workspace = new HeadlessWorkspace { Root = "/workspace" },
+        Output = new HeadlessOutput { File = "/workspace/.andy-run/output.json", Stream = "stdout" },
+        Limits = new HeadlessLimits { MaxIterations = 10, TimeoutSeconds = 60 },
+    };
+}

--- a/tests/Andy.Containers.Api.Tests/Configurator/StubAndyAgentsClientTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Configurator/StubAndyAgentsClientTests.cs
@@ -1,0 +1,56 @@
+using Andy.Containers.Api.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Configurator;
+
+// AP3 (rivoli-ai/andy-containers#105). The stub is the only thing standing
+// between AP3 and a real andy-agents service; its fixtures are part of the
+// developer-experience contract until Epic W lands.
+public class StubAndyAgentsClientTests
+{
+    private readonly StubAndyAgentsClient _client = new();
+
+    [Theory]
+    [InlineData("triage-agent")]
+    [InlineData("planning-agent")]
+    [InlineData("coding-agent")]
+    public async Task GetAgentAsync_KnownSlug_ReturnsFixture(string slug)
+    {
+        var spec = await _client.GetAgentAsync(slug, revision: null);
+
+        spec.Should().NotBeNull();
+        spec!.Slug.Should().Be(slug);
+        spec.Instructions.Should().NotBeNullOrWhiteSpace();
+        spec.Model.Provider.Should().Be("anthropic");
+    }
+
+    [Fact]
+    public async Task GetAgentAsync_UnknownSlug_ReturnsNull()
+    {
+        var spec = await _client.GetAgentAsync("nonexistent-agent", revision: null);
+
+        spec.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GetAgentAsync_BlankSlug_ReturnsNull(string? slug)
+    {
+        var spec = await _client.GetAgentAsync(slug!, revision: null);
+
+        spec.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetAgentAsync_RevisionPin_PropagatesIntoSpec()
+    {
+        var spec = await _client.GetAgentAsync("triage-agent", revision: 7);
+
+        spec.Should().NotBeNull();
+        spec!.Revision.Should().Be(7,
+            "stub echoes the caller's pin so AP6 can verify revision propagation end-to-end");
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
@@ -1,9 +1,12 @@
 using Andy.Containers.Api.Controllers;
 using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Configurator;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using Xunit;
 
 namespace Andy.Containers.Api.Tests.Controllers;
@@ -18,11 +21,19 @@ public class RunsControllerTests : IDisposable
 {
     private readonly ContainersDbContext _db;
     private readonly RunsController _controller;
+    private readonly Mock<IRunConfigurator> _configurator;
 
     public RunsControllerTests()
     {
         _db = InMemoryDbHelper.CreateContext();
-        _controller = new RunsController(_db);
+        // AP3 wires the configurator into Create. These tests focus on
+        // controller behaviour, not configurator behaviour, so stub it to a
+        // no-op success — the dedicated configurator tests cover its surface.
+        _configurator = new Mock<IRunConfigurator>();
+        _configurator
+            .Setup(c => c.ConfigureAsync(It.IsAny<Run>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RunConfiguratorResult.Ok("/tmp/noop/config.json"));
+        _controller = new RunsController(_db, _configurator.Object, NullLogger<RunsController>.Instance);
     }
 
     public void Dispose()
@@ -66,6 +77,32 @@ public class RunsControllerTests : IDisposable
         persisted.Should().NotBeNull();
         persisted!.Status.Should().Be(RunStatus.Pending);
         persisted.AgentRevision.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Create_InvokesConfiguratorAfterPersisting()
+    {
+        // AP3 wiring: the controller calls the configurator with the
+        // persisted Run (Id assigned, Status Pending). A configurator failure
+        // does NOT roll the row back; the row stays Pending so AP5/AP6 can
+        // retry on the next pass.
+        _configurator
+            .Setup(c => c.ConfigureAsync(It.IsAny<Run>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RunConfiguratorResult.Fail("agent not found"));
+
+        var request = new CreateRunRequest
+        {
+            AgentId = "triage-agent",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+        };
+
+        var result = await _controller.Create(request, CancellationToken.None);
+
+        result.Should().BeOfType<CreatedAtActionResult>();
+        _configurator.Verify(c => c.ConfigureAsync(
+            It.Is<Run>(r => r.Id != Guid.Empty && r.Status == RunStatus.Pending),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/tests/Andy.Containers.Tests/HostEnvironmentExtensionsTests.cs
+++ b/tests/Andy.Containers.Tests/HostEnvironmentExtensionsTests.cs
@@ -1,0 +1,45 @@
+using Andy.Containers.Api.Services;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Andy.Containers.Tests;
+
+public class HostEnvironmentExtensionsTests
+{
+    [Theory]
+    [InlineData("Embedded", true)]
+    [InlineData("Development", false)]
+    [InlineData("Docker", false)]
+    [InlineData("Production", false)]
+    public void IsEmbedded_ReturnsExpected(string envName, bool expected)
+    {
+        Assert.Equal(expected, new FakeEnv(envName).IsEmbedded());
+    }
+
+    [Theory]
+    [InlineData("Development", true)]
+    [InlineData("Docker", true)]
+    [InlineData("Embedded", true)]
+    [InlineData("Production", false)]
+    public void IsLocalOrEmbedded_TrueForNonProduction(string envName, bool expected)
+    {
+        Assert.Equal(expected, new FakeEnv(envName).IsLocalOrEmbedded());
+    }
+
+    [Fact]
+    public void EmbeddedEnvironmentName_MatchesConductorContract()
+    {
+        // Kept in lock-step with ServiceEnvironment.embeddedEnvironmentName
+        // on the Swift side. Drift here = silent Embedded-branch no-op.
+        Assert.Equal("Embedded", HostEnvironmentExtensions.EmbeddedEnvironmentName);
+    }
+
+    private sealed class FakeEnv : IHostEnvironment
+    {
+        public FakeEnv(string name) => EnvironmentName = name;
+        public string EnvironmentName { get; set; }
+        public string ApplicationName { get; set; } = "test";
+        public string ContentRootPath { get; set; } = "/";
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+}


### PR DESCRIPTION
Closes #105.

## Summary

Implements the configurator that turns a Run + resolved AgentSpec into an
AQ1-schema-conforming headless config file consumed by `andy-cli run --headless --config <path>`.

Pipeline lives in `Andy.Containers.Configurator` so AP6's runner (when it spins out into its own process) can reuse the same mapper without dragging the API host along:

- `IAndyAgentsClient` + `StubAndyAgentsClient` — the real andy-agents service is Epic W and not reachable yet, so a narrow interface plus an in-process fixture stub keep AP3 + AP6 unblocked. TODO marker on the stub points at the eventual HTTP swap.
- `IHeadlessConfigBuilder` + `HeadlessConfigBuilder` — maps Run + AgentSpec to `HeadlessRunConfig`. Validates the AQ1 schema closures up-front (provider enum, MCP/CLI transport oneOf, required strings) so AP6 never has to load-and-reject a config it just wrote.
- `HeadlessRunConfig` C# record — mirror of `andy-cli/schemas/headless-config.v1.json`. Defining it on the producer side (rather than referencing andy-cli's type) keeps the dependency direction clean: andy-cli owns the canonical schema, andy-containers owns the producer.
- `HeadlessConfigJson.Options` — `JsonNamingPolicy.SnakeCaseLower` + `WhenWritingNull` so the wire JSON matches the schema without per-property `[JsonPropertyName]`.
- `IHeadlessConfigWriter` + `HeadlessConfigWriter` — atomic tmp + rename. Uses `HostEnvironmentExtensions.IsEmbedded()` (popped from the parked AP2-prep stash) to switch between `/var/run/andy/runs/{id}/config.json` (hosted/Docker) and the OS temp dir (embedded Conductor on macOS — can't mkdir under `/var`).
- `IRunConfigurator` + `RunConfigurator` — facade. Returns structured `RunConfiguratorResult` (path or error) rather than throwing so callers can decide whether to mark the Run as Failed or just log + continue.

## Wiring

`RunsController.Create` invokes the configurator after persisting the Run as Pending. A configurator failure does **not** roll the row back — the row stays Pending and AP5/AP6 retry on the next pass. AP3 deliberately does not spawn `andy-cli` (AP6) or publish anything on NATS (AP5/AP6).

## Stash housekeeping

Popped `stash@{2}` ("AP2 prep: HostEnvironmentExtensions"). Both files (the extensions class and its tests) landed in this PR — the writer's path-selection branch is the natural first user of `IsEmbedded()`. Left the unrelated TerminalController WIP stash alone.

## Test plan

29 new tests across 5 files, all green:
- [x] `HeadlessConfigBuilderTests` (10) — happy path + 9 edge cases (empty instructions, unknown provider, MCP missing endpoint, CLI missing binary, unknown transport, empty env_vars/boundaries collapse to null, empty Run.Id).
- [x] `HeadlessConfigWriterTests` (4) — embedded path, snake_case JSON, atomic overwrite, no leftover .tmp, empty RunId guard.
- [x] `StubAndyAgentsClientTests` (8) — three known fixtures, unknown slug, blank slug, revision pin propagation.
- [x] `RunConfiguratorTests` (4) — happy path + agent-not-found + builder-rejects + writer-IO-error.
- [x] `RunsControllerTests.Create_InvokesConfiguratorAfterPersisting` (1) — proves AP3 wiring; existing 9 tests updated to inject a mock configurator.
- [x] `HostEnvironmentExtensionsTests` (9) from the popped stash.

Suites:
- `Andy.Containers.Api.Tests`: **602 / 602 pass** (was 573 baseline; +29).
- `Andy.Containers.Tests`: **299 / 299 pass** (includes the 9 new HostEnvironment tests).
- `Andy.Containers.Client.Tests`: 4 / 4 pass.
- `Andy.Containers.Integration.Tests`: 3 pre-existing failures in `AppleContainerProviderTests`, all from the absence of the Apple `container` CLI on this dev box — not introduced by AP3.

## Out of scope

- Spawning `andy-cli` (AP6).
- Publishing the run.start command on NATS / dispatching to a container (AP5/AP6).
- Real HTTP client to andy-agents (Epic W).
- Cancellation propagation into a running configurator pass (AP3+).
- JSON-schema validation of the emitted file at write time — the consumer (`HeadlessConfigLoader` in andy-cli) already validates against the embedded schema; double-validation here would just couple the producer to the same schema dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)