### PR TITLE
Hotfix: allow empty Origin from loopback (terminal WS handshake regression)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/TerminalController.cs
+++ b/src/Andy.Containers.Api/Controllers/TerminalController.cs
@@ -530,11 +530,40 @@ public class TerminalController : ControllerBase
     internal bool IsOriginAllowed(string origin)
     {
         if (string.IsNullOrEmpty(origin))
-            return false;
+        {
+            // Native WebSocket clients (macOS NSURLSession's
+            // URLSessionWebSocketTask, in particular) do not send an
+            // Origin header for ws:// schemes — Origin is a
+            // browser-only CSWSH defence, and natively-launched
+            // requests aren't subject to that attack vector.
+            //
+            // When the upgrade comes from loopback we treat empty
+            // Origin as a same-origin local request and allow it.
+            // Cross-host requests that arrive without Origin are still
+            // rejected, so the CSWSH guarantee for browser traffic
+            // (which always sends Origin) is preserved.
+            //
+            // Conductor regression: terminal WebSocket from the
+            // bundled Conductor app over the local proxy never
+            // populates Origin, so every WS upgrade was failing 403.
+            return IsRemoteLoopback();
+        }
         var allowed = _configuration.GetSection("Cors:Origins").Get<string[]>();
         if (allowed is null || allowed.Length == 0)
             return false;
         return Array.Exists(allowed, a => string.Equals(a, origin, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// True when the upgrade request arrived from a loopback address
+    /// (127.0.0.0/8, ::1). HttpContext is null in unit-test contexts
+    /// that don't drive the controller through ASP.NET; treat that as
+    /// non-loopback so tests cover the strict path.
+    /// </summary>
+    internal virtual bool IsRemoteLoopback()
+    {
+        var remote = HttpContext?.Connection?.RemoteIpAddress;
+        return remote is not null && System.Net.IPAddress.IsLoopback(remote);
     }
 
     /// <summary>

--- a/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
@@ -154,10 +154,56 @@ public class TerminalControllerTests : IDisposable
     }
 
     [Fact]
-    public void IsOriginAllowed_EmptyOrigin_ReturnsFalse()
+    public void IsOriginAllowed_EmptyOrigin_NonLoopbackRemote_ReturnsFalse()
     {
+        // Empty Origin from an external IP is still rejected (CSWSH
+        // defence preserved for browser traffic that arrives over the
+        // network).
+        var httpContext = new DefaultHttpContext();
+        httpContext.Connection.RemoteIpAddress = System.Net.IPAddress.Parse("203.0.113.42");
+        var controller = CreateController(
+            httpContext: httpContext,
+            configuration: ConfigWithOrigins("https://localhost:5280"));
+        controller.IsOriginAllowed(string.Empty).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsOriginAllowed_EmptyOrigin_NoRemoteAddress_ReturnsFalse()
+    {
+        // DefaultHttpContext.Connection.RemoteIpAddress defaults to
+        // null. Treat that as "we don't know where this came from" and
+        // refuse — fail-closed when ambiguous.
         var controller = CreateController(configuration: ConfigWithOrigins("https://localhost:5280"));
         controller.IsOriginAllowed(string.Empty).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsOriginAllowed_EmptyOrigin_LoopbackRemote_ReturnsTrue()
+    {
+        // Native WebSocket clients (macOS NSURLSession in particular)
+        // don't send an Origin header — Origin is a browser-only CSWSH
+        // defence. Conductor's terminal session connects over a local
+        // proxy, so the upgrade arrives at andy-containers from
+        // 127.0.0.1 with no Origin. This used to fail 403 Forbidden;
+        // post-fix it succeeds because loopback traffic is not
+        // browser-cross-site-attackable.
+        var httpContext = new DefaultHttpContext();
+        httpContext.Connection.RemoteIpAddress = System.Net.IPAddress.Loopback;
+        var controller = CreateController(
+            httpContext: httpContext,
+            configuration: ConfigWithOrigins("https://localhost:5280"));
+        controller.IsOriginAllowed(string.Empty).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsOriginAllowed_EmptyOrigin_IPv6LoopbackRemote_ReturnsTrue()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Connection.RemoteIpAddress = System.Net.IPAddress.IPv6Loopback;
+        var controller = CreateController(
+            httpContext: httpContext,
+            configuration: ConfigWithOrigins("https://localhost:5280"));
+        controller.IsOriginAllowed(string.Empty).Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Hotfix for a regression that broke ALL terminal sessions in the bundled-services Conductor app — every WS upgrade returned \`HTTP/1.1 403 Forbidden — Origin not allowed\`, surfaced to the user as \`[TERM-WS-HANDSHAKE] There was a bad response from the server\`.

## Root cause

macOS NSURLSession's \`URLSessionWebSocketTask\` does not send an \`Origin\` header for \`ws://\` schemes. The terminal WebSocket arrives at andy-containers via the local proxy with no \`Origin\`, and the pre-existing \`IsOriginAllowed\` check (#137) fails closed on empty Origin.

Origin is a browser-only CSWSH defence; native clients aren't subject to that attack vector. Fix: when the upgrade comes from loopback (127.0.0.1, ::1) we treat empty Origin as a same-origin local request and allow it. Cross-host requests that arrive without Origin are still rejected, so the CSWSH guarantee for real browser traffic (which always sends Origin) is preserved.

## Test plan

- [x] Existing \`IsOriginAllowed_EmptyOrigin_ReturnsFalse\` split into three explicit scenarios:
  - \`NoRemoteAddress\` — fail-closed when the remote IP is unknown
  - \`NonLoopbackRemote\` — still 403 (CSWSH defence preserved for cross-host)
  - \`LoopbackRemote\` — now 200, the fix path
- [x] Plus \`IPv6LoopbackRemote\` for \`::1\` parity.
- [x] All 43 \`TerminalControllerTests\` pass under .NET 8.0.302.
- [ ] Manual: rebuild bundled binary, restart Conductor, open any container's terminal, verify the WS handshake completes and a shell appears.

## Worktree note

Worked in \`.claude/worktrees/origin-fix\` per the andy-containers worktree rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)