### PR TITLE
TerminalController: dtach for session persistence (replaces tmux)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/TerminalController.cs
+++ b/src/Andy.Containers.Api/Controllers/TerminalController.cs
@@ -179,13 +179,7 @@ public class TerminalController : ControllerBase
         var checkExisting = providerType == ProviderType.AppleContainer ? "container" : "docker";
         _ = checkExisting;
 
-        var shellCmd = $"stty rows {rows} cols {cols} 2>/dev/null; " +
-                       $"export TERM=xterm-256color LANG=C.UTF-8 LC_ALL=C.UTF-8; " +
-                       $"[ -f /etc/profile ] && . /etc/profile 2>/dev/null; " +
-                       $"[ -f /etc/bash.bashrc ] && . /etc/bash.bashrc 2>/dev/null; " +
-                       $"[ -f ~/.profile ] && . ~/.profile 2>/dev/null; " +
-                       $"[ -f ~/.bashrc ] && . ~/.bashrc 2>/dev/null; " +
-                       $"exec bash -i";
+        var shellCmd = BuildContainerShellCommand(rows: rows, cols: cols);
 
         var execCommand = providerType == ProviderType.AppleContainer ? "container" : "docker";
 
@@ -641,6 +635,46 @@ public class TerminalController : ControllerBase
     internal static bool IsValidTerminalSize(int cols, int rows)
     {
         return cols >= 2 && cols <= 1000 && rows >= 2 && rows <= 1000;
+    }
+
+    /// <summary>
+    /// Builds the shell command piped into <c>docker exec -it … bash
+    /// -c '…'</c> to start a terminal session inside the container.
+    ///
+    /// Sets up the inner PTY (stty), exports a sensible TERM / locale,
+    /// sources rcfiles, then runs an interactive shell — wrapped in
+    /// <c>dtach</c> when available so the bash session survives across
+    /// WebSocket close/reopen. When dtach isn't installed (existing
+    /// containers, minimal images), the command falls back to bare
+    /// <c>bash -i</c> so the terminal still works without persistence.
+    ///
+    /// dtach replaced the previous tmux block (#154 / #842 preview).
+    /// Tmux's <c>resize-window</c> + script-PTY chain produced
+    /// rendering artifacts in TUI apps like claude code; dtach's
+    /// transparent SIGWINCH forwarding sidesteps those entirely.
+    /// </summary>
+    /// <remarks>
+    /// Internal for unit tests. Pure function — no side effects, no
+    /// DI dependencies. Tests pin the dtach-with-fallback shape so
+    /// future changes don't silently lose persistence.
+    /// </remarks>
+    internal static string BuildContainerShellCommand(int rows, int cols)
+    {
+        // Bound the shell socket name to the per-container filesystem.
+        // The container's /tmp is private to the container, so this
+        // path doesn't collide with anything on the host or other
+        // containers. Using a fixed name (not per-WS) is what gives
+        // us "close terminal, reopen, you're back" — every attach
+        // hits the same socket.
+        const string DtachSocket = "/tmp/conductor.sock";
+
+        return $"stty rows {rows} cols {cols} 2>/dev/null; " +
+               $"export TERM=xterm-256color LANG=C.UTF-8 LC_ALL=C.UTF-8; " +
+               $"[ -f /etc/profile ] && . /etc/profile 2>/dev/null; " +
+               $"[ -f /etc/bash.bashrc ] && . /etc/bash.bashrc 2>/dev/null; " +
+               $"[ -f ~/.profile ] && . ~/.profile 2>/dev/null; " +
+               $"[ -f ~/.bashrc ] && . ~/.bashrc 2>/dev/null; " +
+               $"command -v dtach >/dev/null 2>&1 && exec dtach -A {DtachSocket} -z bash -i || exec bash -i";
     }
 
     private static bool IsResizeMessage(byte[] buffer, int count, out int cols, out int rows)

--- a/src/Andy.Containers.Api/Services/ContainerProvisioningWorker.cs
+++ b/src/Andy.Containers.Api/Services/ContainerProvisioningWorker.cs
@@ -392,6 +392,16 @@ command -v fastfetch >/dev/null 2>&1 || {{
     command -v apt-get >/dev/null 2>&1 && apt-get install -y -qq fastfetch >/dev/null 2>&1
 }} || true
 
+# Install dtach for terminal session persistence (#tmux-replacement).
+# Tiny C tool (~600 lines) that lets a bash session survive across
+# WebSocket close/reopen without tmux's resize/redraw quirks.
+# TerminalController falls back to plain bash when dtach is missing,
+# so existing containers still work — they just lose persistence.
+command -v dtach >/dev/null 2>&1 || {{
+    command -v apk >/dev/null 2>&1 && apk add --no-cache dtach >/dev/null 2>&1
+    command -v apt-get >/dev/null 2>&1 && apt-get install -y -qq dtach >/dev/null 2>&1
+}} || true
+
 # Create custom fastfetch config for Andy Containers
 mkdir -p /etc/fastfetch
 cat > /etc/fastfetch/config.jsonc << 'FFCONF'

--- a/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
@@ -379,6 +379,84 @@ public class TerminalControllerTests : IDisposable
             "trailing newline submits the command line");
     }
 
+    // MARK: - BuildContainerShellCommand (dtach + fallback)
+
+    [Fact]
+    public void BuildContainerShellCommand_SetsPtySize()
+    {
+        var cmd = TerminalController.BuildContainerShellCommand(rows: 40, cols: 120);
+        cmd.Should().Contain("stty rows 40 cols 120",
+            "the inner PTY's reported size must match what the renderer asked for");
+    }
+
+    [Fact]
+    public void BuildContainerShellCommand_ExportsXTermAndLocale()
+    {
+        var cmd = TerminalController.BuildContainerShellCommand(rows: 40, cols: 120);
+        cmd.Should().Contain("TERM=xterm-256color",
+            "256-color is what claude / vim / less expect");
+        cmd.Should().Contain("LANG=C.UTF-8");
+        cmd.Should().Contain("LC_ALL=C.UTF-8",
+            "UTF-8 locale is needed for emoji / box-drawing characters");
+    }
+
+    [Fact]
+    public void BuildContainerShellCommand_SourcesRcfiles()
+    {
+        var cmd = TerminalController.BuildContainerShellCommand(rows: 40, cols: 120);
+        cmd.Should().Contain("/etc/profile");
+        cmd.Should().Contain("/etc/bash.bashrc");
+        cmd.Should().Contain("~/.profile");
+        cmd.Should().Contain("~/.bashrc");
+    }
+
+    [Fact]
+    public void BuildContainerShellCommand_PrefersDtachWhenAvailable()
+    {
+        var cmd = TerminalController.BuildContainerShellCommand(rows: 40, cols: 120);
+        cmd.Should().Contain("command -v dtach",
+            "must check for dtach before invoking it");
+        cmd.Should().Contain("exec dtach -A /tmp/conductor.sock -z bash -i",
+            "dtach gets a fixed socket per container so reattach works");
+    }
+
+    [Fact]
+    public void BuildContainerShellCommand_FallsBackToBareBashWhenDtachMissing()
+    {
+        var cmd = TerminalController.BuildContainerShellCommand(rows: 40, cols: 120);
+        cmd.Should().Contain("|| exec bash -i",
+            "containers without dtach installed must still get a working terminal");
+    }
+
+    [Fact]
+    public void BuildContainerShellCommand_DtachUsesAttachOrCreate()
+    {
+        var cmd = TerminalController.BuildContainerShellCommand(rows: 40, cols: 120);
+        cmd.Should().Contain("dtach -A",
+            "the -A flag means 'attach if exists, create if not' — what gives us persistence across reconnects");
+    }
+
+    [Fact]
+    public void BuildContainerShellCommand_DtachUsesQuietMode()
+    {
+        var cmd = TerminalController.BuildContainerShellCommand(rows: 40, cols: 120);
+        cmd.Should().Contain("dtach -A /tmp/conductor.sock -z bash",
+            "the -z flag suppresses dtach's own escape sequences so the terminal output is clean");
+    }
+
+    [Fact]
+    public void BuildContainerShellCommand_DoesNotMentionTmux()
+    {
+        // Regression guard: tmux was removed in #154 / #842 preview
+        // because it caused rendering artifacts in TUI apps. dtach
+        // is the replacement. If anyone re-introduces tmux into the
+        // shell command without going through #842's per-mode
+        // picker, this test fires.
+        var cmd = TerminalController.BuildContainerShellCommand(rows: 40, cols: 120);
+        cmd.Should().NotContain("tmux ",
+            "tmux must not appear in the shell command — use dtach for persistence");
+    }
+
     [Fact]
     public void BuildWelcomeBannerCommand_DoesNotInjectTmuxCommands()
     {


### PR DESCRIPTION
Switches the container terminal's session-multiplexer from tmux back to dtach — a tiny C tool (~600 lines) that gives "close terminal, reopen, you're back" without tmux's resize/redraw quirks.

## Why dtach over tmux

- dtach forwards SIGWINCH from the attaching client to the inner shell directly. No `resize-window` games, no smallest-client clamp, no rendering-artifact races with TUI apps.
- No status bar, no keybindings, no chrome.
- Multiplayer by default: same socket, multiple attaches see the same content. Today gated by `RequirePermission` + `CanAccess`. Future feature: relax for collaborators → real pair-coding.

## How to revert

Single `git revert` of this commit. The dtach branch falls back to bare-bash when dtach isn't installed, so existing containers without dtach keep working — they just lose persistence until they're recreated.

## Test plan

- [x] 8 new tests for `BuildContainerShellCommand` covering: stty, TERM, locale, rcfile sourcing, dtach prefix, fallback, regression guard against tmux re-introduction.
- [x] All 65 `TerminalController + ResizeDebouncer` tests pass under .NET 8.0.302.
- [ ] Manual: open terminal, run claude code, type something, close terminal. Reopen — should see the same claude session resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)