### PR TITLE
Reconcile stale ExternalIds at startup (conductor #840)

### DIFF
--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -81,6 +81,11 @@ try
     // Container status sync worker — periodically checks running containers against provider
     builder.Services.AddHostedService<ContainerStatusSyncWorker>();
 
+    // Startup-only externalId reconciler (conductor #840) — closes the
+    // ~25 s cold-start window during which orphan rows show as Running
+    // before the periodic ContainerStatusSyncWorker catches them.
+    builder.Services.AddHostedService<ContainerExternalIdReconciler>();
+
     // Container screenshot capture worker
     builder.Services.AddHostedService<ContainerScreenshotWorker>();
 

--- a/src/Andy.Containers.Api/Services/ContainerExternalIdReconciler.cs
+++ b/src/Andy.Containers.Api/Services/ContainerExternalIdReconciler.cs
@@ -1,0 +1,164 @@
+using Andy.Containers.Abstractions;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// Startup-time reconciler that detects DB rows whose underlying
+/// container was removed out-of-band (host reboot, manual
+/// <c>docker rm -f</c>) and marks them <see cref="ContainerStatus.Destroyed"/>.
+///
+/// Without this, the periodic <see cref="ContainerStatusSyncWorker"/>
+/// eventually catches orphans, but only after a 10 s startup delay
+/// plus ~15 s polling interval — up to 25 s of zombies showing as
+/// running in Conductor's UI. Running once at startup before the
+/// polling worker fixes the cold-start window. Conductor #840.
+///
+/// Per-provider behaviour:
+///   * Local providers (Docker, Apple Containers) implement
+///     <see cref="IInfrastructureProvider.ListExternalIdsAsync"/> as a
+///     single CLI call — fast, bulk.
+///   * Cloud providers return <c>null</c> from
+///     <see cref="IInfrastructureProvider.ListExternalIdsAsync"/>;
+///     we skip them and let the periodic worker handle them.
+/// </summary>
+public class ContainerExternalIdReconciler : IHostedService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<ContainerExternalIdReconciler> _logger;
+
+    public ContainerExternalIdReconciler(
+        IServiceScopeFactory scopeFactory,
+        ILogger<ContainerExternalIdReconciler> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Fire-and-forget the reconcile so we don't block app startup.
+        // The periodic worker covers ongoing drift; this just closes
+        // the cold-start window.
+        _ = Task.Run(() => ReconcileAsync(cancellationToken), cancellationToken);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
+    /// Internal for unit tests. Reconciles every Running row against
+    /// its provider's bulk externalId listing; flips orphans to
+    /// <see cref="ContainerStatus.Destroyed"/>.
+    /// </summary>
+    internal async Task ReconcileAsync(CancellationToken ct)
+    {
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var db = scope.ServiceProvider.GetRequiredService<ContainersDbContext>();
+            var providerFactory = scope.ServiceProvider
+                .GetRequiredService<IInfrastructureProviderFactory>();
+
+            var rows = await db.Containers
+                .Include(c => c.Provider)
+                .Where(c => c.Status == ContainerStatus.Running &&
+                            c.ExternalId != null && c.ExternalId != "")
+                .ToListAsync(ct);
+
+            if (rows.Count == 0)
+            {
+                _logger.LogDebug(
+                    "[CONTAINERS-RECONCILE] No running rows to reconcile at startup");
+                return;
+            }
+
+            // Group by provider entity so we issue one bulk listing per
+            // distinct provider, not per row.
+            var byProvider = rows
+                .Where(r => r.Provider is not null)
+                .GroupBy(r => r.ProviderId);
+
+            var orphanCount = 0;
+
+            foreach (var group in byProvider)
+            {
+                var providerEntity = group.First().Provider!;
+                IInfrastructureProvider provider;
+                try
+                {
+                    provider = providerFactory.GetProvider(providerEntity);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "[CONTAINERS-RECONCILE] Failed to resolve provider {Provider}; skipping {Count} rows",
+                        providerEntity.Name, group.Count());
+                    continue;
+                }
+
+                HashSet<string>? liveIds;
+                try
+                {
+                    liveIds = await provider.ListExternalIdsAsync(ct);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "[CONTAINERS-RECONCILE] Provider {Provider} ListExternalIdsAsync threw; skipping {Count} rows",
+                        providerEntity.Name, group.Count());
+                    continue;
+                }
+
+                if (liveIds is null)
+                {
+                    // Provider doesn't support bulk listing — periodic
+                    // worker will reconcile these via per-row probes.
+                    _logger.LogDebug(
+                        "[CONTAINERS-RECONCILE] Provider {Provider} does not support bulk enumeration",
+                        providerEntity.Name);
+                    continue;
+                }
+
+                foreach (var row in group)
+                {
+                    if (!liveIds.Contains(row.ExternalId!))
+                    {
+                        _logger.LogWarning(
+                            "[CONTAINERS-RECONCILE] Container {Name} ({Id}) ExternalId {ExternalId} not present on {Provider} — marking Destroyed",
+                            row.Name,
+                            row.Id,
+                            row.ExternalId,
+                            providerEntity.Name);
+                        row.Status = ContainerStatus.Destroyed;
+                        if (row.StoppedAt is null)
+                            row.StoppedAt = DateTime.UtcNow;
+                        orphanCount++;
+                    }
+                }
+            }
+
+            if (orphanCount > 0)
+            {
+                await db.SaveChangesAsync(ct);
+                _logger.LogInformation(
+                    "[CONTAINERS-RECONCILE] Marked {Count} orphan container(s) Destroyed at startup",
+                    orphanCount);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Shutdown — fine.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "[CONTAINERS-RECONCILE] Startup reconciliation failed");
+        }
+    }
+}

--- a/src/Andy.Containers.Infrastructure/Providers/Apple/AppleContainerProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Apple/AppleContainerProvider.cs
@@ -230,6 +230,70 @@ public class AppleContainerProvider : IInfrastructureProvider
         };
     }
 
+    /// <summary>
+    /// Lists every externalId currently known to the Apple `container`
+    /// runtime via <c>container ls -a</c>. Used by the startup
+    /// reconciler to detect rows whose containers were removed
+    /// out-of-band (host reboot, manual deletion). Conductor #840.
+    /// </summary>
+    public async Task<HashSet<string>?> ListExternalIdsAsync(CancellationToken ct = default)
+    {
+        // `container ls -a --format json` returns an array of records;
+        // extract every `id` field and collect into a HashSet.
+        var result = await RunCliAsync("ls -a --format json", ct, TimeSpan.FromSeconds(15));
+        if (result.ExitCode != 0)
+        {
+            _logger.LogWarning(
+                "[CONTAINERS-RECONCILE] container ls -a failed (exit {Exit}): {Stderr}",
+                result.ExitCode,
+                result.StdErr);
+            return null;
+        }
+
+        var ids = new HashSet<string>(StringComparer.Ordinal);
+        if (string.IsNullOrWhiteSpace(result.StdOut))
+        {
+            return ids;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(result.StdOut);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array)
+            {
+                return ids;
+            }
+            foreach (var item in doc.RootElement.EnumerateArray())
+            {
+                // Apple's CLI uses `configuration.id` per the inspect schema;
+                // fall back to top-level `id` for forward-compat.
+                if (item.TryGetProperty("configuration", out var config) &&
+                    config.TryGetProperty("id", out var configId) &&
+                    configId.ValueKind == JsonValueKind.String)
+                {
+                    var id = configId.GetString();
+                    if (!string.IsNullOrEmpty(id))
+                        ids.Add(id);
+                }
+                else if (item.TryGetProperty("id", out var idProp) &&
+                         idProp.ValueKind == JsonValueKind.String)
+                {
+                    var id = idProp.GetString();
+                    if (!string.IsNullOrEmpty(id))
+                        ids.Add(id);
+                }
+            }
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex,
+                "[CONTAINERS-RECONCILE] Failed to parse container ls JSON output");
+            return null;
+        }
+
+        return ids;
+    }
+
     private async Task<InspectInfo> InspectAsync(string externalId, CancellationToken ct)
     {
         var result = await RunCliAsync($"inspect {externalId}", ct, TimeSpan.FromSeconds(10));

--- a/src/Andy.Containers.Infrastructure/Providers/Local/DockerInfrastructureProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Local/DockerInfrastructureProvider.cs
@@ -384,6 +384,32 @@ public class DockerInfrastructureProvider : IInfrastructureProvider
     }
 
     /// <summary>
+    /// Lists every externalId currently known to the Docker daemon
+    /// (running OR stopped). Used by the startup reconciler to detect
+    /// rows whose containers were removed out-of-band (host reboot,
+    /// manual <c>docker rm -f</c>). Conductor #840.
+    /// </summary>
+    public async Task<HashSet<string>?> ListExternalIdsAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var containers = await _client.Containers.ListContainersAsync(
+                new ContainersListParameters { All = true },
+                ct);
+            // Docker returns full 64-char IDs in `ID`. Andy stores the
+            // same full form (see CreateContainerAsync), so a direct
+            // string compare is correct — no truncation needed.
+            return new HashSet<string>(containers.Select(c => c.ID), StringComparer.Ordinal);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "[CONTAINERS-RECONCILE] Docker ListContainers failed");
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Builds a desktop image from local Dockerfiles using docker CLI.
     /// </summary>
     private async Task BuildDesktopImageAsync(string imageReference, CancellationToken ct)

--- a/src/Andy.Containers/Abstractions/IInfrastructureProvider.cs
+++ b/src/Andy.Containers/Abstractions/IInfrastructureProvider.cs
@@ -33,6 +33,22 @@ public interface IInfrastructureProvider
     // Execution
     Task<ExecResult> ExecAsync(string externalId, string command, CancellationToken ct = default);
     Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the set of container externalIds currently known to the
+    /// provider, or <c>null</c> if this provider does not support bulk
+    /// enumeration. Used by the startup reconciler (conductor #840) to
+    /// detect rows whose containers were removed out-of-band (host
+    /// reboot, manual <c>docker rm -f</c>, etc.) without paying the
+    /// per-row cost of <see cref="GetContainerInfoAsync"/>.
+    ///
+    /// Cloud providers (AWS, Azure, GCP, Fly, etc.) typically return
+    /// <c>null</c> — the existing periodic <c>ContainerStatusSyncWorker</c>
+    /// covers them via per-row probes. Local providers (Docker, Apple
+    /// Containers) override this to issue a single CLI call.
+    /// </summary>
+    Task<HashSet<string>?> ListExternalIdsAsync(CancellationToken ct = default)
+        => Task.FromResult<HashSet<string>?>(null);
 }
 
 public class ProviderCapabilities

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerExternalIdReconcilerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerExternalIdReconcilerTests.cs
@@ -1,0 +1,266 @@
+using Andy.Containers.Abstractions;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+/// <summary>
+/// Unit tests for ContainerExternalIdReconciler (conductor #840).
+///
+/// The reconciler runs once at startup, groups Running rows by their
+/// provider, asks each provider for the bulk live ID set, and flips
+/// any row whose ExternalId is missing to Destroyed.
+/// </summary>
+public class ContainerExternalIdReconcilerTests : IDisposable
+{
+    private readonly ContainersDbContext _db;
+    private readonly Mock<IInfrastructureProviderFactory> _providerFactory;
+    private readonly Mock<IInfrastructureProvider> _mockProvider;
+    private readonly ContainerExternalIdReconciler _reconciler;
+
+    public ContainerExternalIdReconcilerTests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+        _providerFactory = new Mock<IInfrastructureProviderFactory>();
+        _mockProvider = new Mock<IInfrastructureProvider>();
+
+        var scopeFactory = InMemoryDbHelper.CreateScopeFactory(_db);
+        _reconciler = new ContainerExternalIdReconciler(
+            scopeFactory,
+            new Mock<ILogger<ContainerExternalIdReconciler>>().Object);
+
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        // The factory is also registered into the scope so the reconciler
+        // can resolve it. InMemoryDbHelper.CreateScopeFactory only wires
+        // ContainersDbContext; we override scope resolution here via
+        // shimming the factory mock through the scope.
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private InfrastructureProvider AddProvider(string name = "test-provider")
+    {
+        var provider = new InfrastructureProvider
+        {
+            Code = name,
+            Name = name,
+            Type = ProviderType.Docker,
+            IsEnabled = true
+        };
+        _db.Providers.Add(provider);
+        _db.SaveChanges();
+        _providerFactory
+            .Setup(f => f.GetProvider(It.Is<InfrastructureProvider>(p => p.Id == provider.Id)))
+            .Returns(_mockProvider.Object);
+        return provider;
+    }
+
+    private Container AddContainer(
+        InfrastructureProvider provider,
+        string name,
+        string? externalId,
+        ContainerStatus status = ContainerStatus.Running)
+    {
+        var container = new Container
+        {
+            Name = name,
+            OwnerId = "test-user",
+            ProviderId = provider.Id,
+            ExternalId = externalId,
+            Status = status
+        };
+        _db.Containers.Add(container);
+        _db.SaveChanges();
+        return container;
+    }
+
+    /// <summary>
+    /// Builds a reconciler whose scope resolves both DbContext AND the
+    /// mocked provider factory. The default
+    /// <c>InMemoryDbHelper.CreateScopeFactory</c> only wires the db
+    /// context; the reconciler also asks the scope for an
+    /// <c>IInfrastructureProviderFactory</c>.
+    /// </summary>
+    private ContainerExternalIdReconciler CreateReconcilerWithFactoryInScope()
+    {
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        services.AddSingleton(_db);
+        services.AddSingleton(_providerFactory.Object);
+        var provider = services.BuildServiceProvider();
+
+        var scopeFactoryMock = new Mock<Microsoft.Extensions.DependencyInjection.IServiceScopeFactory>();
+        scopeFactoryMock.Setup(f => f.CreateScope())
+            .Returns(() =>
+            {
+                var scope = new Mock<Microsoft.Extensions.DependencyInjection.IServiceScope>();
+                scope.Setup(s => s.ServiceProvider).Returns(provider);
+                return scope.Object;
+            });
+
+        return new ContainerExternalIdReconciler(
+            scopeFactoryMock.Object,
+            new Mock<ILogger<ContainerExternalIdReconciler>>().Object);
+    }
+
+    // MARK: - Tests
+
+    [Fact]
+    public async Task ReconcileAsync_NoRunningRows_NoOp()
+    {
+        var reconciler = CreateReconcilerWithFactoryInScope();
+        await reconciler.ReconcileAsync(CancellationToken.None);
+
+        // Mock provider should never be asked for the live ID set.
+        _mockProvider.Verify(
+            p => p.ListExternalIdsAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_AllRowsAlive_StatusUnchanged()
+    {
+        var provider = AddProvider();
+        var alive1 = AddContainer(provider, "alive-1", "ext-1");
+        var alive2 = AddContainer(provider, "alive-2", "ext-2");
+
+        _mockProvider
+            .Setup(p => p.ListExternalIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HashSet<string>(["ext-1", "ext-2"]));
+
+        var reconciler = CreateReconcilerWithFactoryInScope();
+        await reconciler.ReconcileAsync(CancellationToken.None);
+
+        var refreshed1 = await _db.Containers.FindAsync(alive1.Id);
+        var refreshed2 = await _db.Containers.FindAsync(alive2.Id);
+        refreshed1!.Status.Should().Be(ContainerStatus.Running);
+        refreshed2!.Status.Should().Be(ContainerStatus.Running);
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_OrphanRow_FlipsToDestroyed()
+    {
+        var provider = AddProvider();
+        var orphan = AddContainer(provider, "orphan", "ext-gone");
+
+        _mockProvider
+            .Setup(p => p.ListExternalIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HashSet<string>()); // empty live set
+
+        var reconciler = CreateReconcilerWithFactoryInScope();
+        await reconciler.ReconcileAsync(CancellationToken.None);
+
+        var refreshed = await _db.Containers.FindAsync(orphan.Id);
+        refreshed!.Status.Should().Be(ContainerStatus.Destroyed,
+            "row whose ExternalId disappeared off the host should be marked Destroyed");
+        refreshed.StoppedAt.Should().NotBeNull(
+            "Destroyed transition stamps StoppedAt for the audit trail");
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_OnlyMissingRowsAreFlipped()
+    {
+        var provider = AddProvider();
+        var alive = AddContainer(provider, "alive", "ext-keep");
+        var orphan = AddContainer(provider, "orphan", "ext-gone");
+
+        _mockProvider
+            .Setup(p => p.ListExternalIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HashSet<string>(["ext-keep"]));
+
+        var reconciler = CreateReconcilerWithFactoryInScope();
+        await reconciler.ReconcileAsync(CancellationToken.None);
+
+        (await _db.Containers.FindAsync(alive.Id))!.Status.Should().Be(ContainerStatus.Running);
+        (await _db.Containers.FindAsync(orphan.Id))!.Status.Should().Be(ContainerStatus.Destroyed);
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_NonRunningRowsAreIgnored()
+    {
+        var provider = AddProvider();
+        // Orphan ExternalId, but row is Stopped — out of scope for this
+        // worker, the periodic ContainerStatusSyncWorker handles
+        // running drift. We only fix the cold-start "Running but gone"
+        // window.
+        var stopped = AddContainer(provider, "stopped-orphan", "ext-stale", ContainerStatus.Stopped);
+
+        _mockProvider
+            .Setup(p => p.ListExternalIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HashSet<string>());
+
+        var reconciler = CreateReconcilerWithFactoryInScope();
+        await reconciler.ReconcileAsync(CancellationToken.None);
+
+        // Stopped row should remain Stopped — the reconciler only
+        // touches Running rows.
+        (await _db.Containers.FindAsync(stopped.Id))!.Status.Should().Be(ContainerStatus.Stopped);
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_NullProviderReturn_SkipsProvider()
+    {
+        var provider = AddProvider();
+        var orphan = AddContainer(provider, "orphan", "ext-gone");
+
+        _mockProvider
+            .Setup(p => p.ListExternalIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((HashSet<string>?)null);
+
+        var reconciler = CreateReconcilerWithFactoryInScope();
+        await reconciler.ReconcileAsync(CancellationToken.None);
+
+        // Provider doesn't support bulk listing — periodic worker will
+        // catch this row, reconciler must NOT mark it Destroyed.
+        (await _db.Containers.FindAsync(orphan.Id))!.Status.Should().Be(
+            ContainerStatus.Running,
+            "providers that return null from ListExternalIdsAsync are skipped — periodic worker handles them");
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_ProviderThrows_DoesNotThrow()
+    {
+        var provider = AddProvider();
+        var orphan = AddContainer(provider, "orphan", "ext-gone");
+
+        _mockProvider
+            .Setup(p => p.ListExternalIdsAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("docker daemon unreachable"));
+
+        var reconciler = CreateReconcilerWithFactoryInScope();
+        // Should swallow + log, not crash.
+        await reconciler.ReconcileAsync(CancellationToken.None);
+
+        // Same row, untouched — better to leave the UI showing "Running"
+        // than to flip every container to Destroyed because docker is
+        // momentarily unreachable.
+        (await _db.Containers.FindAsync(orphan.Id))!.Status.Should().Be(ContainerStatus.Running);
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_RowsWithEmptyExternalId_AreIgnored()
+    {
+        var provider = AddProvider();
+        AddContainer(provider, "no-id", externalId: "");
+        AddContainer(provider, "null-id", externalId: null);
+
+        _mockProvider
+            .Setup(p => p.ListExternalIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HashSet<string>());
+
+        var reconciler = CreateReconcilerWithFactoryInScope();
+        await reconciler.ReconcileAsync(CancellationToken.None);
+
+        // Provider should never be asked — both rows are filtered out
+        // before the bulk listing call.
+        _mockProvider.Verify(
+            p => p.ListExternalIdsAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}


### PR DESCRIPTION
## Summary

The DB can hold \`Container\` rows whose docker / apple-container counterpart was removed out-of-band (host reboot, manual \`docker rm -f <id>\`). The existing periodic \`ContainerStatusSyncWorker\` eventually catches them via per-row \`GetContainerInfoAsync\` probes, but only after its 10 s startup delay + 15 s polling interval — up to 25 s where Conductor's UI shows running zombies. Every \`docker exec\` against those rows fails opaquely, blocking terminals, port lookups, stats, and agent runs.

This PR adds a startup-only \`IHostedService\` that runs ONCE before the periodic worker, asks each provider for the bulk live ID set in a single CLI call, and flips orphaned rows to \`Destroyed\`.

## Changes

- \`IInfrastructureProvider.ListExternalIdsAsync\` — new method with a default interface implementation that returns \`null\`. Cloud providers (Azure, AWS, GCP, Fly, Hetzner, DO, Civo) inherit the null default — the periodic worker keeps covering them.
- \`DockerInfrastructureProvider\` — overrides via Docker.DotNet \`ListContainersAsync({All = true})\`; single round-trip.
- \`AppleContainerProvider\` — overrides via \`container ls -a --format json\`; single CLI call.
- \`ContainerExternalIdReconciler : IHostedService\` — runs \`ReconcileAsync\` once at startup, fire-and-forget so app boot isn't blocked. Groups Running rows by provider, calls \`ListExternalIdsAsync\` per provider, marks orphans \`Destroyed\` (and stamps \`StoppedAt\` for the audit trail).
- Wired into \`Program.cs\` alongside \`ContainerStatusSyncWorker\`.

## Decisions

- **No new \`ContainerStatus\` enum value** — \`Destroyed\` already means \"the container is gone.\" Adding \`Lost\` was tempting but the migration risk plus the conductor-side enum mirror weren't worth the nuance for this PR. Can be filed separately if we want the finer distinction later.
- **Per-provider bulk fetch, not per-row probe** — N round-trips don't scale; one \`docker ps\` / \`container ls\` covers every row on that host.
- **Cloud providers skip silently** (\`ListExternalIdsAsync\` returns \`null\`) — no special-casing in the reconciler, the existing periodic worker continues to cover them via per-row probes.

## Test plan

- [x] \`dotnet build src/Andy.Containers.Api/Andy.Containers.Api.csproj\` — green.
- [x] 8 new xunit cases pinning reconciler behaviour:
  - empty DB → no-op (provider not asked)
  - all rows alive → status unchanged
  - single orphan → flips to \`Destroyed\`, stamps \`StoppedAt\`
  - mixed alive + orphan → only the orphan flips
  - non-Running rows ignored (out of scope; periodic worker covers them)
  - provider returns \`null\` → skipped (period worker covers)
  - provider throws → swallowed + logged, rows untouched
  - rows with empty/null \`ExternalId\` filtered before the bulk call
- [x] All 654 \`Andy.Containers.Api.Tests\` pass under .NET 8.0.302.
- [ ] Manual: kill a container with \`docker rm -f <id>\`, restart andy-containers, verify the row flips to Destroyed within ~1 s of startup (instead of 10–25 s with periodic-only).

## Worktree note

Per the user-stated workflow rule, all andy-containers work happens in \`.claude/worktrees/840-reconcile\` — no edits on the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)