### PR TITLE
AP6: wire ExecAsync timeout to limits.timeout_seconds + grace

### DIFF
--- a/src/Andy.Containers.Api/Services/HeadlessRunner.cs
+++ b/src/Andy.Containers.Api/Services/HeadlessRunner.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
+using System.Text.Json;
 using Andy.Containers.Abstractions;
+using Andy.Containers.Configurator;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Infrastructure.Messaging;
 using Andy.Containers.Messaging.Events;
@@ -14,11 +16,18 @@ public sealed class HeadlessRunner : IHeadlessRunner
     private readonly ContainersDbContext _db;
     private readonly ILogger<HeadlessRunner> _logger;
 
-    // Generous upper bound on a single headless run. AQ3 will wire
-    // limits.timeout_seconds-aware spawning; until then this is the only
-    // ceiling between us and a hung process. ExecAsync surfaces a timeout
-    // by throwing OperationCanceledException, which we map to Failed.
-    private static readonly TimeSpan DefaultExecTimeout = TimeSpan.FromMinutes(15);
+    // Outer-watchdog grace: AQ3 honours limits.timeout_seconds internally
+    // and exits with code 4 (→ RunEventKind.Timeout) when its CTS fires.
+    // We let it have a head start before our outer ExecAsync ceiling so
+    // the AQ3 self-timeout is what we observe — the outer one is reserved
+    // for genuinely hung processes that don't honour their own deadline.
+    private static readonly TimeSpan OuterGrace = TimeSpan.FromSeconds(30);
+
+    // Fallback when the config file isn't readable or doesn't pin a
+    // positive timeout. Pre-AQ3, this was the only ceiling. Now it's
+    // a defensive default — every well-formed config carries
+    // limits.timeout_seconds.
+    private static readonly TimeSpan FallbackExecTimeout = TimeSpan.FromMinutes(15);
 
     public HeadlessRunner(
         IContainerService containers,
@@ -64,14 +73,15 @@ public sealed class HeadlessRunner : IHeadlessRunner
         await _db.SaveChangesAsync(ct);
 
         var command = $"andy-cli run --headless --config {ShellEscape(configPath)}";
+        var execTimeout = await ResolveExecTimeoutAsync(configPath, ct);
         ExecResult result;
         try
         {
             _logger.LogInformation(
-                "Spawning headless agent for Run {RunId} in container {ContainerId} with config {ConfigPath}",
-                run.Id, containerId, configPath);
+                "Spawning headless agent for Run {RunId} in container {ContainerId} with config {ConfigPath} (outer timeout {Seconds}s)",
+                run.Id, containerId, configPath, (int)execTimeout.TotalSeconds);
 
-            result = await _containers.ExecAsync(containerId, command, DefaultExecTimeout, ct);
+            result = await _containers.ExecAsync(containerId, command, execTimeout, ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -192,6 +202,38 @@ public sealed class HeadlessRunner : IHeadlessRunner
                 "Run {RunId} could not transition {From} → {To}: {Message}",
                 run.Id, run.Status, next, ex.Message);
         }
+    }
+
+    // Read the config AP3 just wrote and pull limits.timeout_seconds so
+    // our outer ExecAsync ceiling is config-driven (with a small grace
+    // period above AQ3's internal deadline). On any read/parse failure
+    // we fall back to FallbackExecTimeout — a malformed config is
+    // surfaced as an exit-code mismatch from andy-cli rather than as a
+    // timeout-resolution crash here.
+    private async Task<TimeSpan> ResolveExecTimeoutAsync(string configPath, CancellationToken ct)
+    {
+        try
+        {
+            var json = await File.ReadAllTextAsync(configPath, ct);
+            var config = JsonSerializer.Deserialize<HeadlessRunConfig>(json, HeadlessConfigJson.Options);
+            var inner = config?.Limits?.TimeoutSeconds ?? 0;
+            if (inner > 0)
+            {
+                return TimeSpan.FromSeconds(inner) + OuterGrace;
+            }
+
+            _logger.LogWarning(
+                "Config at {Path} has limits.timeout_seconds={Inner}; using fallback {Fallback}s",
+                configPath, inner, (int)FallbackExecTimeout.TotalSeconds);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex,
+                "Could not read limits.timeout_seconds from {Path}; using fallback {Fallback}s",
+                configPath, (int)FallbackExecTimeout.TotalSeconds);
+        }
+
+        return FallbackExecTimeout;
     }
 
     // POSIX single-quote escape — safe for /bin/sh -c "...". Single quotes

--- a/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
@@ -189,6 +189,74 @@ public class HeadlessRunnerTests : IDisposable
     }
 
     [Fact]
+    public async Task StartAsync_ReadsLimitsTimeoutSecondsFromConfig_AddsGrace()
+    {
+        // AP6's outer ExecAsync ceiling is config-driven: limits.timeout_seconds
+        // + a 30s grace. The grace gives AQ3 a head start so its own internal
+        // CTS fires first (mapping to exit code 4 → RunEventKind.Timeout)
+        // before our outer watchdog kicks in. Without it, both fire
+        // simultaneously and we lose the ability to distinguish a self-timeout
+        // from a hung process.
+        var run = SeedRun();
+        var configPath = WriteRealConfig(timeoutSeconds: 120);
+
+        TimeSpan? capturedTimeout = null;
+        _containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, CancellationToken>((_, _, t, _) => capturedTimeout = t)
+            .ReturnsAsync(new ExecResult { ExitCode = 0 });
+
+        await _runner.StartAsync(run, configPath);
+
+        capturedTimeout.Should().Be(TimeSpan.FromSeconds(150),
+            "120s inner + 30s grace should land at ExecAsync.");
+    }
+
+    [Fact]
+    public async Task StartAsync_ConfigUnreadable_FallsBackToFifteenMinuteDefault()
+    {
+        // A missing/malformed config file must not crash the runner — fall
+        // back to the legacy 15-min ceiling so a misconfigured run still
+        // terminates instead of hanging on the inner CTS that AQ3 also
+        // refuses to set up.
+        var run = SeedRun();
+        var missingPath = Path.Combine(Path.GetTempPath(), $"never-existed-{Guid.NewGuid():N}.json");
+
+        TimeSpan? capturedTimeout = null;
+        _containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, CancellationToken>((_, _, t, _) => capturedTimeout = t)
+            .ReturnsAsync(new ExecResult { ExitCode = 0 });
+
+        await _runner.StartAsync(run, missingPath);
+
+        capturedTimeout.Should().Be(TimeSpan.FromMinutes(15));
+    }
+
+    [Fact]
+    public async Task StartAsync_ConfigTimeoutZero_FallsBackToFifteenMinuteDefault()
+    {
+        // A schema-valid config can still carry a non-positive timeout;
+        // fall back rather than calling ExecAsync with a zero / negative
+        // ceiling that the underlying provider would interpret unpredictably.
+        var run = SeedRun();
+        var configPath = WriteRealConfig(timeoutSeconds: 0);
+
+        TimeSpan? capturedTimeout = null;
+        _containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, CancellationToken>((_, _, t, _) => capturedTimeout = t)
+            .ReturnsAsync(new ExecResult { ExitCode = 0 });
+
+        await _runner.StartAsync(run, configPath);
+
+        capturedTimeout.Should().Be(TimeSpan.FromMinutes(15));
+    }
+
+    [Fact]
     public async Task StartAsync_OutboxRowCarriesCorrelationIdFromRun()
     {
         var correlation = Guid.NewGuid();
@@ -200,6 +268,27 @@ public class HeadlessRunnerTests : IDisposable
         var entry = await _db.OutboxEntries.SingleAsync();
         entry.CorrelationId.Should().Be(correlation,
             "ADR-0001 root-causation chain must propagate from the Run");
+    }
+
+    // Writes a real headless config to a temp file so the runner can
+    // parse limits.timeout_seconds. Other fields are placeholders — only
+    // the limits block is exercised by these tests, but a complete object
+    // round-trips through HeadlessConfigJson.Options without touching the
+    // schema validator (validation is andy-cli's job).
+    private static string WriteRealConfig(int timeoutSeconds, int maxIterations = 4)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"ap6-test-{Guid.NewGuid():N}.json");
+        var config = new Andy.Containers.Configurator.HeadlessRunConfig
+        {
+            RunId = Guid.NewGuid(),
+            Limits = new Andy.Containers.Configurator.HeadlessLimits
+            {
+                MaxIterations = maxIterations,
+                TimeoutSeconds = timeoutSeconds,
+            },
+        };
+        File.WriteAllText(path, Andy.Containers.Configurator.HeadlessConfigJson.Serialize(config));
+        return path;
     }
 
     private void SetupExec(Guid containerId, int exitCode, string? stdOut = null, string? stdErr = null)


### PR DESCRIPTION
## Summary

The hardcoded 15-minute `DefaultExecTimeout` in `HeadlessRunner` was the only ceiling on a headless run before AQ3 landed. Now that AQ3 honours `limits.timeout_seconds` internally — exiting with code 4 (→ `RunEventKind.Timeout`) when its own CTS fires — AP6's outer ceiling should track the same field plus a small grace.

## Why a grace period

Without it, both timeouts fire at the same instant and we lose the ability to distinguish a self-timeout (clean, attributable to the agent) from a hung process (genuine watchdog case). Letting AQ3's deadline land first by 30s means the typical timeout path is the one we observe in the outbox; the outer `ExecAsync` ceiling stays reserved for AQ3 not honouring its own contract.

## What changed in `HeadlessRunner`

- Reads the same config file AP3 just wrote (existing path arg, no new parameter).
- Pulls `limits.timeout_seconds` via the existing `HeadlessRunConfig` record + `HeadlessConfigJson.Options`.
- Computes `outer = inner + 30s` grace.
- Falls back to the legacy 15-min default if the file is missing, malformed, or carries a non-positive timeout — logs a warning so the operator notices.
- Logs the resolved timeout on the spawn-info line for observability.

## Test plan

- [x] `dotnet test --filter HeadlessRunnerTests` — 15/15 pass.
  - 12 existing tests still pass (their config paths point at `/tmp/x/config.json` which never exists, so the helper falls through to the 15-min default — preserving prior behaviour).
  - `StartAsync_ReadsLimitsTimeoutSecondsFromConfig_AddsGrace` — writes a real config with `timeout_seconds=120`, asserts the captured `ExecAsync` timeout is exactly 150s.
  - `StartAsync_ConfigUnreadable_FallsBackToFifteenMinuteDefault` — missing path → 15-min fallback.
  - `StartAsync_ConfigTimeoutZero_FallsBackToFifteenMinuteDefault` — schema-valid config with `timeout_seconds=0` → 15-min fallback (rather than passing zero to `ExecAsync`).
- [x] `dotnet test` (full Api.Tests) — 695 passed, 1 skipped (AP6→AQ3 smoke, opt-in), 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)