### PR TITLE
[CRITICAL] Harden container HostConfig: PidsLimit, no-new-privileges, drop NET_RAW/MKNOD (#121)

### DIFF
--- a/src/Andy.Containers.Infrastructure/Providers/Local/DockerInfrastructureProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Local/DockerInfrastructureProvider.cs
@@ -217,7 +217,19 @@ public class DockerInfrastructureProvider : IInfrastructureProvider
             {
                 PortBindings = portBindings,
                 Memory = (long)(spec.Resources?.MemoryMb ?? 4096) * 1024 * 1024,
-                NanoCPUs = (long)((spec.Resources?.CpuCores ?? 2) * 1e9)
+                NanoCPUs = (long)((spec.Resources?.CpuCores ?? 2) * 1e9),
+                // Cap PID count so a fork bomb inside the container cannot DoS
+                // the host. 4096 leaves plenty of headroom for parallel builds
+                // and language servers.
+                PidsLimit = 4096,
+                // Block setuid-driven privilege escalation; closes the easiest
+                // post-exploitation path for an attacker who lands in the
+                // container.
+                SecurityOpt = new List<string> { "no-new-privileges:true" },
+                // Drop capabilities that are not needed by typical dev workloads
+                // and have known abuse paths: NET_RAW (ARP spoofing / raw
+                // packets), MKNOD (creating device nodes).
+                CapDrop = new List<string> { "NET_RAW", "MKNOD" }
             }
         }, ct);
 

--- a/src/Andy.Containers.Infrastructure/Providers/Shared/SshDockerHelper.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Shared/SshDockerHelper.cs
@@ -65,8 +65,15 @@ public class SshDockerHelper : IDisposable
         var resources = spec.Resources ?? new ResourceSpec();
         var cpuLimit = $"--cpus={resources.CpuCores}";
         var memLimit = $"--memory={resources.MemoryMb}m";
+        // Mirror the local DockerInfrastructureProvider hardening: PID cap to
+        // resist fork bombs, no-new-privileges to block setuid escalation, and
+        // drop NET_RAW + MKNOD which dev workloads do not need.
+        const string hardening =
+            " --pids-limit 4096" +
+            " --security-opt no-new-privileges" +
+            " --cap-drop NET_RAW --cap-drop MKNOD";
 
-        var cmd = $"docker run -d --name {containerName} {cpuLimit} {memLimit}{envArgs}{portArgs} {spec.ImageReference}";
+        var cmd = $"docker run -d --name {containerName} {cpuLimit} {memLimit}{hardening}{envArgs}{portArgs} {spec.ImageReference}";
         if (!string.IsNullOrEmpty(spec.Command))
         {
             cmd += $" {spec.Command}";
@@ -147,7 +154,7 @@ public class SshDockerHelper : IDisposable
                 systemctl enable docker
                 systemctl start docker
                 docker pull {dockerImage}
-                docker run -d --name {containerName} --restart unless-stopped{portArgs} {dockerImage}
+                docker run -d --name {containerName} --restart unless-stopped --pids-limit 4096 --security-opt no-new-privileges --cap-drop NET_RAW --cap-drop MKNOD{portArgs} {dockerImage}
                 """;
     }
 


### PR DESCRIPTION
Closes #121.

## Summary

`DockerInfrastructureProvider` (and the shared `SshDockerHelper` that wraps `docker run` over SSH) created containers with only `Memory` + `NanoCPUs` in `HostConfig` — no PID cap, default Linux capability set retained, and no `no-new-privileges`. Combined with the API mounting `docker.sock`, any container compromise was a free path to host root.

Defense-in-depth at the create call:

- **`PidsLimit = 4096`** — caps PIDs/threads so a fork bomb cannot DoS the host. 4096 leaves headroom for parallel builds and language servers.
- **`SecurityOpt = [\"no-new-privileges:true\"]`** — blocks setuid-driven privilege escalation, the easiest post-exploitation path.
- **`CapDrop = [\"NET_RAW\", \"MKNOD\"]`** — drops two capabilities dev workloads do not need. NET_RAW gates ARP spoofing / raw packet crafting; MKNOD gates creating device nodes.

Same flags are mirrored in the SSH helper's `docker run` invocation (and in the cloud-init bootstrap script it generates).

## Out of scope (intentional, follow-ups)

- `ReadonlyRootfs` — would block `apt install` etc. inside the container.
- Custom seccomp profile — needs a separate profile asset.
- Removing the `NOPASSWD` sudo grant on the container user — would break `sudo apt …` in dev sessions.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test tests/Andy.Containers.Api.Tests` — 574/574 pass
- [x] `dotnet test tests/Andy.Containers.Tests` — 290/290 pass
- [ ] Smoke (Docker): create a container; `docker inspect <id>` shows the new flags; normal dev workflows (apt install, parallel build) still work
- [ ] Smoke: fork bomb inside container halts at 4096 processes, host stays responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)