### PR TITLE
TerminalController: force tmux refresh-client -S on reattach (conductor #838)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/TerminalController.cs
+++ b/src/Andy.Containers.Api/Controllers/TerminalController.cs
@@ -327,7 +327,21 @@ public class TerminalController : ControllerBase
             }
         }, ct);
 
-        // Send welcome banner after tmux has initialized (only on new sessions)
+        // Post-attach injection: on a NEW session, run the welcome
+        // banner; on an EXISTING session (reattach), force a full
+        // server-side redraw so the user sees a complete frame
+        // immediately instead of a stale buffer until tmux's next
+        // status-interval (~15 s).
+        //
+        // Why force a redraw at all: the bytes tmux already drew on
+        // the server-side window are not replayed when a new client
+        // attaches. The renderer paints a blinking cursor and nothing
+        // else until tmux happens to repaint a region (status-interval
+        // tick, vim cursor move, etc.). `tmux refresh-client -S`
+        // serialises a fresh full-screen redraw through the tmux
+        // server, which is what we actually need.
+        //
+        // Conductor #838.
         var stdinStream = process.StandardInput.BaseStream;
         _ = Task.Run(async () =>
         {
@@ -335,13 +349,13 @@ public class TerminalController : ControllerBase
             {
                 // Wait for tmux to fully initialize and draw
                 await Task.Delay(1500, ct);
-                if (!hasExistingSession && !process.HasExited && ws.State == WebSocketState.Open)
+                if (process.HasExited || ws.State != WebSocketState.Open)
                 {
-                    // Clear screen, run banner silently (space prefix avoids bash history), then clear the command line
-                    var bannerCmd = System.Text.Encoding.UTF8.GetBytes(" clear && /usr/local/bin/andy-banner 2>/dev/null; true\n");
-                    await stdinStream.WriteAsync(bannerCmd, ct);
-                    await stdinStream.FlushAsync(ct);
+                    return;
                 }
+                var cmd = BuildPostAttachCommand(hasExistingSession);
+                await stdinStream.WriteAsync(cmd, ct);
+                await stdinStream.FlushAsync(ct);
             }
             catch { /* ignore */ }
         }, ct);
@@ -521,6 +535,32 @@ public class TerminalController : ControllerBase
         if (allowed is null || allowed.Length == 0)
             return false;
         return Array.Exists(allowed, a => string.Equals(a, origin, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Builds the bytes the controller injects into the inner shell's
+    /// stdin once tmux has initialised. New sessions get the welcome
+    /// banner; existing sessions get a forced full-screen redraw so
+    /// the reattached client doesn't show a stale buffer.
+    /// </summary>
+    /// <remarks>
+    /// Internal for unit tests. Conductor #838.
+    /// </remarks>
+    internal static byte[] BuildPostAttachCommand(bool hasExistingSession)
+    {
+        if (hasExistingSession)
+        {
+            // tmux refresh-client -S asks the server to issue a full
+            // redraw to every attached client of the current session.
+            // Cheaper and more reliable than \x0c (Ctrl-L), which a
+            // foreground program (vim, less) would intercept.
+            return System.Text.Encoding.UTF8.GetBytes("tmux refresh-client -S\n");
+        }
+        // New session: clear + welcome banner. Space prefix keeps the
+        // command out of bash history; trailing `; true` swallows the
+        // exit code so a missing andy-banner binary doesn't surface
+        // as a `1` exit on the prompt.
+        return System.Text.Encoding.UTF8.GetBytes(" clear && /usr/local/bin/andy-banner 2>/dev/null; true\n");
     }
 
     /// <summary>

--- a/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
@@ -293,4 +293,47 @@ public class TerminalControllerTests : IDisposable
     {
         TerminalController.IsValidTerminalSize(cols, rows).Should().BeFalse(reason);
     }
+
+    // MARK: - BuildPostAttachCommand (conductor #838)
+
+    [Fact]
+    public void BuildPostAttachCommand_NewSession_ReturnsWelcomeBanner()
+    {
+        var bytes = TerminalController.BuildPostAttachCommand(hasExistingSession: false);
+        var text = System.Text.Encoding.UTF8.GetString(bytes);
+        text.Should().StartWith(" clear", "space prefix keeps the command out of bash history");
+        text.Should().Contain("/usr/local/bin/andy-banner",
+            "new sessions show the welcome banner");
+        text.Should().Contain("2>/dev/null",
+            "banner failure is silenced — a missing binary should not break the shell");
+        text.Should().EndWith("\n",
+            "trailing newline submits the command line");
+    }
+
+    [Fact]
+    public void BuildPostAttachCommand_ExistingSession_ReturnsTmuxRefresh()
+    {
+        var bytes = TerminalController.BuildPostAttachCommand(hasExistingSession: true);
+        var text = System.Text.Encoding.UTF8.GetString(bytes);
+        text.Should().Be("tmux refresh-client -S\n",
+            "reattach forces a server-side redraw so the user sees a complete frame immediately");
+    }
+
+    [Fact]
+    public void BuildPostAttachCommand_DistinguishesNewVsExisting()
+    {
+        var newSession = TerminalController.BuildPostAttachCommand(hasExistingSession: false);
+        var existing = TerminalController.BuildPostAttachCommand(hasExistingSession: true);
+        newSession.Should().NotEqual(existing,
+            "new sessions and reattaches must inject different commands");
+    }
+
+    [Fact]
+    public void BuildPostAttachCommand_BothBranches_TerminateWithNewline()
+    {
+        var newBytes = TerminalController.BuildPostAttachCommand(hasExistingSession: false);
+        var existingBytes = TerminalController.BuildPostAttachCommand(hasExistingSession: true);
+        newBytes[^1].Should().Be((byte)'\n');
+        existingBytes[^1].Should().Be((byte)'\n');
+    }
 }


### PR DESCRIPTION
## Summary

Reconnecting to an existing tmux session showed a stale frame — blinking cursor, no glyphs — until tmux's next \`status-interval\` (~15 s) triggered a partial repaint. The bytes already drawn on the server-side window aren't replayed when a new client attaches; the inner shell is alive and writing, the renderer just hasn't been asked to redraw.

This PR extends the post-attach injection block to inject \`tmux refresh-client -S\\n\` to the inner shell's stdin when \`hasExistingSession == true\`. The tmux server then issues a full-screen redraw to every attached client of the session. New sessions still get the welcome banner; the only change is the existing-session branch goes from \"do nothing\" to \"force redraw.\"

Why \`tmux refresh-client -S\` and not \`\\x0c\` (Ctrl-L): a foreground program (vim, less, htop) would intercept Ctrl-L, redrawing only its own viewport. The tmux server-level refresh redraws every pane without involving whichever app has focus.

## History

Originally stacked on #145 (fix/836). Now that #145 is merged, this PR is rebased onto \`main\` directly. The two #145 commits drop cleanly during rebase (\"patch contents already upstream\"), leaving just the #838 change.

## Test plan

- [x] \`dotnet build src/Andy.Containers.Api/Andy.Containers.Api.csproj\` — green.
- [x] \`BuildPostAttachCommand\` extracted as \`internal static\` so it's testable as a pure function.
- [x] 4 new xunit cases pin the command shape:
  - new sessions return the welcome banner (space prefix, andy-banner path, \`2>/dev/null\`, trailing newline)
  - existing sessions return exactly \`tmux refresh-client -S\\n\`
  - both branches terminate with \`\\n\`
  - the two branches return different bytes
- [x] All 40 \`TerminalControllerTests\` pass under .NET 8.0.302.
- [ ] Manual: launch a workspace, open the terminal, close the detached window, reopen — assert the prior buffer is visible within 2 s instead of after a status-interval delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)