### PR TITLE
Hotfix: send tmux refresh-client through side channel (conductor #838 corrective)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/TerminalController.cs
+++ b/src/Andy.Containers.Api/Controllers/TerminalController.cs
@@ -353,9 +353,37 @@ public class TerminalController : ControllerBase
                 {
                     return;
                 }
-                var cmd = BuildPostAttachCommand(hasExistingSession);
-                await stdinStream.WriteAsync(cmd, ct);
-                await stdinStream.FlushAsync(ct);
+
+                if (hasExistingSession)
+                {
+                    // Reattach: force tmux to repaint via the side
+                    // channel — `<provider> exec -u <user> tmux
+                    // refresh-client -S` against the same per-UID
+                    // tmux socket the session uses. Going through
+                    // stdin here would type `tmux refresh-client -S`
+                    // into the user's foreground process (vim,
+                    // claude, even just bash), which is wrong: the
+                    // command would land in the user's shell history
+                    // and run as if they typed it. The side channel
+                    // talks directly to the tmux server and is
+                    // invisible to the user. Conductor #838.
+                    InvokeTmuxCommand(
+                        providerCommand: execCommand,
+                        externalId: externalId,
+                        containerUser: containerUser,
+                        tmuxArguments: $"refresh-client -S -t {tmuxSession}",
+                        ct: ct);
+                }
+                else
+                {
+                    // New session: the welcome banner runs INSIDE
+                    // the user's bash session because that's exactly
+                    // where it should print. Stdin injection is
+                    // correct here.
+                    var bannerCmd = BuildWelcomeBannerCommand();
+                    await stdinStream.WriteAsync(bannerCmd, ct);
+                    await stdinStream.FlushAsync(ct);
+                }
             }
             catch { /* ignore */ }
         }, ct);
@@ -468,15 +496,8 @@ public class TerminalController : ControllerBase
     /// Tells the tmux server to resize the named window to the new
     /// columns/rows. Runs as <paramref name="containerUser"/> so the
     /// command lands on the same per-UID tmux socket that owns the
-    /// session — see <c>tmux has-session</c> probing for the same
-    /// reason. Best-effort: a failure to forward is logged but does
-    /// not interrupt the live WebSocket.
+    /// session.
     /// </summary>
-    /// <remarks>
-    /// Used by <see cref="RunExecSession"/> to handle client resize
-    /// messages. Fire-and-forget so a slow <c>docker exec</c> doesn't
-    /// stall the main relay loop.
-    /// </remarks>
     private void ForwardResizeToTmux(
         string providerCommand,
         string externalId,
@@ -494,11 +515,50 @@ public class TerminalController : ControllerBase
             return;
         }
 
+        // Bumped to Information so the resize chain is visible in the
+        // diagnostics console without raising the global log level.
+        // Conductor #836 verification.
+        _logger.LogInformation(
+            "[CONTAINERS-TMUX] resize-window {Cols}x{Rows} on {Provider} {ExternalId} as {User}",
+            cols, rows, providerCommand, externalId, containerUser);
+
+        InvokeTmuxCommand(
+            providerCommand: providerCommand,
+            externalId: externalId,
+            containerUser: containerUser,
+            tmuxArguments: $"resize-window -t {tmuxSession} -x {cols} -y {rows}",
+            ct: ct);
+    }
+
+    /// <summary>
+    /// Spawns a <c>&lt;providerCommand&gt; exec -u &lt;user&gt; &lt;externalId&gt; tmux &lt;args&gt;</c>
+    /// against the container's per-UID tmux socket. Used for any
+    /// out-of-band tmux server command (resize-window, refresh-client,
+    /// kill-session, …) where stdin injection into the user's shell
+    /// would be wrong (they'd see the command typed in their session).
+    ///
+    /// Fire-and-forget: a slow <c>docker exec</c> spawn never stalls
+    /// the main WebSocket relay loop. Failures are logged at Debug
+    /// level so a transient error isn't surfaced as a banner.
+    /// </summary>
+    /// <remarks>
+    /// Conductor #838 — replaces the previous stdin-injection path
+    /// for the post-attach redraw, which typed
+    /// <c>tmux refresh-client -S</c> into the user's foreground
+    /// process.
+    /// </remarks>
+    private void InvokeTmuxCommand(
+        string providerCommand,
+        string externalId,
+        string containerUser,
+        string tmuxArguments,
+        CancellationToken ct)
+    {
         _ = Task.Run(async () =>
         {
             try
             {
-                var args = $"exec -u {containerUser} {externalId} tmux resize-window -t {tmuxSession} -x {cols} -y {rows}";
+                var args = $"exec -u {containerUser} {externalId} tmux {tmuxArguments}";
                 using var p = System.Diagnostics.Process.Start(new ProcessStartInfo
                 {
                     FileName = providerCommand,
@@ -514,15 +574,16 @@ public class TerminalController : ControllerBase
                 {
                     var stderr = await p.StandardError.ReadToEndAsync(ct);
                     _logger.LogDebug(
-                        "tmux resize-window exited {Code}: {Stderr}",
-                        p.ExitCode,
-                        stderr.Trim());
+                        "tmux {Args} exited {Code}: {Stderr}",
+                        tmuxArguments, p.ExitCode, stderr.Trim());
                 }
             }
             catch (OperationCanceledException) { /* WS closed */ }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Failed to forward terminal resize to tmux");
+                _logger.LogDebug(ex,
+                    "Failed to invoke tmux command: {Args}",
+                    tmuxArguments);
             }
         }, ct);
     }
@@ -567,29 +628,22 @@ public class TerminalController : ControllerBase
     }
 
     /// <summary>
-    /// Builds the bytes the controller injects into the inner shell's
-    /// stdin once tmux has initialised. New sessions get the welcome
-    /// banner; existing sessions get a forced full-screen redraw so
-    /// the reattached client doesn't show a stale buffer.
+    /// Builds the bytes injected into the inner shell's stdin on first
+    /// attach to display the welcome banner. Only invoked on new
+    /// sessions — reattach uses the tmux side channel
+    /// (<see cref="InvokeTmuxCommand"/>) so commands don't get typed
+    /// into the user's foreground process.
     /// </summary>
     /// <remarks>
-    /// Internal for unit tests. Conductor #838.
+    /// Internal for unit tests. Space prefix keeps the command out
+    /// of bash history; trailing <c>; true</c> swallows the exit code
+    /// so a missing andy-banner binary doesn't surface as a `1` exit
+    /// on the prompt.
     /// </remarks>
-    internal static byte[] BuildPostAttachCommand(bool hasExistingSession)
+    internal static byte[] BuildWelcomeBannerCommand()
     {
-        if (hasExistingSession)
-        {
-            // tmux refresh-client -S asks the server to issue a full
-            // redraw to every attached client of the current session.
-            // Cheaper and more reliable than \x0c (Ctrl-L), which a
-            // foreground program (vim, less) would intercept.
-            return System.Text.Encoding.UTF8.GetBytes("tmux refresh-client -S\n");
-        }
-        // New session: clear + welcome banner. Space prefix keeps the
-        // command out of bash history; trailing `; true` swallows the
-        // exit code so a missing andy-banner binary doesn't surface
-        // as a `1` exit on the prompt.
-        return System.Text.Encoding.UTF8.GetBytes(" clear && /usr/local/bin/andy-banner 2>/dev/null; true\n");
+        return System.Text.Encoding.UTF8.GetBytes(
+            " clear && /usr/local/bin/andy-banner 2>/dev/null; true\n");
     }
 
     /// <summary>

--- a/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
@@ -340,46 +340,58 @@ public class TerminalControllerTests : IDisposable
         TerminalController.IsValidTerminalSize(cols, rows).Should().BeFalse(reason);
     }
 
-    // MARK: - BuildPostAttachCommand (conductor #838)
+    // MARK: - BuildWelcomeBannerCommand (conductor #838 corrective)
 
     [Fact]
-    public void BuildPostAttachCommand_NewSession_ReturnsWelcomeBanner()
+    public void BuildWelcomeBannerCommand_StartsWithSpaceClear()
     {
-        var bytes = TerminalController.BuildPostAttachCommand(hasExistingSession: false);
+        var bytes = TerminalController.BuildWelcomeBannerCommand();
         var text = System.Text.Encoding.UTF8.GetString(bytes);
-        text.Should().StartWith(" clear", "space prefix keeps the command out of bash history");
+        text.Should().StartWith(" clear",
+            "space prefix keeps the command out of bash history");
+    }
+
+    [Fact]
+    public void BuildWelcomeBannerCommand_RunsAndyBanner()
+    {
+        var bytes = TerminalController.BuildWelcomeBannerCommand();
+        var text = System.Text.Encoding.UTF8.GetString(bytes);
         text.Should().Contain("/usr/local/bin/andy-banner",
             "new sessions show the welcome banner");
+    }
+
+    [Fact]
+    public void BuildWelcomeBannerCommand_SilencesBannerErrors()
+    {
+        var bytes = TerminalController.BuildWelcomeBannerCommand();
+        var text = System.Text.Encoding.UTF8.GetString(bytes);
         text.Should().Contain("2>/dev/null",
             "banner failure is silenced — a missing binary should not break the shell");
-        text.Should().EndWith("\n",
+        text.Should().Contain("; true",
+            "trailing `; true` swallows the exit code");
+    }
+
+    [Fact]
+    public void BuildWelcomeBannerCommand_TerminatesWithNewline()
+    {
+        var bytes = TerminalController.BuildWelcomeBannerCommand();
+        bytes[^1].Should().Be((byte)'\n',
             "trailing newline submits the command line");
     }
 
     [Fact]
-    public void BuildPostAttachCommand_ExistingSession_ReturnsTmuxRefresh()
+    public void BuildWelcomeBannerCommand_DoesNotInjectTmuxCommands()
     {
-        var bytes = TerminalController.BuildPostAttachCommand(hasExistingSession: true);
+        // Regression guard: the previous version had a
+        // hasExistingSession=true branch that returned
+        // "tmux refresh-client -S\n", which got TYPED into the user's
+        // foreground process (bash → ran it; vim/claude → keystrokes
+        // landed in their input). Existing sessions now go through
+        // the tmux side channel via InvokeTmuxCommand. The banner
+        // helper must never embed a `tmux` command.
+        var bytes = TerminalController.BuildWelcomeBannerCommand();
         var text = System.Text.Encoding.UTF8.GetString(bytes);
-        text.Should().Be("tmux refresh-client -S\n",
-            "reattach forces a server-side redraw so the user sees a complete frame immediately");
-    }
-
-    [Fact]
-    public void BuildPostAttachCommand_DistinguishesNewVsExisting()
-    {
-        var newSession = TerminalController.BuildPostAttachCommand(hasExistingSession: false);
-        var existing = TerminalController.BuildPostAttachCommand(hasExistingSession: true);
-        newSession.Should().NotEqual(existing,
-            "new sessions and reattaches must inject different commands");
-    }
-
-    [Fact]
-    public void BuildPostAttachCommand_BothBranches_TerminateWithNewline()
-    {
-        var newBytes = TerminalController.BuildPostAttachCommand(hasExistingSession: false);
-        var existingBytes = TerminalController.BuildPostAttachCommand(hasExistingSession: true);
-        newBytes[^1].Should().Be((byte)'\n');
-        existingBytes[^1].Should().Be((byte)'\n');
+        text.Should().NotContain("tmux ",
+            "post-attach injection must not type tmux commands into the user's shell — those go through the side channel");
     }
 }


### PR DESCRIPTION
## Summary

Corrective fix for #838 (PR #147). The first cut wrote \`tmux refresh-client -S\\n\` to the inner shell's stdin on reattach. On a bash prompt that runs the command (visible to the user as a typed line + lands in shell history); inside a foreground program (vim, less, claude, etc.) the bytes land as keyboard input — corrupting the user's session.

Fix: route the redraw through the same side channel as \`tmux resize-window\` (#836). Spawn \`<provider> exec -u <user> <externalId> tmux refresh-client -S -t web\` against the per-UID tmux socket. The tmux server schedules a server-side redraw to every attached client; the user's foreground process sees no keystrokes, no command in history, no visible output line.

## Refactor

- New \`InvokeTmuxCommand\` helper generalises the side-channel pattern from \`ForwardResizeToTmux\`. Any out-of-band tmux server command (refresh-client, resize-window, kill-session, …) routes through it.
- \`ForwardResizeToTmux\` reduced to bounds-check + log + \`InvokeTmuxCommand\` — same behaviour, less duplication.
- \`BuildPostAttachCommand(bool)\` collapsed to \`BuildWelcomeBannerCommand()\` — the existing-session branch is obsolete, and removing it locks the rule \"no tmux commands ever land in stdin injection.\"
- Resize log bumped from \`LogDebug\` to \`LogInformation\` so the diagnostics console shows the resize chain without raising the global log level. This lets us verify the #836 fix is actually firing in the bundled-services build (sister symptom: status bar still accumulating).

## Test plan

- [x] 5 cases pinning \`BuildWelcomeBannerCommand\`:
  - starts with \`space + clear\`
  - runs \`/usr/local/bin/andy-banner\`
  - silences errors with \`2>/dev/null\` + \`; true\`
  - terminates with \`\\n\`
  - does NOT contain \`tmux \` (regression guard for the bug this PR fixes)
- [x] All 44 \`TerminalControllerTests\` pass under .NET 8.0.302.
- [ ] Manual: rebuild bundled binary, restart Conductor, open a terminal and reattach, verify no \`tmux refresh-client -S\` line appears in the user's shell.

## Worktree

\`.claude/worktrees/838-fix\` per the andy-containers worktree rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)