### PR TITLE
Debounced resize forwarder for terminal sessions (conductor #863)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/TerminalController.cs
+++ b/src/Andy.Containers.Api/Controllers/TerminalController.cs
@@ -386,6 +386,44 @@ public class TerminalController : ControllerBase
         // (e.g. arrow keys: \x1b[A, \x1b[B, etc.)
         // Also intercepts resize messages from the client to update the PTY size
         // via ioctl, which sends SIGWINCH to tmux so it redraws at the new size.
+        // Debounced resize forwarder (#863).
+        //
+        // The Ghostty renderer fires `onSurfaceResize` on every
+        // SwiftUI frame change — during a 200 ms inspector-collapse
+        // animation that's a dozen events at slightly different
+        // sizes. The previous "forward every resize" approach caused
+        // visible artifacts in TUI apps (claude, vim) because each
+        // forwarded `tmux resize-window` raced with the app's own
+        // writes.
+        //
+        // Strategy: collect resize messages, but only spawn the
+        // side-channel `tmux resize-window` AFTER a quiet period
+        // (250 ms with no new resize) AND only if the size actually
+        // changed since the last forwarded value. The animation's
+        // mid-frames are absorbed; tmux sees one resize at the end.
+        //
+        // Conductor #836 / #863. Pre-existing "status bar wraps
+        // inline at status-interval" is the alternative — strictly
+        // worse than this debounced approach for users on smaller
+        // displays.
+        var resizeDebouncer = new ResizeDebouncer(
+            providerCommand: execCommand,
+            externalId: externalId,
+            containerUser: containerUser,
+            tmuxSession: tmuxSession,
+            initialCols: cols,
+            initialRows: rows,
+            quietPeriod: TimeSpan.FromMilliseconds(250),
+            forward: (newCols, newRows) => ForwardResizeToTmux(
+                providerCommand: execCommand,
+                externalId: externalId,
+                containerUser: containerUser,
+                tmuxSession: tmuxSession,
+                cols: newCols,
+                rows: newRows,
+                ct: ct),
+            ct: ct);
+
         var wsToProcess = Task.Run(async () =>
         {
             var buffer = new byte[4096];
@@ -400,27 +438,9 @@ public class TerminalController : ControllerBase
 
                     if (result.Count > 0)
                     {
-                        // Drop client resize messages on the floor.
-                        //
-                        // Forwarding them via `tmux resize-window`
-                        // (the previous attempt) caused a feedback
-                        // cascade with the macOS Ghostty renderer,
-                        // and even with dedupe the side-channel
-                        // resize created visible artifacts in TUI
-                        // apps running inside tmux (claude code, vim)
-                        // — duplicated frames, partial redraws,
-                        // status bar wrapping inline.
-                        //
-                        // The pre-existing "status bar wraps at
-                        // status-interval" annoyance returns, but
-                        // it's strictly less broken than the
-                        // resize cascade. The proper fix lives in
-                        // #842 (multiplexer-aware mode) and a
-                        // ground-up rework of the script ↔ docker
-                        // exec ↔ bash ↔ tmux PTY chain. Conductor
-                        // #836 follow-up.
-                        if (result.Count > 10 && buffer[0] == '{' && IsResizeMessage(buffer, result.Count, out _, out _))
+                        if (result.Count > 10 && buffer[0] == '{' && IsResizeMessage(buffer, result.Count, out var newCols, out var newRows))
                         {
+                            resizeDebouncer.Observe(newCols, newRows);
                             continue;
                         }
 

--- a/src/Andy.Containers.Api/Services/ResizeDebouncer.cs
+++ b/src/Andy.Containers.Api/Services/ResizeDebouncer.cs
@@ -1,0 +1,155 @@
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// Collects terminal-resize messages and emits at most one
+/// <c>tmux resize-window</c> per quiet-period after the size has
+/// stabilised. Conductor #863.
+///
+/// The Ghostty renderer fires <c>onSurfaceResize</c> on every
+/// SwiftUI frame change (typically a dozen events during a 200 ms
+/// animation). Forwarding each one to <c>tmux resize-window</c> via
+/// the side channel (a) hammers the tmux server with redundant work
+/// and (b) raced with TUI apps running inside tmux, producing
+/// visible drawing artifacts. This debouncer absorbs the mid-frames
+/// and only forwards the final, stable value.
+///
+/// Behaviour:
+/// <list type="bullet">
+/// <item>First <c>Observe</c> after a quiet period restarts the timer.</item>
+/// <item>Subsequent <c>Observe</c> calls within the quiet period
+/// reset the timer — the forwarder fires once after the LAST
+/// observed value sits unchanged for <c>quietPeriod</c>.</item>
+/// <item>If the final stable size matches the last forwarded value
+/// (no actual change), the forward is skipped.</item>
+/// <item>Cancellation via the constructor's token cleanly stops any
+/// pending fire.</item>
+/// </list>
+/// </summary>
+public sealed class ResizeDebouncer
+{
+    private readonly TimeSpan _quietPeriod;
+    private readonly Action<int, int> _forward;
+    private readonly CancellationToken _ct;
+    private readonly object _gate = new();
+
+    private int _pendingCols;
+    private int _pendingRows;
+    private int _lastForwardedCols;
+    private int _lastForwardedRows;
+    private CancellationTokenSource? _pendingCts;
+
+    /// <summary>
+    /// Number of times <see cref="_forward"/> has fired. Visible
+    /// to tests for verifying debounce semantics.
+    /// </summary>
+    public int ForwardCount { get; private set; }
+
+    public ResizeDebouncer(
+        string providerCommand,
+        string externalId,
+        string containerUser,
+        string tmuxSession,
+        int initialCols,
+        int initialRows,
+        TimeSpan quietPeriod,
+        Action<int, int> forward,
+        CancellationToken ct)
+    {
+        _quietPeriod = quietPeriod;
+        _forward = forward;
+        _ct = ct;
+        _lastForwardedCols = initialCols;
+        _lastForwardedRows = initialRows;
+        _pendingCols = initialCols;
+        _pendingRows = initialRows;
+        // Provider/externalId/containerUser/tmuxSession are bound
+        // into the `forward` closure by the caller; we don't store
+        // them here.
+        _ = providerCommand;
+        _ = externalId;
+        _ = containerUser;
+        _ = tmuxSession;
+    }
+
+    /// <summary>
+    /// Records an incoming resize event. The actual forward fires
+    /// after <see cref="_quietPeriod"/> elapses with no further
+    /// <c>Observe</c> calls.
+    /// </summary>
+    public void Observe(int cols, int rows)
+    {
+        if (cols <= 0 || rows <= 0) return;
+
+        CancellationTokenSource newCts;
+        lock (_gate)
+        {
+            _pendingCols = cols;
+            _pendingRows = rows;
+            _pendingCts?.Cancel();
+            _pendingCts = CancellationTokenSource.CreateLinkedTokenSource(_ct);
+            newCts = _pendingCts;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(_quietPeriod, newCts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            int colsToForward, rowsToForward;
+            lock (_gate)
+            {
+                if (newCts != _pendingCts) return; // superseded
+                if (_pendingCols == _lastForwardedCols && _pendingRows == _lastForwardedRows)
+                {
+                    return;
+                }
+                colsToForward = _pendingCols;
+                rowsToForward = _pendingRows;
+                _lastForwardedCols = colsToForward;
+                _lastForwardedRows = rowsToForward;
+                ForwardCount++;
+            }
+
+            try
+            {
+                _forward(colsToForward, rowsToForward);
+            }
+            catch
+            {
+                // The forward closure handles its own logging.
+                // Swallow here so a single failure doesn't kill the
+                // debouncer.
+            }
+        }, _ct);
+    }
+
+    /// <summary>
+    /// Test-only: synchronously fires a single forward with the
+    /// most recently observed values, regardless of quiet-period
+    /// state. Useful for asserting the dedupe / no-change branches
+    /// without sleeping in tests.
+    /// </summary>
+    internal void FlushForTesting()
+    {
+        int colsToForward, rowsToForward;
+        lock (_gate)
+        {
+            if (_pendingCols == _lastForwardedCols && _pendingRows == _lastForwardedRows)
+            {
+                return;
+            }
+            colsToForward = _pendingCols;
+            rowsToForward = _pendingRows;
+            _lastForwardedCols = colsToForward;
+            _lastForwardedRows = rowsToForward;
+            ForwardCount++;
+        }
+        _forward(colsToForward, rowsToForward);
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Services/ResizeDebouncerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ResizeDebouncerTests.cs
@@ -1,0 +1,225 @@
+using Andy.Containers.Api.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ResizeDebouncer"/> (conductor #863).
+/// Cover the contract that animation-frame storms produce one
+/// forward, that no-change inputs are skipped, and that the timer
+/// resets correctly when new observations arrive within the quiet
+/// period.
+/// </summary>
+public class ResizeDebouncerTests
+{
+    private record Forwarded(int Cols, int Rows);
+
+    private (ResizeDebouncer debouncer, List<Forwarded> log) CreateDebouncer(
+        int initialCols = 80,
+        int initialRows = 24,
+        TimeSpan? quietPeriod = null)
+    {
+        var log = new List<Forwarded>();
+        var debouncer = new ResizeDebouncer(
+            providerCommand: "docker",
+            externalId: "ext-test",
+            containerUser: "test-user",
+            tmuxSession: "web",
+            initialCols: initialCols,
+            initialRows: initialRows,
+            quietPeriod: quietPeriod ?? TimeSpan.FromMilliseconds(50),
+            forward: (c, r) =>
+            {
+                lock (log) { log.Add(new Forwarded(c, r)); }
+            },
+            ct: CancellationToken.None);
+        return (debouncer, log);
+    }
+
+    // MARK: - Single observation
+
+    [Fact]
+    public async Task SingleObservation_ForwardsAfterQuietPeriod()
+    {
+        var (d, log) = CreateDebouncer(initialCols: 80, initialRows: 24);
+        d.Observe(120, 40);
+
+        await Task.Delay(150);
+
+        log.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new Forwarded(120, 40));
+        d.ForwardCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SingleObservation_MatchingInitial_DoesNotForward()
+    {
+        // The initial size is the value that was used to create
+        // the tmux session. An incoming resize at the same size is
+        // a no-op — no need to spawn a tmux exec.
+        var (d, log) = CreateDebouncer(initialCols: 120, initialRows: 40);
+        d.Observe(120, 40);
+
+        await Task.Delay(150);
+
+        log.Should().BeEmpty(
+            "the size matches the initial value the session was created with");
+        d.ForwardCount.Should().Be(0);
+    }
+
+    // MARK: - Animation storm
+
+    [Fact]
+    public async Task AnimationStorm_ProducesSingleForwardAtEnd()
+    {
+        // Simulates an inspector-collapse animation: 12 events at
+        // intermediate widths, the final value is 200x40.
+        var (d, log) = CreateDebouncer(initialCols: 100, initialRows: 30);
+
+        for (int width = 100; width <= 200; width += 10)
+        {
+            d.Observe(width, 30);
+            await Task.Delay(20); // intra-animation interval
+        }
+
+        // Settle past the quiet period.
+        await Task.Delay(150);
+
+        log.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new Forwarded(200, 30),
+                "only the final stable value reaches tmux");
+        d.ForwardCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AnimationStorm_QuietPeriodResetsOnEachObservation()
+    {
+        // Rapid-fire observations within the quiet period should
+        // postpone the forward. If we only waited for the FIRST
+        // observation's quiet period the forward would fire mid-storm.
+        var quietPeriod = TimeSpan.FromMilliseconds(100);
+        var (d, log) = CreateDebouncer(quietPeriod: quietPeriod);
+
+        // Six observations 50 ms apart — each one should reset the
+        // timer, so total elapsed at the last one is 300 ms but
+        // the forward should not have fired yet because the quiet
+        // period (100 ms) hasn't elapsed since the last observation.
+        for (int i = 0; i < 6; i++)
+        {
+            d.Observe(100 + i, 30);
+            await Task.Delay(50);
+        }
+
+        log.Should().BeEmpty(
+            "the timer should still be pending — last observation was 50 ms ago, quiet period is 100 ms");
+
+        await Task.Delay(150);
+
+        log.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new Forwarded(105, 30));
+    }
+
+    // MARK: - Distinct settle points
+
+    [Fact]
+    public async Task TwoSettlePoints_EachProduceAForward()
+    {
+        var (d, log) = CreateDebouncer();
+
+        d.Observe(120, 40);
+        await Task.Delay(150);
+        d.Observe(160, 40);
+        await Task.Delay(150);
+
+        log.Should().HaveCount(2);
+        log[0].Should().BeEquivalentTo(new Forwarded(120, 40));
+        log[1].Should().BeEquivalentTo(new Forwarded(160, 40));
+        d.ForwardCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task SecondSettleAtSameSize_DoesNotForwardAgain()
+    {
+        var (d, log) = CreateDebouncer();
+
+        d.Observe(120, 40);
+        await Task.Delay(150);
+        // Same value again — should be skipped.
+        d.Observe(120, 40);
+        await Task.Delay(150);
+
+        log.Should().ContainSingle();
+        d.ForwardCount.Should().Be(1);
+    }
+
+    // MARK: - Validation
+
+    [Theory]
+    [InlineData(0, 24)]
+    [InlineData(80, 0)]
+    [InlineData(-1, 24)]
+    [InlineData(80, -1)]
+    public async Task NonPositiveValues_AreIgnored(int cols, int rows)
+    {
+        var (d, log) = CreateDebouncer(initialCols: 80, initialRows: 24);
+        d.Observe(cols, rows);
+
+        await Task.Delay(150);
+
+        log.Should().BeEmpty();
+        d.ForwardCount.Should().Be(0);
+    }
+
+    // MARK: - Cancellation
+
+    [Fact]
+    public async Task ObserveAfterTokenCancellation_DoesNotFire()
+    {
+        var cts = new CancellationTokenSource();
+        var log = new List<Forwarded>();
+        var d = new ResizeDebouncer(
+            providerCommand: "docker",
+            externalId: "ext-test",
+            containerUser: "test-user",
+            tmuxSession: "web",
+            initialCols: 80,
+            initialRows: 24,
+            quietPeriod: TimeSpan.FromMilliseconds(50),
+            forward: (c, r) =>
+            {
+                lock (log) { log.Add(new Forwarded(c, r)); }
+            },
+            ct: cts.Token);
+
+        d.Observe(120, 40);
+        cts.Cancel();
+        await Task.Delay(150);
+
+        log.Should().BeEmpty(
+            "cancelling the token should suppress any pending forward");
+    }
+
+    // MARK: - FlushForTesting
+
+    [Fact]
+    public void FlushForTesting_ForwardsCurrentPending()
+    {
+        var (d, log) = CreateDebouncer();
+        d.Observe(180, 50);
+        d.FlushForTesting();
+
+        log.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new Forwarded(180, 50));
+    }
+
+    [Fact]
+    public void FlushForTesting_SkipsWhenAlreadyAtThatSize()
+    {
+        var (d, log) = CreateDebouncer(initialCols: 100, initialRows: 30);
+        d.Observe(100, 30); // matches initial — already-at-size
+        d.FlushForTesting();
+
+        log.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Re-introduce client-resize forwarding to tmux, this time with a proper debounce that handles the macOS Ghostty renderer's animation-frame storm (a dozen \`onSurfaceResize\` events during a 200 ms inspector-collapse animation).

Closes [conductor #863](https://github.com/rivoli-ai/conductor/issues/863). Re-opens proper support for [conductor #836](https://github.com/rivoli-ai/conductor/issues/836) without the artifacts that #145 / #147 / #150 / #151 / #152 cycled through.

## Strategy

- Collect resize messages into a new \`ResizeDebouncer\` actor.
- Only spawn \`tmux resize-window\` AFTER **250 ms** with no further resize observation AND only when the size actually changed since the last forwarded value.
- Animation mid-frames are absorbed; tmux sees one resize at the end. No cascade — \`tmux resize-window\`'s redraw doesn't re-trigger SwiftUI frame changes, only application content does.

## Why the previous attempts failed

| Attempt | Problem |
|---|---|
| PR #145 (every-resize forward) | Hammered tmux every animation frame |
| PR #151 (dedupe by \`(cols, rows)\`) | Ghostty interpolates pixel sizes through animation, so consecutive events have slightly different grid sizes — dedupe missed them |
| Both | Raced with TUI apps' own writes inside tmux, producing visible artifacts (claude / vim partial-frame corruption) |

Quiet-period debounce sidesteps both: by the time we forward, the animation is over and the size is stable, and we send exactly one \`resize-window\` per real settle.

## Test plan

13 new tests for \`ResizeDebouncer\` + 44 prior \`TerminalControllerTests\`:

- [x] Single observation forwards after quiet period.
- [x] Single observation matching the initial size is skipped.
- [x] 12-event animation storm produces ONE forward at the final size.
- [x] Quiet period restarts on every observation (rapid-fire 50 ms intervals don't fire mid-storm; only after 100 ms quiet).
- [x] Two distinct settle points produce two forwards.
- [x] Same-size second settle is skipped.
- [x] Non-positive values (0, -1) ignored.
- [x] Cancellation suppresses pending forwards.
- [x] \`FlushForTesting\` helper for synchronous test assertions.
- [x] All 57 tests pass under .NET 8.0.302.
- [ ] Manual: collapse the inspector in Conductor's WorkspaceDetailView, verify the terminal content reflows to the new width within ~250 ms (one tmux redraw, no artifacts).

## Worktree

\`.claude/worktrees/863-resize-debounce\` per the andy-containers worktree rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)