### PR TITLE
Hotfix: stop auto-installing dtach in the provisioning script

### DIFF
--- a/src/Andy.Containers.Api/Services/ContainerProvisioningWorker.cs
+++ b/src/Andy.Containers.Api/Services/ContainerProvisioningWorker.cs
@@ -392,15 +392,15 @@ command -v fastfetch >/dev/null 2>&1 || {{
     command -v apt-get >/dev/null 2>&1 && apt-get install -y -qq fastfetch >/dev/null 2>&1
 }} || true
 
-# Install dtach for terminal session persistence (#tmux-replacement).
-# Tiny C tool (~600 lines) that lets a bash session survive across
-# WebSocket close/reopen without tmux's resize/redraw quirks.
-# TerminalController falls back to plain bash when dtach is missing,
-# so existing containers still work — they just lose persistence.
-command -v dtach >/dev/null 2>&1 || {{
-    command -v apk >/dev/null 2>&1 && apk add --no-cache dtach >/dev/null 2>&1
-    command -v apt-get >/dev/null 2>&1 && apt-get install -y -qq dtach >/dev/null 2>&1
-}} || true
+# Note: dtach (terminal session persistence) is NOT installed here.
+# An earlier version of this script tried `apt-get install dtach`,
+# but on containers whose apt cache hasn't been refreshed the install
+# hangs against the 30-second exec timeout — leaving the container
+# stuck in Creating for ~30s and breaking new-container UX.
+# Containers can install dtach manually with `apt-get update &&
+# apt-get install -y dtach` and the bash session will be wrapped in
+# dtach on the next reattach. Tracking proper install-at-image-build
+# under conductor #842.
 
 # Create custom fastfetch config for Andy Containers
 mkdir -p /etc/fastfetch


### PR DESCRIPTION
The dtach install I added in PR #155 was inside the welcome-banner exec, which runs against a 30-second timeout. On containers whose apt cache hasn't been refreshed, `apt-get install -y -qq dtach` hangs trying to fetch package lists, hits the timeout, and leaves the container stuck in Creating state for ~30 s instead of the usual sub-second transition. New-terminal clicks during this window get HTTP/1.1 400 "Container is Creating, must be Running" — surfaced to the user as the opaque `[TERM-WS-HANDSHAKE]` error.

Reverting just the install call. The detection logic in `BuildContainerShellCommand` stays — containers with dtach installed (manually or via base-image build) get persistence; others fall back to bare bash. No behavioural regression for containers without dtach; significant UX win for new-container provisioning speed.

Tracked: dtach-at-image-build-time should land in the Dockerfile under [conductor #842](https://github.com/rivoli-ai/conductor/issues/842), not in the provisioning exec script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)