### PR TITLE
TerminalController: forward client resize + fix banner check (conductor #836)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/TerminalController.cs
+++ b/src/Andy.Containers.Api/Controllers/TerminalController.cs
@@ -369,10 +369,32 @@ public class TerminalController : ControllerBase
                         // Check for resize messages: {"type":"resize","cols":N,"rows":N}
                         if (result.Count > 10 && buffer[0] == '{' && IsResizeMessage(buffer, result.Count, out var newCols, out var newRows))
                         {
-                            // Send Ctrl+L-style redraw hint: resize the outer PTY
-                            // by piping a stty command, then clear+redraw
-                            // tmux detects the PTY size change via SIGWINCH automatically
+                            // Forward the resize to the tmux server via a side
+                            // channel: a fresh `<provider> exec -u <user> tmux
+                            // resize-window -t <session> -x C -y R`. We can't
+                            // ioctl(TIOCSWINSZ) the inner PTY directly because
+                            // `script` owns it — `process.StandardInput` is a
+                            // pipe to script's stdin, not the PTY master FD.
+                            // tmux resize-window updates the server-side
+                            // window state and emits the SIGWINCH-equivalent
+                            // to the inner shell, which is what we actually
+                            // need.
+                            //
+                            // Without this, tmux keeps drawing its status bar
+                            // at the original column count; on every status
+                            // interval the bar overflows the renderer's
+                            // viewport and accumulates inline. See conductor
+                            // issue #836 for the byte-accumulation bug this
+                            // fixes.
                             _logger.LogDebug("Terminal resized to {Cols}x{Rows}", newCols, newRows);
+                            ForwardResizeToTmux(
+                                providerCommand: execCommand,
+                                externalId: externalId,
+                                containerUser: containerUser,
+                                tmuxSession: tmuxSession,
+                                cols: newCols,
+                                rows: newRows,
+                                ct: ct);
                             continue;
                         }
 
@@ -428,6 +450,69 @@ public class TerminalController : ControllerBase
         return container.OwnerId == _currentUser.GetUserId();
     }
 
+    /// <summary>
+    /// Tells the tmux server to resize the named window to the new
+    /// columns/rows. Runs as <paramref name="containerUser"/> so the
+    /// command lands on the same per-UID tmux socket that owns the
+    /// session — see <c>tmux has-session</c> probing for the same
+    /// reason. Best-effort: a failure to forward is logged but does
+    /// not interrupt the live WebSocket.
+    /// </summary>
+    /// <remarks>
+    /// Used by <see cref="RunExecSession"/> to handle client resize
+    /// messages. Fire-and-forget so a slow <c>docker exec</c> doesn't
+    /// stall the main relay loop.
+    /// </remarks>
+    private void ForwardResizeToTmux(
+        string providerCommand,
+        string externalId,
+        string containerUser,
+        string tmuxSession,
+        int cols,
+        int rows,
+        CancellationToken ct)
+    {
+        if (!IsValidTerminalSize(cols, rows))
+        {
+            _logger.LogWarning(
+                "Refusing tmux resize-window — out of range: {Cols}x{Rows}",
+                cols, rows);
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var args = $"exec -u {containerUser} {externalId} tmux resize-window -t {tmuxSession} -x {cols} -y {rows}";
+                using var p = System.Diagnostics.Process.Start(new ProcessStartInfo
+                {
+                    FileName = providerCommand,
+                    Arguments = args,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                });
+                if (p is null) return;
+                await p.WaitForExitAsync(ct);
+                if (p.ExitCode != 0)
+                {
+                    var stderr = await p.StandardError.ReadToEndAsync(ct);
+                    _logger.LogDebug(
+                        "tmux resize-window exited {Code}: {Stderr}",
+                        p.ExitCode,
+                        stderr.Trim());
+                }
+            }
+            catch (OperationCanceledException) { /* WS closed */ }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to forward terminal resize to tmux");
+            }
+        }, ct);
+    }
+
     internal bool IsOriginAllowed(string origin)
     {
         if (string.IsNullOrEmpty(origin))
@@ -436,6 +521,26 @@ public class TerminalController : ControllerBase
         if (allowed is null || allowed.Length == 0)
             return false;
         return Array.Exists(allowed, a => string.Equals(a, origin, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Validates a (columns, rows) pair against the bounds tmux accepts.
+    ///
+    /// xterm hardware limits are 1..999 for both axes; tmux silently
+    /// clamps to a stricter floor of 2, so a 1-column resize crashes
+    /// with "create window failed: size too small". Refuse pathological
+    /// input rather than passing it along — a malformed resize message
+    /// from a stale client should not break the live session.
+    /// </summary>
+    /// <remarks>
+    /// Public for unit tests. The full forwarding helper itself spawns
+    /// a child process and is harder to isolate; pinning the bounds
+    /// rule as a pure function lets tests cover the most error-prone
+    /// branch directly.
+    /// </remarks>
+    internal static bool IsValidTerminalSize(int cols, int rows)
+    {
+        return cols >= 2 && cols <= 1000 && rows >= 2 && rows <= 1000;
     }
 
     private static bool IsResizeMessage(byte[] buffer, int count, out int cols, out int rows)

--- a/src/Andy.Containers.Api/Controllers/TerminalController.cs
+++ b/src/Andy.Containers.Api/Controllers/TerminalController.cs
@@ -156,7 +156,11 @@ public class TerminalController : ControllerBase
         // - default-terminal xterm-256color prevents arrow key / escape issues
         var tmuxSession = "web";
 
-        // Check if tmux session already exists (to decide whether to show banner)
+        // Check if tmux session already exists (to decide whether to show banner).
+        // Must run as the same user that owns the session — tmux uses a per-UID
+        // socket (/tmp/tmux-<uid>/default), so a check as root cannot see a session
+        // owned by `containerUser`. Without -u, hasExistingSession is always false
+        // and the banner is injected on every reconnect.
         var checkExisting = providerType == ProviderType.AppleContainer ? "container" : "docker";
         var hasExistingSession = false;
         try
@@ -164,7 +168,7 @@ public class TerminalController : ControllerBase
             var checkProcess = System.Diagnostics.Process.Start(new ProcessStartInfo
             {
                 FileName = checkExisting == "docker" ? "docker" : "container",
-                Arguments = $"exec {externalId} tmux has-session -t {tmuxSession}",
+                Arguments = $"exec -u {containerUser} {externalId} tmux has-session -t {tmuxSession}",
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,

--- a/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
@@ -265,4 +265,32 @@ public class TerminalControllerTests : IDisposable
         string.IsNullOrEmpty(container.ExternalId).Should().BeTrue(
             "a container with empty ExternalId should cause the controller to return 400");
     }
+
+    // MARK: - IsValidTerminalSize (conductor #836)
+
+    [Theory]
+    [InlineData(2, 2)]
+    [InlineData(80, 24)]
+    [InlineData(120, 40)]
+    [InlineData(1000, 1000)]
+    public void IsValidTerminalSize_ReturnsTrue_ForValidPairs(int cols, int rows)
+    {
+        TerminalController.IsValidTerminalSize(cols, rows).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0, 24, "zero columns")]
+    [InlineData(80, 0, "zero rows")]
+    [InlineData(1, 24, "one column (tmux floor is 2)")]
+    [InlineData(80, 1, "one row (tmux floor is 2)")]
+    [InlineData(-1, 40, "negative columns")]
+    [InlineData(120, -10, "negative rows")]
+    [InlineData(1001, 40, "columns past xterm max")]
+    [InlineData(120, 1001, "rows past xterm max")]
+    [InlineData(int.MaxValue, 24, "overflow columns")]
+    [InlineData(120, int.MaxValue, "overflow rows")]
+    public void IsValidTerminalSize_ReturnsFalse_ForInvalidPairs(int cols, int rows, string reason)
+    {
+        TerminalController.IsValidTerminalSize(cols, rows).Should().BeFalse(reason);
+    }
 }


### PR DESCRIPTION
## Summary

Two related fixes to `TerminalController`, both surfaced by the user during epic [conductor #835](https://github.com/rivoli-ai/conductor/issues/835).

**1. Banner suppression sees the right tmux socket** — the post-attach \`hasExistingSession\` check was running \`docker exec <id> tmux has-session -t web\` without \`-u\`, but the actual session is created with \`-u {containerUser}\`. tmux keys its socket on UID, so the root-default check looks at the wrong socket and never sees the session — banner is injected on every reconnect, never just on first attach. Adding \`-u {containerUser}\` shares the user's tmux socket. (First commit.)

**2. Forward resize messages to tmux** — the WS handler was parsing \`{\"type\":\"resize\",\"cols\":N,\"rows\":N}\` payloads and logging them, but \`continue\`-ing without applying the resize. The comment claimed \"tmux detects via SIGWINCH automatically\" — false; nothing actually resized any PTY. Result: tmux kept drawing its status bar at the original column count; every \`status-interval\` the bar overflowed the client's viewport and accumulated inline. (Second commit.)

We can't \`ioctl(TIOCSWINSZ)\` the inner PTY directly because \`script\` owns it (\`process.StandardInput\` is a pipe to script's stdin, not the PTY master FD). Simpler fix: side-channel \`<provider> exec -u <user> tmux resize-window -t web -x C -y R\` against the same per-UID tmux socket the session uses. tmux updates the server-side window state and emits the SIGWINCH-equivalent to the inner shell.

## Test plan

- [x] \`dotnet build src/Andy.Containers.Api/Andy.Containers.Api.csproj\` — green.
- [x] 14 new theory rows for \`IsValidTerminalSize\` (valid pairs / zero / negative / tmux floor / xterm max / overflow).
- [x] All 36 \`TerminalControllerTests\` pass under .NET 8.0.302.
- [ ] Manual: launch a workspace, resize the Conductor window, confirm tmux status bar repaints at the new width on the next \`status-interval\` (~15 s) instead of overflowing inline.

## Notes

- Forwarding is fire-and-forget (\`Task.Run\`) so a slow \`docker exec\` spawn can't stall the main WS relay loop.
- Bounds check (2..1000 on both axes) refuses pathological input rather than passing a 1-column resize to tmux, which crashes with \"create window failed: size too small\".
- Conductor-side: filed [conductor #838](https://github.com/rivoli-ai/conductor/issues/838) for the complementary force-redraw-on-attach stop-gap. Even with this fix, an explicit \`refresh-client -S\` on every attach is desirable to avoid stale frames during reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)