### PR TITLE
[HIGH] Remove default Postgres password from repo; require .env override (#129)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy to .env and fill in real values. .env is gitignored; .env.example is committed.
+# `docker compose up` reads variables from .env automatically.
+
+# Postgres password used by both the postgres service and the API service's
+# ConnectionStrings__DefaultConnection. Required — no default ships in the
+# repo so a real password is never committed.
+POSTGRES_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -49,8 +49,12 @@ Development container management platform for the Andy ecosystem.
 ```bash
 git clone https://github.com/rivoli-ai/andy-containers.git
 cd andy-containers
+cp .env.example .env  # then edit to set POSTGRES_PASSWORD
 docker compose up --build
 ```
+
+`docker compose` will refuse to start until `POSTGRES_PASSWORD` is set in
+`.env` (or exported in the shell). No default password ships in the repo.
 
 This starts all services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: andy-containers-db
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env (see .env.example)}
       POSTGRES_DB: andy_containers
     ports:
       - "7434:5432"
@@ -44,7 +44,7 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=https://+:8443;http://+:8080
-      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=andy_containers;Username=postgres;Password=postgres
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=andy_containers;Username=postgres;Password=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env (see .env.example)}
       - AndyAuth__Authority=https://host.docker.internal:5001
       - AndyAuth__Audience=urn:andy-containers-api
       - AndyAuth__RequireHttpsMetadata=false

--- a/src/Andy.Containers.Api/appsettings.json
+++ b/src/Andy.Containers.Api/appsettings.json
@@ -1,6 +1,7 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5434;Database=andy_containers;Username=postgres;Password=postgres"
+    "_comment": "Supply ConnectionStrings__DefaultConnection via env var or environment-specific appsettings; ResolveConnectionString throws if it is missing. The leading empty default avoids shipping a real password.",
+    "DefaultConnection": ""
   },
   "Database": {
     "_comment": "PostgreSQL is the hosted/Docker default. Conductor's embedded launcher overrides this with Database__Provider=Sqlite via environment variables.",

--- a/src/Andy.Containers.Infrastructure/Data/DatabaseProviderExtensions.cs
+++ b/src/Andy.Containers.Infrastructure/Data/DatabaseProviderExtensions.cs
@@ -92,16 +92,22 @@ public static class DatabaseProviderExtensions
         return provider switch
         {
             DatabaseProvider.Sqlite =>
-                configuration.GetConnectionString("Sqlite")
+                NotEmpty(configuration.GetConnectionString("Sqlite"))
                 ?? DefaultSqliteConnectionString(),
 
             DatabaseProvider.PostgreSql =>
-                configuration.GetConnectionString("DefaultConnection")
+                NotEmpty(configuration.GetConnectionString("DefaultConnection"))
                 ?? throw new InvalidOperationException(
-                    "ConnectionStrings:DefaultConnection is not configured"),
+                    "ConnectionStrings:DefaultConnection is not configured. " +
+                    "Set the connection string via env var (ConnectionStrings__DefaultConnection) " +
+                    "or appsettings.Development.json. appsettings.json ships with an empty value " +
+                    "so a Postgres password is never committed to the repo."),
 
             _ => throw new InvalidOperationException($"Unsupported database provider: {provider}")
         };
+
+        static string? NotEmpty(string? value) =>
+            string.IsNullOrWhiteSpace(value) ? null : value;
     }
 
     private static string DefaultSqliteConnectionString()


### PR DESCRIPTION
Closes #129.

## Summary

`appsettings.json` and `docker-compose.yml` shipped with `Password=postgres` / `POSTGRES_PASSWORD=postgres`. Easy to forget to rotate, visible in every clone of the repo.

- **`appsettings.json`** — connection string set to empty. No credential ships in the repo at all.
- **`DatabaseProviderExtensions.ResolveConnectionString`** — treat empty / whitespace as missing and throw a clear error pointing at the env var override and `appsettings.Development.json`.
- **`docker-compose.yml`** — both `POSTGRES_PASSWORD` references use `${POSTGRES_PASSWORD:?...}`, so `docker compose up` fails fast until the operator provides a real value.
- **`.env.example`** — documents `POSTGRES_PASSWORD`; `.gitignore` already allowlists this file via `!.env.example`.
- **`README`** — instructs operators to `cp .env.example .env` before `docker compose up`.

`appsettings.Development.json` keeps its own dev-only connection string (out of scope for the audit finding, which targets the production default).

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test tests/Andy.Containers.Api.Tests` — 610/610 pass
- [ ] Smoke: `docker compose up` without `.env` → exits with the new error message
- [ ] Smoke: `docker compose up` with `POSTGRES_PASSWORD=…` in `.env` → starts normally
- [ ] Smoke: API started without `ConnectionStrings__DefaultConnection` env var (and prod-style appsettings) → throws the new resolver error at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)