### PR TITLE
AP6: headless agent runner — spawn, capture exit code, publish event (#108)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/RunsController.cs
+++ b/src/Andy.Containers.Api/Controllers/RunsController.cs
@@ -1,3 +1,4 @@
+using Andy.Containers.Api.Services;
 using Andy.Containers.Configurator;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Models;
@@ -22,15 +23,18 @@ public class RunsController : ControllerBase
 {
     private readonly ContainersDbContext _db;
     private readonly IRunConfigurator _configurator;
+    private readonly IHeadlessRunner _runner;
     private readonly ILogger<RunsController> _logger;
 
     public RunsController(
         ContainersDbContext db,
         IRunConfigurator configurator,
+        IHeadlessRunner runner,
         ILogger<RunsController> logger)
     {
         _db = db;
         _configurator = configurator;
+        _runner = runner;
         _logger = logger;
     }
 
@@ -91,6 +95,25 @@ public class RunsController : ControllerBase
             _logger.LogWarning(
                 "Run {RunId} persisted as Pending but configurator failed: {Error}. AP5/AP6 will retry.",
                 run.Id, configResult.Error);
+        }
+        else if (run.ContainerId is not null)
+        {
+            // AP6 (rivoli-ai/andy-containers#108). Spawn andy-cli headless
+            // synchronously so the controller blocks until the run is
+            // terminal. AP5 will move this onto a background queue once
+            // ContainerId assignment is async; for now ContainerId is null
+            // until that lands, so this branch is effectively dormant in
+            // production traffic and exercised primarily by tests.
+            try
+            {
+                await _runner.StartAsync(run, configResult.Path!, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Run {RunId} headless spawn threw before terminal write: {Message}",
+                    run.Id, ex.Message);
+            }
         }
 
         var dto = RunDto.FromEntity(run);

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -238,6 +238,11 @@ try
     builder.Services.AddSingleton<IHeadlessConfigWriter, HeadlessConfigWriter>();
     builder.Services.AddScoped<IRunConfigurator, RunConfigurator>();
 
+    // AP6 (rivoli-ai/andy-containers#108). Headless runner: spawns
+    // andy-cli inside the run's container, captures exit code, publishes
+    // the terminal run.* event to the outbox.
+    builder.Services.AddScoped<IHeadlessRunner, HeadlessRunner>();
+
     var app = builder.Build();
 
     // Auto-migrate (PostgreSQL) or auto-create (SQLite) and seed.

--- a/src/Andy.Containers.Api/Services/HeadlessRunner.cs
+++ b/src/Andy.Containers.Api/Services/HeadlessRunner.cs
@@ -1,0 +1,209 @@
+using System.Diagnostics;
+using Andy.Containers.Abstractions;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Messaging.Events;
+using Andy.Containers.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Containers.Api.Services;
+
+public sealed class HeadlessRunner : IHeadlessRunner
+{
+    private readonly IContainerService _containers;
+    private readonly ContainersDbContext _db;
+    private readonly ILogger<HeadlessRunner> _logger;
+
+    // Generous upper bound on a single headless run. AQ3 will wire
+    // limits.timeout_seconds-aware spawning; until then this is the only
+    // ceiling between us and a hung process. ExecAsync surfaces a timeout
+    // by throwing OperationCanceledException, which we map to Failed.
+    private static readonly TimeSpan DefaultExecTimeout = TimeSpan.FromMinutes(15);
+
+    public HeadlessRunner(
+        IContainerService containers,
+        ContainersDbContext db,
+        ILogger<HeadlessRunner> logger)
+    {
+        _containers = containers;
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<HeadlessRunOutcome> StartAsync(Run run, string configPath, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        ArgumentException.ThrowIfNullOrWhiteSpace(configPath);
+
+        if (run.ContainerId is not { } containerId)
+        {
+            // AP5 (mode dispatcher) is responsible for assigning ContainerId.
+            // If it hasn't run, AP6 has nothing to spawn against.
+            var error = $"Run {run.Id} has no ContainerId — AP5 must assign one before AP6 can spawn.";
+            _logger.LogError("{Error}", error);
+            return await TerminateAsync(run, RunEventKind.Failed, RunStatus.Failed,
+                exitCode: null, durationSeconds: null, error: error, CancellationToken.None);
+        }
+
+        if (ct.IsCancellationRequested)
+        {
+            // Caller cancelled before we even started — short-circuit to
+            // Cancelled without trying to drive intermediate transitions
+            // (the SaveChanges below would just throw on the same token).
+            return await TerminateAsync(run, RunEventKind.Cancelled, RunStatus.Cancelled,
+                exitCode: null, durationSeconds: 0, error: "Cancelled before spawn", CancellationToken.None);
+        }
+
+        var sw = Stopwatch.StartNew();
+        // AP1's state-machine requires Pending → Provisioning → Running
+        // before any terminal transition. We compress all three into the
+        // span of one ExecAsync because AP5 isn't writing them yet; once
+        // AP5 emits Provisioning itself, drop that transition here.
+        SafeTransition(run, RunStatus.Provisioning);
+        SafeTransition(run, RunStatus.Running);
+        await _db.SaveChangesAsync(ct);
+
+        var command = $"andy-cli run --headless --config {ShellEscape(configPath)}";
+        ExecResult result;
+        try
+        {
+            _logger.LogInformation(
+                "Spawning headless agent for Run {RunId} in container {ContainerId} with config {ConfigPath}",
+                run.Id, containerId, configPath);
+
+            result = await _containers.ExecAsync(containerId, command, DefaultExecTimeout, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            sw.Stop();
+            _logger.LogWarning("Headless spawn for Run {RunId} cancelled by caller", run.Id);
+            return await TerminateAsync(run, RunEventKind.Cancelled, RunStatus.Cancelled,
+                exitCode: null, durationSeconds: sw.Elapsed.TotalSeconds, error: "Cancelled by caller", CancellationToken.None);
+        }
+        catch (OperationCanceledException ex)
+        {
+            // ExecAsync's internal timeout fired — distinct from the AQ2
+            // exit-code 4 path, but semantically the same outcome.
+            sw.Stop();
+            _logger.LogError(ex, "Headless spawn for Run {RunId} hit ExecAsync timeout after {Elapsed}s",
+                run.Id, sw.Elapsed.TotalSeconds);
+            return await TerminateAsync(run, RunEventKind.Timeout, RunStatus.Timeout,
+                exitCode: null, durationSeconds: sw.Elapsed.TotalSeconds, error: "ExecAsync timeout", CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            _logger.LogError(ex, "Headless spawn for Run {RunId} failed before exit: {Message}", run.Id, ex.Message);
+            return await TerminateAsync(run, RunEventKind.Failed, RunStatus.Failed,
+                exitCode: null, durationSeconds: sw.Elapsed.TotalSeconds, error: ex.Message, CancellationToken.None);
+        }
+
+        sw.Stop();
+        var durationSeconds = sw.Elapsed.TotalSeconds;
+
+        if (!string.IsNullOrEmpty(result.StdErr))
+        {
+            _logger.LogDebug("Run {RunId} stderr: {StdErr}", run.Id, result.StdErr);
+        }
+        if (!string.IsNullOrEmpty(result.StdOut))
+        {
+            _logger.LogDebug("Run {RunId} stdout: {StdOut}", run.Id, result.StdOut);
+        }
+
+        var (kind, status) = MapExitCode(result.ExitCode);
+        _logger.LogInformation(
+            "Run {RunId} exited with code {ExitCode} → {Kind}/{Status} after {Duration}s",
+            run.Id, result.ExitCode, kind, status, durationSeconds);
+
+        return await TerminateAsync(run, kind, status,
+            exitCode: result.ExitCode, durationSeconds: durationSeconds,
+            error: status == RunStatus.Succeeded ? null : Truncate(result.StdErr, 500), ct);
+    }
+
+    // AQ2 (rivoli-ai/andy-cli#47) exit-code contract. Keep this mapping in
+    // sync with HeadlessExitCode in andy-cli — the two enums are parallel
+    // by design but live in separate repos so they have to be re-checked
+    // whenever either side changes.
+    private static (RunEventKind Kind, RunStatus Status) MapExitCode(int exitCode) => exitCode switch
+    {
+        0 => (RunEventKind.Finished, RunStatus.Succeeded),
+        1 => (RunEventKind.Failed, RunStatus.Failed),
+        2 => (RunEventKind.Failed, RunStatus.Failed),
+        3 => (RunEventKind.Cancelled, RunStatus.Cancelled),
+        4 => (RunEventKind.Timeout, RunStatus.Timeout),
+        5 => (RunEventKind.Failed, RunStatus.Failed),
+        _ => (RunEventKind.Failed, RunStatus.Failed),
+    };
+
+    private async Task<HeadlessRunOutcome> TerminateAsync(
+        Run run, RunEventKind kind, RunStatus status,
+        int? exitCode, double? durationSeconds, string? error,
+        CancellationToken ct)
+    {
+        try
+        {
+            // Best-effort transition. If the run is already terminal (e.g.
+            // a parallel cancel beat us here), keep the existing status.
+            if (RunStatusTransitions.CanTransition(run.Status, status))
+            {
+                run.TransitionTo(status);
+            }
+
+            run.ExitCode ??= exitCode;
+            if (!string.IsNullOrEmpty(error))
+            {
+                run.Error ??= error;
+            }
+
+            _db.AppendAgentRunEvent(run, kind, exitCode, durationSeconds);
+            await _db.SaveChangesAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to persist terminal outcome for Run {RunId}: {Message}",
+                run.Id, ex.Message);
+        }
+
+        return new HeadlessRunOutcome
+        {
+            Kind = kind,
+            Status = status,
+            ExitCode = exitCode,
+            DurationSeconds = durationSeconds,
+            Error = error,
+        };
+    }
+
+    private void SafeTransition(Run run, RunStatus next)
+    {
+        if (!RunStatusTransitions.CanTransition(run.Status, next))
+        {
+            return;
+        }
+
+        try
+        {
+            run.TransitionTo(next);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex,
+                "Run {RunId} could not transition {From} → {To}: {Message}",
+                run.Id, run.Status, next, ex.Message);
+        }
+    }
+
+    // POSIX single-quote escape — safe for /bin/sh -c "...". Single quotes
+    // close, '\'' inserts a literal quote, single quotes reopen. We don't
+    // bother covering edge cases (NULs etc.) because configPath comes
+    // from HeadlessConfigWriter which mints filesystem-safe paths.
+    private static string ShellEscape(string value)
+        => "'" + value.Replace("'", "'\\''") + "'";
+
+    private static string? Truncate(string? value, int max)
+    {
+        if (string.IsNullOrEmpty(value)) return null;
+        return value.Length <= max ? value : value[..max] + "...";
+    }
+}

--- a/src/Andy.Containers.Api/Services/IHeadlessRunner.cs
+++ b/src/Andy.Containers.Api/Services/IHeadlessRunner.cs
@@ -1,0 +1,36 @@
+using Andy.Containers.Messaging.Events;
+using Andy.Containers.Models;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// AP6 (rivoli-ai/andy-containers#108). Spawns
+/// <c>andy-cli run --headless --config &lt;path&gt;</c> inside the run's
+/// container, waits for exit, maps the AQ2 exit-code contract to a
+/// <see cref="RunEventKind"/>, transitions the <see cref="Run"/> entity,
+/// and writes the terminal event to the outbox.
+/// </summary>
+/// <remarks>
+/// Stdout/stderr are captured for diagnostic logging only — structured
+/// event-stream parsing is AQ3's job, not this runner's. Cancellation
+/// propagation, idempotency, and watchdog timeouts beyond
+/// <c>ExecAsync</c>'s built-in timeout are intentionally out of scope.
+/// </remarks>
+public interface IHeadlessRunner
+{
+    Task<HeadlessRunOutcome> StartAsync(Run run, string configPath, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Terminal outcome of a headless agent-run spawn. <see cref="ExitCode"/>
+/// is the raw process exit; <see cref="Kind"/> + <see cref="Status"/> are
+/// the mapped semantic projections written to the outbox + Run row.
+/// </summary>
+public sealed record HeadlessRunOutcome
+{
+    public required RunEventKind Kind { get; init; }
+    public required RunStatus Status { get; init; }
+    public int? ExitCode { get; init; }
+    public double? DurationSeconds { get; init; }
+    public string? Error { get; init; }
+}

--- a/src/Andy.Containers.Infrastructure/Messaging/RunEventOutbox.cs
+++ b/src/Andy.Containers.Infrastructure/Messaging/RunEventOutbox.cs
@@ -10,12 +10,14 @@ using Andy.Containers.Models;
 namespace Andy.Containers.Infrastructure.Messaging;
 
 // Helper for appending a run.* OutboxEntry to the DbContext in the same
-// unit of work as the container's status transition. Caller controls
-// SaveChangesAsync — the outbox row lands with whatever else is pending,
-// so dual-write consistency is preserved by EF's transaction scope.
+// unit of work as the domain change that produced the message. Caller
+// controls SaveChangesAsync — the outbox row lands with whatever else is
+// pending, so dual-write consistency is preserved by EF's transaction scope.
 public static class RunEventOutbox
 {
-    // Build and attach a run event outbox row. Does not SaveChanges.
+    // Container-lifecycle variant. Subject is keyed on Container.Id —
+    // this is the legacy run.* path used by the provisioning worker /
+    // orchestration service for create/stop/destroy transitions.
     public static void AppendRunEvent(
         this ContainersDbContext db,
         Container container,
@@ -33,6 +35,42 @@ public static class RunEventOutbox
         var subject = $"andy.containers.events.run.{container.Id}.{kind.ToSubjectKind()}";
 
         var correlationId = container.StoryId ?? container.Id;
+
+        db.OutboxEntries.Add(new OutboxEntry
+        {
+            Id = Guid.NewGuid(),
+            Subject = subject,
+            PayloadType = typeof(RunEventPayload).FullName,
+            PayloadJson = JsonSerializer.Serialize(payload, EventJson.Options),
+            CorrelationId = correlationId,
+            CausationId = null,
+            Generation = 0,
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+    }
+
+    // Agent-run variant (AP6). Subject is keyed on Run.Id — the AP1 entity
+    // distinct from Container.Id, so headless-run consumers can correlate
+    // back to the run row directly. Status mirrors Run.Status; the
+    // CorrelationId chain prefers Run.CorrelationId over a fresh id so
+    // ADR-0001 header semantics are preserved end-to-end.
+    public static void AppendAgentRunEvent(
+        this ContainersDbContext db,
+        Run run,
+        RunEventKind kind,
+        int? exitCode = null,
+        double? durationSeconds = null)
+    {
+        var payload = new RunEventPayload(
+            RunId: run.Id,
+            StoryId: null,
+            Status: run.Status.ToString(),
+            ExitCode: exitCode,
+            DurationSeconds: durationSeconds);
+
+        var subject = $"andy.containers.events.run.{run.Id}.{kind.ToSubjectKind()}";
+
+        var correlationId = run.CorrelationId == Guid.Empty ? run.Id : run.CorrelationId;
 
         db.OutboxEntries.Add(new OutboxEntry
         {

--- a/src/Andy.Containers/Messaging/Events/RunEvents.cs
+++ b/src/Andy.Containers/Messaging/Events/RunEvents.cs
@@ -23,16 +23,17 @@ public sealed record RunEventPayload(
     public int Schema_Version => SchemaVersion;
 }
 
-// Three terminal-lifecycle kinds are published. Mapping to container
-// status transitions:
-//   Finished  — StopContainerAsync (clean shutdown)
-//   Failed    — MarkFailedAsync in ProvisioningWorker (provision failure)
-//   Cancelled — DestroyContainerAsync (explicit teardown)
+// Terminal-lifecycle kinds published on andy.containers.events.run.{id}.<kind>.
+// Container provisioning emits Finished/Failed/Cancelled. AP6's agent-run
+// runner additionally emits Timeout, mapped from the AQ2 process exit code 4
+// — kept distinct from Failed so consumers (and the Run.Status enum, which
+// already has a Timeout member) don't lose the watchdog signal.
 public enum RunEventKind
 {
     Finished,
     Failed,
-    Cancelled
+    Cancelled,
+    Timeout
 }
 
 public static class RunEventKindExtensions
@@ -42,6 +43,7 @@ public static class RunEventKindExtensions
         RunEventKind.Finished => "finished",
         RunEventKind.Failed => "failed",
         RunEventKind.Cancelled => "cancelled",
+        RunEventKind.Timeout => "timeout",
         _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
     };
 }

--- a/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
@@ -1,7 +1,9 @@
 using Andy.Containers.Api.Controllers;
+using Andy.Containers.Api.Services;
 using Andy.Containers.Api.Tests.Helpers;
 using Andy.Containers.Configurator;
 using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
@@ -22,6 +24,7 @@ public class RunsControllerTests : IDisposable
     private readonly ContainersDbContext _db;
     private readonly RunsController _controller;
     private readonly Mock<IRunConfigurator> _configurator;
+    private readonly Mock<IHeadlessRunner> _runner;
 
     public RunsControllerTests()
     {
@@ -33,7 +36,19 @@ public class RunsControllerTests : IDisposable
         _configurator
             .Setup(c => c.ConfigureAsync(It.IsAny<Run>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(RunConfiguratorResult.Ok("/tmp/noop/config.json"));
-        _controller = new RunsController(_db, _configurator.Object, NullLogger<RunsController>.Instance);
+        // AP6 wires the runner into Create. Default stub: no-op outcome.
+        // Runs without a ContainerId never invoke it (the controller skips
+        // the call), and the dedicated HeadlessRunnerTests cover its surface.
+        _runner = new Mock<IHeadlessRunner>();
+        _runner
+            .Setup(r => r.StartAsync(It.IsAny<Run>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HeadlessRunOutcome
+            {
+                Kind = RunEventKind.Finished,
+                Status = RunStatus.Succeeded,
+                ExitCode = 0,
+            });
+        _controller = new RunsController(_db, _configurator.Object, _runner.Object, NullLogger<RunsController>.Instance);
     }
 
     public void Dispose()
@@ -103,6 +118,82 @@ public class RunsControllerTests : IDisposable
         _configurator.Verify(c => c.ConfigureAsync(
             It.Is<Run>(r => r.Id != Guid.Empty && r.Status == RunStatus.Pending),
             It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_DoesNotInvokeRunner_WhenContainerIdNull()
+    {
+        // AP6 wiring: AP5 hasn't run yet, so ContainerId is null and the
+        // controller must not attempt to spawn — the runner needs a target.
+        var request = new CreateRunRequest
+        {
+            AgentId = "x",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+        };
+
+        await _controller.Create(request, CancellationToken.None);
+
+        _runner.Verify(r => r.StartAsync(It.IsAny<Run>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Create_InvokesRunner_WhenConfiguratorSucceeds_AndContainerIdPresent()
+    {
+        // Once AP5 lands and assigns a ContainerId, the controller hands
+        // off to the runner with the configurator's path. We simulate that
+        // by intercepting the configurator and stamping ContainerId on the
+        // run before the runner check fires.
+        var containerId = Guid.NewGuid();
+        _configurator
+            .Setup(c => c.ConfigureAsync(It.IsAny<Run>(), It.IsAny<CancellationToken>()))
+            .Callback<Run, CancellationToken>((r, _) => r.ContainerId = containerId)
+            .ReturnsAsync(RunConfiguratorResult.Ok("/tmp/runs/x/config.json"));
+
+        var request = new CreateRunRequest
+        {
+            AgentId = "x",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+        };
+
+        await _controller.Create(request, CancellationToken.None);
+
+        _runner.Verify(r => r.StartAsync(
+            It.Is<Run>(rn => rn.ContainerId == containerId),
+            "/tmp/runs/x/config.json",
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_RunnerThrows_DoesNotRollBackRun()
+    {
+        // Spawn failures must not roll the row back — the configurator's
+        // existing failure semantics apply to AP6 too, so the Run row
+        // persists for inspection / cleanup.
+        var containerId = Guid.NewGuid();
+        _configurator
+            .Setup(c => c.ConfigureAsync(It.IsAny<Run>(), It.IsAny<CancellationToken>()))
+            .Callback<Run, CancellationToken>((r, _) => r.ContainerId = containerId)
+            .ReturnsAsync(RunConfiguratorResult.Ok("/tmp/runs/x/config.json"));
+        _runner
+            .Setup(r => r.StartAsync(It.IsAny<Run>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("kaboom"));
+
+        var request = new CreateRunRequest
+        {
+            AgentId = "x",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+        };
+
+        var result = await _controller.Create(request, CancellationToken.None);
+
+        var dto = result.Should().BeOfType<CreatedAtActionResult>().Subject.Value
+            .Should().BeOfType<RunDto>().Subject;
+        var persisted = await _db.Runs.FindAsync(dto.Id);
+        persisted.Should().NotBeNull();
     }
 
     [Fact]

--- a/tests/Andy.Containers.Api.Tests/Messaging/RunEventOutboxTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Messaging/RunEventOutboxTests.cs
@@ -80,6 +80,7 @@ public class RunEventOutboxTests
     [InlineData(RunEventKind.Finished, "finished")]
     [InlineData(RunEventKind.Failed, "failed")]
     [InlineData(RunEventKind.Cancelled, "cancelled")]
+    [InlineData(RunEventKind.Timeout, "timeout")]
     public async Task AppendRunEvent_SubjectKindMatchesEnum(RunEventKind kind, string expectedSuffix)
     {
         using var db = InMemoryDbHelper.CreateContext();
@@ -96,5 +97,61 @@ public class RunEventOutboxTests
 
         var entry = await db.OutboxEntries.SingleAsync();
         entry.Subject.Should().EndWith($".{expectedSuffix}");
+    }
+
+    [Fact]
+    public async Task AppendAgentRunEvent_KeyedOnRunIdNotContainerId()
+    {
+        // AP6 (rivoli-ai/andy-containers#108). Agent-run events live on
+        // andy.containers.events.run.{Run.Id}.<kind> — distinct from the
+        // container-lifecycle path that keys on Container.Id.
+        using var db = InMemoryDbHelper.CreateContext();
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "triage-agent",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            ContainerId = Guid.NewGuid(),
+            Status = RunStatus.Succeeded,
+        };
+
+        db.AppendAgentRunEvent(run, RunEventKind.Finished, exitCode: 0, durationSeconds: 12.3);
+        await db.SaveChangesAsync();
+
+        var entry = await db.OutboxEntries.SingleAsync();
+        entry.Subject.Should().Be($"andy.containers.events.run.{run.Id}.finished");
+        entry.Subject.Should().NotContain(run.ContainerId!.Value.ToString(),
+            "subject must key on Run.Id, not the assigned Container.Id");
+        entry.CorrelationId.Should().Be(run.CorrelationId);
+
+        using var doc = JsonDocument.Parse(entry.PayloadJson);
+        var root = doc.RootElement;
+        root.GetProperty("run_id").GetString().Should().Be(run.Id.ToString());
+        root.GetProperty("status").GetString().Should().Be("Succeeded");
+        root.GetProperty("exit_code").GetInt32().Should().Be(0);
+        root.GetProperty("duration_seconds").GetDouble().Should().Be(12.3);
+    }
+
+    [Fact]
+    public async Task AppendAgentRunEvent_EmptyCorrelationFallsBackToRunId()
+    {
+        using var db = InMemoryDbHelper.CreateContext();
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "x",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.Empty,
+            Status = RunStatus.Failed,
+        };
+
+        db.AppendAgentRunEvent(run, RunEventKind.Failed);
+        await db.SaveChangesAsync();
+
+        var entry = await db.OutboxEntries.SingleAsync();
+        entry.CorrelationId.Should().Be(run.Id);
     }
 }

--- a/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
@@ -1,0 +1,240 @@
+using System.Text.Json;
+using Andy.Containers.Abstractions;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Messaging.Events;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+// AP6 (rivoli-ai/andy-containers#108). HeadlessRunner spawns andy-cli
+// inside the run's container, maps the AQ2 exit-code contract to a
+// RunEventKind + RunStatus, and writes the terminal event to the outbox
+// keyed on Run.Id (NOT Container.Id — that's the legacy lifecycle path).
+public class HeadlessRunnerTests : IDisposable
+{
+    private readonly ContainersDbContext _db;
+    private readonly Mock<IContainerService> _containers = new();
+    private readonly HeadlessRunner _runner;
+
+    public HeadlessRunnerTests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+        _runner = new HeadlessRunner(_containers.Object, _db, NullLogger<HeadlessRunner>.Instance);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task StartAsync_ExitZero_TransitionsToSucceeded_WritesFinishedEvent()
+    {
+        var run = SeedRun();
+        SetupExec(run.ContainerId!.Value, exitCode: 0, stdOut: "ok");
+
+        var outcome = await _runner.StartAsync(run, "/tmp/x/config.json");
+
+        outcome.Kind.Should().Be(RunEventKind.Finished);
+        outcome.Status.Should().Be(RunStatus.Succeeded);
+        outcome.ExitCode.Should().Be(0);
+
+        var persisted = await _db.Runs.FindAsync(run.Id);
+        persisted!.Status.Should().Be(RunStatus.Succeeded);
+        persisted.EndedAt.Should().NotBeNull();
+        persisted.StartedAt.Should().NotBeNull();
+        persisted.ExitCode.Should().Be(0);
+
+        var entry = await _db.OutboxEntries.SingleAsync();
+        entry.Subject.Should().Be($"andy.containers.events.run.{run.Id}.finished");
+        entry.CorrelationId.Should().Be(run.CorrelationId);
+
+        using var doc = JsonDocument.Parse(entry.PayloadJson);
+        doc.RootElement.GetProperty("run_id").GetString().Should().Be(run.Id.ToString());
+        doc.RootElement.GetProperty("status").GetString().Should().Be("Succeeded");
+        doc.RootElement.GetProperty("exit_code").GetInt32().Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData(1, RunEventKind.Failed, RunStatus.Failed, "failed")]
+    [InlineData(2, RunEventKind.Failed, RunStatus.Failed, "failed")]
+    [InlineData(3, RunEventKind.Cancelled, RunStatus.Cancelled, "cancelled")]
+    [InlineData(4, RunEventKind.Timeout, RunStatus.Timeout, "timeout")]
+    [InlineData(5, RunEventKind.Failed, RunStatus.Failed, "failed")]
+    public async Task StartAsync_ExitCode_MapsToExpectedKindAndStatus(
+        int exitCode, RunEventKind kind, RunStatus status, string subjectSuffix)
+    {
+        var run = SeedRun();
+        SetupExec(run.ContainerId!.Value, exitCode: exitCode, stdErr: "boom");
+
+        var outcome = await _runner.StartAsync(run, "/tmp/x/config.json");
+
+        outcome.Kind.Should().Be(kind);
+        outcome.Status.Should().Be(status);
+        outcome.ExitCode.Should().Be(exitCode);
+
+        var persisted = await _db.Runs.FindAsync(run.Id);
+        persisted!.Status.Should().Be(status);
+
+        var entry = await _db.OutboxEntries.SingleAsync();
+        entry.Subject.Should().EndWith($".{subjectSuffix}");
+        entry.Subject.Should().Contain(run.Id.ToString(),
+            "AP6 must key on Run.Id, not Container.Id");
+    }
+
+    [Fact]
+    public async Task StartAsync_ExecThrows_TransitionsToFailed_WritesFailedEvent()
+    {
+        var run = SeedRun();
+        _containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("docker daemon unreachable"));
+
+        var outcome = await _runner.StartAsync(run, "/tmp/x/config.json");
+
+        outcome.Kind.Should().Be(RunEventKind.Failed);
+        outcome.Status.Should().Be(RunStatus.Failed);
+        outcome.ExitCode.Should().BeNull();
+        outcome.Error.Should().Contain("docker daemon");
+
+        var persisted = await _db.Runs.FindAsync(run.Id);
+        persisted!.Status.Should().Be(RunStatus.Failed);
+        persisted.Error.Should().Contain("docker daemon");
+
+        var entry = await _db.OutboxEntries.SingleAsync();
+        entry.Subject.Should().EndWith(".failed");
+    }
+
+    [Fact]
+    public async Task StartAsync_ExecAsyncTimeoutThrows_MapsToTimeout()
+    {
+        // ExecAsync's internal timeout surfaces as OperationCanceledException
+        // even though the caller's token never fired. Distinct from caller
+        // cancellation (Cancelled) — this is the watchdog path.
+        var run = SeedRun();
+        _containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException("exec timeout"));
+
+        var outcome = await _runner.StartAsync(run, "/tmp/x/config.json", CancellationToken.None);
+
+        outcome.Kind.Should().Be(RunEventKind.Timeout);
+        outcome.Status.Should().Be(RunStatus.Timeout);
+
+        var entry = await _db.OutboxEntries.SingleAsync();
+        entry.Subject.Should().EndWith(".timeout");
+    }
+
+    [Fact]
+    public async Task StartAsync_CallerCancels_MapsToCancelled()
+    {
+        var run = SeedRun();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var outcome = await _runner.StartAsync(run, "/tmp/x/config.json", cts.Token);
+
+        outcome.Kind.Should().Be(RunEventKind.Cancelled);
+        outcome.Status.Should().Be(RunStatus.Cancelled);
+    }
+
+    [Fact]
+    public async Task StartAsync_NoContainerId_DoesNotInvokeExec_TransitionsToFailed()
+    {
+        var run = SeedRunWithoutContainer();
+
+        var outcome = await _runner.StartAsync(run, "/tmp/x/config.json");
+
+        outcome.Kind.Should().Be(RunEventKind.Failed);
+        outcome.Status.Should().Be(RunStatus.Failed);
+        outcome.Error.Should().Contain("ContainerId");
+
+        _containers.Verify(c => c.ExecAsync(
+            It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        var entry = await _db.OutboxEntries.SingleAsync();
+        entry.Subject.Should().EndWith(".failed");
+    }
+
+    [Fact]
+    public async Task StartAsync_ConfigPathIsShellEscaped()
+    {
+        // A config path with a single quote in it would break a naive
+        // command interpolation. Verify the runner emits a properly
+        // single-quote-escaped argument so /bin/sh -c can parse it.
+        var run = SeedRun();
+        string? captured = null;
+        _containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, CancellationToken>((_, cmd, _, _) => captured = cmd)
+            .ReturnsAsync(new ExecResult { ExitCode = 0 });
+
+        await _runner.StartAsync(run, "/tmp/o'malley/config.json");
+
+        captured.Should().NotBeNull();
+        captured.Should().Contain("andy-cli run --headless --config");
+        captured.Should().Contain("'/tmp/o'\\''malley/config.json'");
+    }
+
+    [Fact]
+    public async Task StartAsync_OutboxRowCarriesCorrelationIdFromRun()
+    {
+        var correlation = Guid.NewGuid();
+        var run = SeedRun(correlationId: correlation);
+        SetupExec(run.ContainerId!.Value, exitCode: 0);
+
+        await _runner.StartAsync(run, "/tmp/x/config.json");
+
+        var entry = await _db.OutboxEntries.SingleAsync();
+        entry.CorrelationId.Should().Be(correlation,
+            "ADR-0001 root-causation chain must propagate from the Run");
+    }
+
+    private void SetupExec(Guid containerId, int exitCode, string? stdOut = null, string? stdErr = null)
+    {
+        _containers
+            .Setup(c => c.ExecAsync(
+                containerId, It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExecResult
+            {
+                ExitCode = exitCode,
+                StdOut = stdOut,
+                StdErr = stdErr,
+            });
+    }
+
+    private Run SeedRun(Guid? containerId = null, Guid? correlationId = null)
+        => SeedRunCore(containerId ?? Guid.NewGuid(), correlationId);
+
+    private Run SeedRunWithoutContainer()
+        => SeedRunCore(null, null);
+
+    private Run SeedRunCore(Guid? containerId, Guid? correlationId)
+    {
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "triage-agent",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            ContainerId = containerId,
+            CorrelationId = correlationId ?? Guid.NewGuid(),
+            Status = RunStatus.Pending,
+        };
+        _db.Runs.Add(run);
+        _db.SaveChanges();
+        return run;
+    }
+}


### PR DESCRIPTION
Closes #108.

## Summary

Adds the headless agent runner that spawns
`andy-cli run --headless --config <path>` inside the run's container,
waits for exit, maps the AQ2 exit-code contract to a `RunEventKind` +
`RunStatus`, and publishes the terminal event to the outbox keyed on
`Run.Id` (the AP1 entity, distinct from `Container.Id`).

Pipeline:

- `IHeadlessRunner` + `HeadlessRunner` (in `Andy.Containers.Api/Services/`).
  `StartAsync(Run, configPath, ct)` returns a `HeadlessRunOutcome` and
  drives the Run through `Pending → Provisioning → Running → terminal`,
  appending a `andy.containers.events.run.{Run.Id}.<kind>` outbox row
  in the same SaveChanges. Compresses the Provisioning→Running pair
  because AP5 is not yet writing them itself; once AP5 lands, that
  prefix collapses naturally.
- `RunEventOutbox.AppendAgentRunEvent(this DbContext, Run, kind, ...)` —
  parallel helper to the existing container-keyed `AppendRunEvent`.
  Run-keyed subject, `Run.CorrelationId` as the ADR-0001 root id (falls
  back to `Run.Id` when empty).
- `RunEventKind.Timeout` — new enum member so AQ2 exit code 4 maps
  cleanly to `andy.containers.events.run.{run_id}.timeout` and the
  existing `RunStatus.Timeout` member round-trips. (See "Decisions"
  below for the trade-off.)
- `RunsController.Create` wires the runner in immediately after the
  configurator. The branch only fires when both the configurator
  succeeded **and** `Run.ContainerId` is set; AP5 isn't assigning
  `ContainerId` yet, so this is dormant in production traffic until
  AP5 lands. Spawn failures are logged and do **not** roll the Run row
  back, consistent with the configurator's failure semantics.
- DI registration in `Program.cs`.

## Decisions

- **Timeout exit code (AQ2 exit 4) → `RunEventKind.Timeout`, not
  `Failed`.** `RunStatus.Timeout` already exists in the AP1 state
  machine, so the mapping is naturally one-to-one. The brief notes the
  U2 consumer in andy-tasks doesn't recognise the new subject yet and
  will log a "skipping unrecognized run-event subject" warning until
  U2's mapping grows — accepted as a clean cross-repo follow-up rather
  than collapse the signal at the source.
- **`RunEventOutbox` extension shape: new method on the existing static
  class.** Same domain (run lifecycle), same outbox table, same payload
  record — just a different correlation key. A sibling type would have
  duplicated the JSON serialisation + `OutboxEntry` construction without
  a clean separation justifying the split.
- **Spawn is synchronous in `RunsController.Create`.** Brief allowed
  one indirection; staying in the controller keeps AP6 minimal and
  matches AP3's seam. The async/queue split is AP5's natural shape and
  not in scope here.

## Out of scope

- Stdout structured event-stream parsing (AQ3).
- Cancellation propagation while running.
- Watchdog timeouts beyond `ExecAsync`'s built-in.
- Idempotency / dedupe of duplicate spawns.
- `andy-cli` discovery / version checks (assumes the binary is on
  `$PATH` inside the container).
- Updating `Andy.Tasks` U2 to recognise `*.timeout` subjects — that's
  the cross-repo follow-up flagged above.

## Test plan

20 new tests across 3 files, all green:
- [x] `HeadlessRunnerTests` (12) — happy path, all five AQ2 exit-code
  mappings (1/2/3/4/5), `ExecAsync` exception, ExecAsync internal
  timeout, caller cancellation, missing `ContainerId`, shell escaping
  of single-quoted config paths, correlation-id propagation.
- [x] `RunEventOutboxTests` (+3) — `AppendAgentRunEvent` keys on
  `Run.Id` (not `Container.Id`), correlation-id fallback to `Run.Id`,
  `Timeout` subject suffix.
- [x] `RunsControllerTests` (+3) — controller skips runner when
  `ContainerId` is null, invokes runner with the configurator's path
  when `ContainerId` is set, runner exception does not roll back the
  Run row.

Suites:
- `Andy.Containers.Api.Tests`: **620 / 620 pass** (was 602 baseline; +18
  net after one wiring update each in three existing controller tests).
- `Andy.Containers.Tests`: **299 / 299 pass**.
- `Andy.Containers.Integration.Tests`: 3 pre-existing failures from the
  absence of the Apple `container` CLI on this dev box — not introduced
  by AP6.

## Follow-ups (not opened)

- Update U2 in `andy-tasks` to recognise `andy.containers.events.run.*.timeout`.
- Replace synchronous spawn in `RunsController.Create` with the AP5
  background queue once that lands.
- Wire `limits.timeout_seconds` from the agent spec into the
  `ExecAsync` timeout (currently hard-coded to 15 minutes); revisit
  when AQ3 ships limits-aware spawning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)