### PR TITLE
X1: EnvironmentProfile entity + EF migration

### DIFF
--- a/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
+++ b/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
@@ -25,6 +25,7 @@ public class ContainersDbContext : DbContext
     public DbSet<ImageBuildRecord> ImageBuildRecords => Set<ImageBuildRecord>();
     public DbSet<OutboxEntry> OutboxEntries => Set<OutboxEntry>();
     public DbSet<Run> Runs => Set<Run>();
+    public DbSet<EnvironmentProfile> EnvironmentProfiles => Set<EnvironmentProfile>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -272,6 +273,26 @@ public class ContainersDbContext : DbContext
             {
                 wr.Property(w => w.WorkspaceId).HasColumnName("WorkspaceRef_WorkspaceId");
                 wr.Property(w => w.Branch).HasColumnName("WorkspaceRef_Branch").HasMaxLength(200);
+            });
+        });
+
+        // EnvironmentProfile — catalog of runtime shapes (X1, rivoli-ai/andy-containers#90).
+        // Capabilities is stored as JSON via OwnsOne(...).ToJson() so the envelope can
+        // grow without a per-field migration; Postgres uses native jsonb, SQLite stores
+        // it as TEXT — both round-trip the same CLR object.
+        modelBuilder.Entity<EnvironmentProfile>(e =>
+        {
+            e.HasKey(p => p.Id);
+            e.Property(p => p.Name).IsRequired().HasMaxLength(100);
+            e.Property(p => p.DisplayName).IsRequired().HasMaxLength(200);
+            e.Property(p => p.BaseImageRef).IsRequired().HasMaxLength(500);
+            e.Property(p => p.Kind).HasConversion<string>().HasMaxLength(32);
+            e.HasIndex(p => p.Name).IsUnique();
+            e.OwnsOne(p => p.Capabilities, c =>
+            {
+                c.ToJson();
+                c.Property(x => x.SecretsScope).HasConversion<string>();
+                c.Property(x => x.AuditMode).HasConversion<string>();
             });
         });
     }

--- a/src/Andy.Containers.Infrastructure/Migrations/20260426222833_AddEnvironmentProfiles.Designer.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260426222833_AddEnvironmentProfiles.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Andy.Containers.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Containers.Infrastructure.Migrations
 {
     [DbContext(typeof(ContainersDbContext))]
-    partial class ContainersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260426222833_AddEnvironmentProfiles")]
+    partial class AddEnvironmentProfiles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Containers.Infrastructure/Migrations/20260426222833_AddEnvironmentProfiles.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260426222833_AddEnvironmentProfiles.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Containers.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEnvironmentProfiles : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EnvironmentProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Kind = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    BaseImageRef = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Capabilities = table.Column<string>(type: "jsonb", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EnvironmentProfiles", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EnvironmentProfiles_Name",
+                table: "EnvironmentProfiles",
+                column: "Name",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EnvironmentProfiles");
+        }
+    }
+}

--- a/src/Andy.Containers/Models/EnvironmentProfile.cs
+++ b/src/Andy.Containers/Models/EnvironmentProfile.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Containers.Models;
+
+/// <summary>
+/// A named, first-class environment profile — the runtime shape (headless container,
+/// terminal, desktop) plus its capability envelope (network, secrets, GUI, audit).
+/// Agents declare the set of profiles they're allowed to run in; <c>Run</c>s pick one.
+/// </summary>
+/// <remarks>
+/// Story X1 (rivoli-ai/andy-containers#90). See Epic X (#88) for the broader
+/// EnvironmentProfile-catalog design. AP1's <see cref="Run.EnvironmentProfileId"/>
+/// becomes a real FK once the seed (X2) lands and existing rows can be backfilled.
+/// </remarks>
+public class EnvironmentProfile
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>Slug, unique across the catalog (e.g. <c>headless-container</c>).</summary>
+    public required string Name { get; set; }
+
+    /// <summary>Human-readable label shown in catalog UIs.</summary>
+    public required string DisplayName { get; set; }
+
+    public EnvironmentKind Kind { get; set; }
+
+    /// <summary>
+    /// Container image reference the run starts from (e.g.
+    /// <c>ghcr.io/rivoli-ai/andy-headless:2026.04</c>). Mutable per-profile;
+    /// AP4's run configurator resolves it at run time.
+    /// </summary>
+    public required string BaseImageRef { get; set; }
+
+    public EnvironmentCapabilities Capabilities { get; set; } = new();
+
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+}
+
+/// <summary>
+/// Runtime shape of a profile. Mirrors <see cref="RunMode"/> but lives on the
+/// catalog: a profile of kind <see cref="HeadlessContainer"/> can only back
+/// <see cref="RunMode.Headless"/> runs (X5 enforces the pairing on workspace
+/// create).
+/// </summary>
+public enum EnvironmentKind
+{
+    HeadlessContainer,
+    Terminal,
+    Desktop
+}
+
+/// <summary>
+/// Capability envelope for a profile. Stored as a single JSON column so the
+/// shape can grow (e.g. new capability flags) without a migration per field.
+/// </summary>
+public class EnvironmentCapabilities
+{
+    /// <summary>
+    /// Hostnames or CIDR ranges the run is permitted to reach. Empty list =
+    /// no outbound network. Wildcards (<c>*.github.com</c>) follow the same
+    /// semantics as the container provider's network policy.
+    /// </summary>
+    public List<string> NetworkAllowlist { get; set; } = new();
+
+    public SecretsScope SecretsScope { get; set; } = SecretsScope.RunScoped;
+
+    /// <summary>True if the profile attaches a graphical session (X server, VNC).</summary>
+    public bool HasGui { get; set; }
+
+    public AuditMode AuditMode { get; set; } = AuditMode.Standard;
+}
+
+/// <summary>
+/// What credentials the run can request. Couples to AP10's run-scoped token
+/// wiring: <see cref="RunScoped"/> tokens are revoked on terminal events;
+/// broader scopes are not.
+/// </summary>
+public enum SecretsScope
+{
+    None,
+    RunScoped,
+    WorkspaceScoped,
+    OrganizationScoped
+}
+
+/// <summary>
+/// Audit-trail intensity for the profile. <see cref="Strict"/> implies every
+/// tool call is captured pre-redaction; <see cref="Standard"/> matches the
+/// default action-log behaviour; <see cref="None"/> disables audit emission
+/// (only valid for sandboxed dev profiles, never production runs).
+/// </summary>
+public enum AuditMode
+{
+    None,
+    Standard,
+    Strict
+}

--- a/tests/Andy.Containers.Integration.Tests/Data/EnvironmentProfileRepositoryTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/Data/EnvironmentProfileRepositoryTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.Containers.Integration.Tests.Data;
+
+// X1 integration tests: round-trip the EnvironmentProfile entity through a real
+// EF Core stack (SQLite in-memory). Exercises the JSON-mapped Capabilities owned
+// type, enum-as-string conversions on Kind / SecretsScope / AuditMode, and the
+// unique index on Name.
+public class EnvironmentProfileRepositoryTests : IAsyncLifetime
+{
+    private SqliteConnection _conn = null!;
+    private ContainersDbContext _db = null!;
+
+    public async Task InitializeAsync()
+    {
+        _conn = new SqliteConnection("DataSource=:memory:");
+        await _conn.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<ContainersDbContext>()
+            .UseSqlite(_conn)
+            .Options;
+
+        _db = new ContainersDbContext(options);
+        await _db.Database.EnsureCreatedAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _db.DisposeAsync();
+        await _conn.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task EnvironmentProfile_RoundTrip_PersistsAllFields_IncludingCapabilities()
+    {
+        var profile = new EnvironmentProfile
+        {
+            Name = "headless-container",
+            DisplayName = "Headless container",
+            Kind = EnvironmentKind.HeadlessContainer,
+            BaseImageRef = "ghcr.io/rivoli-ai/andy-headless:2026.04",
+            Capabilities = new EnvironmentCapabilities
+            {
+                NetworkAllowlist = ["api.github.com", "*.npmjs.org"],
+                SecretsScope = SecretsScope.RunScoped,
+                HasGui = false,
+                AuditMode = AuditMode.Strict
+            }
+        };
+
+        _db.EnvironmentProfiles.Add(profile);
+        await _db.SaveChangesAsync();
+
+        // Fresh DbContext so we re-hydrate from the database, not the change tracker.
+        using var otherDb = new ContainersDbContext(
+            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).Options);
+        var reloaded = await otherDb.EnvironmentProfiles.SingleAsync(p => p.Id == profile.Id);
+
+        reloaded.Should().BeEquivalentTo(profile, options => options
+            .Excluding(p => p.CreatedAt));
+    }
+
+    [Fact]
+    public async Task EnvironmentProfile_NameIsUnique()
+    {
+        _db.EnvironmentProfiles.Add(NewProfile("desktop"));
+        await _db.SaveChangesAsync();
+
+        _db.EnvironmentProfiles.Add(NewProfile("desktop"));
+        var act = async () => await _db.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>(
+            "the unique index on Name should reject a duplicate");
+    }
+
+    private static EnvironmentProfile NewProfile(string name) => new()
+    {
+        Name = name,
+        DisplayName = name,
+        Kind = EnvironmentKind.Desktop,
+        BaseImageRef = "ghcr.io/rivoli-ai/andy-desktop:2026.04"
+    };
+}

--- a/tests/Andy.Containers.Tests/Models/EnvironmentProfileTests.cs
+++ b/tests/Andy.Containers.Tests/Models/EnvironmentProfileTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Tests.Models;
+
+public class EnvironmentProfileTests
+{
+    [Fact]
+    public void NewProfile_HasFreshId_AndCapabilityDefaults()
+    {
+        var profile = NewProfile();
+
+        profile.Id.Should().NotBe(Guid.Empty);
+        profile.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+        profile.Capabilities.Should().NotBeNull();
+        profile.Capabilities.NetworkAllowlist.Should().BeEmpty();
+        profile.Capabilities.SecretsScope.Should().Be(SecretsScope.RunScoped);
+        profile.Capabilities.HasGui.Should().BeFalse();
+        profile.Capabilities.AuditMode.Should().Be(AuditMode.Standard);
+    }
+
+    [Fact]
+    public void Capabilities_AreReplaceable()
+    {
+        var profile = NewProfile();
+
+        profile.Capabilities = new EnvironmentCapabilities
+        {
+            NetworkAllowlist = ["api.github.com", "*.npmjs.org"],
+            SecretsScope = SecretsScope.WorkspaceScoped,
+            HasGui = true,
+            AuditMode = AuditMode.Strict
+        };
+
+        profile.Capabilities.NetworkAllowlist.Should().HaveCount(2);
+        profile.Capabilities.HasGui.Should().BeTrue();
+        profile.Capabilities.AuditMode.Should().Be(AuditMode.Strict);
+    }
+
+    private static EnvironmentProfile NewProfile() => new()
+    {
+        Name = "headless-container",
+        DisplayName = "Headless container",
+        Kind = EnvironmentKind.HeadlessContainer,
+        BaseImageRef = "ghcr.io/rivoli-ai/andy-headless:2026.04"
+    };
+}


### PR DESCRIPTION
## Summary

- New `EnvironmentProfile` entity (`src/Andy.Containers/Models/EnvironmentProfile.cs`) with `Id`, `Name` (unique slug), `DisplayName`, `Kind`, `BaseImageRef`, `Capabilities`, `CreatedAt`.
- Capabilities (`NetworkAllowlist`, `SecretsScope`, `HasGui`, `AuditMode`) stored as a single JSON column via `OwnsOne(...).ToJson()` — `jsonb` on Postgres, TEXT on SQLite, same CLR shape on both.
- EF migration `AddEnvironmentProfiles` creates the table + unique index on `Name`.

## Why this story doesn't add the FK on `Run.EnvironmentProfileId`

`Run.EnvironmentProfileId` (AP1) has been a bare `Guid` with no FK since AP landed — the comment on `Run.cs:25` literally says "Stored without FK constraint until X lands." Adding the FK now would fail against existing `Run` rows that carry `Guid.Empty`. The FK migration is deferred to **X2** (seed) where real ids exist and a backfill / default-seed-id can be applied in the same migration.

## Test plan
- [x] Unit tests on entity defaults (`tests/Andy.Containers.Tests/Models/EnvironmentProfileTests.cs`)
- [x] EF round-trip + unique-name index test (`tests/Andy.Containers.Integration.Tests/Data/EnvironmentProfileRepositoryTests.cs`) — exercises the JSON owned-type and enum-as-string conversions on SQLite
- [x] Full solution build: 0 warnings / 0 errors
- [x] Full test suite: 698 API tests + 12 integration tests pass; pre-existing 3 `AppleContainerProvider` env-dependent failures unchanged from `main`

## Story
Closes one of the boxes on rivoli-ai/andy-containers#90 (Story X1, Epic X — #88).

🤖 Generated with [Claude Code](https://claude.com/claude-code)