### PR TITLE
PR 1/2 (#871): friendly name + OS label on Container

### DIFF
--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -93,6 +93,17 @@ public class ContainerOrchestrationService : IContainerService
             CreationSource = request.Source,
             ClientInfo = request.ClientInfo,
             StoryId = request.StoryId,
+            // Conductor #871: short human-friendly handle generated
+            // at create time. Stable for the container's lifetime.
+            // Avoid collisions with names already in the live fleet
+            // (Destroyed rows are excluded — those names are free to
+            // recycle since the user can't see them anymore).
+            FriendlyName = FriendlyNameGenerator.GenerateAvoiding(
+                (await _db.Containers
+                    .Where(c => c.Status != ContainerStatus.Destroyed
+                                && c.FriendlyName != null)
+                    .Select(c => c.FriendlyName!)
+                    .ToListAsync(ct)).ToHashSet()),
             ExpiresAt = request.ExpiresAfter.HasValue
                 ? DateTime.UtcNow.Add(request.ExpiresAfter.Value)
                 : null

--- a/src/Andy.Containers.Api/Services/ContainerProvisioningWorker.cs
+++ b/src/Andy.Containers.Api/Services/ContainerProvisioningWorker.cs
@@ -264,6 +264,33 @@ public class ContainerProvisioningWorker : BackgroundService
                 _logger.LogDebug(bannerEx, "Failed to install welcome banner for container {ContainerId}", job.ContainerId);
             }
 
+            // Conductor #871: probe /etc/os-release so the UI can show
+            // "Debian 12" / "Alpine 3.19" alongside the friendly name.
+            // Best-effort: a probe failure leaves OsLabel null and
+            // does NOT block provisioning — the banner step above
+            // already passed, so the container is healthy enough to
+            // surface to the user.
+            try
+            {
+                var containerService = scope.ServiceProvider.GetRequiredService<IContainerService>();
+                var probe = await containerService.ExecAsync(
+                    job.ContainerId,
+                    "cat /etc/os-release 2>/dev/null || true",
+                    TimeSpan.FromSeconds(10),
+                    stoppingToken);
+                var label = OsReleaseParser.ParseLabel(probe.StdOut);
+                if (!string.IsNullOrEmpty(label))
+                {
+                    container.OsLabel = label;
+                    _logger.LogDebug("OS label probed for container {ContainerId}: {Label}",
+                        job.ContainerId, label);
+                }
+            }
+            catch (Exception osEx)
+            {
+                _logger.LogDebug(osEx, "Failed to probe /etc/os-release for container {ContainerId}", job.ContainerId);
+            }
+
             // All setup complete — now mark as Running
             container.Status = ContainerStatus.Running;
             container.StartedAt = DateTime.UtcNow;

--- a/src/Andy.Containers.Client/ContainersClient.cs
+++ b/src/Andy.Containers.Client/ContainersClient.cs
@@ -119,7 +119,12 @@ public sealed class ContainersClient
         string Id, string Name, string Status, string? ExternalId, string OwnerId,
         string? TemplateId, string? ProviderId, string? StartedAt, string? CreatedAt,
         string? HostIp, string? IdeEndpoint, string? VncEndpoint,
-        TemplateDto? Template, ProviderDto? Provider);
+        TemplateDto? Template, ProviderDto? Provider,
+        // Conductor #871: identity fields the UI uses to label
+        // containers — FriendlyName is generated at create time,
+        // OsLabel is probed post-provisioning. Both nullable since
+        // older containers (pre-migration) won't have either.
+        string? FriendlyName, string? OsLabel);
 
     public record TemplateDto(string Id, string Code, string Name, string? BaseImage);
     public record ProviderDto(string Id, string Code, string Name, string Type);

--- a/src/Andy.Containers.Infrastructure/Migrations/20260426223517_AddFriendlyNameAndOsLabelToContainers.Designer.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260426223517_AddFriendlyNameAndOsLabelToContainers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Andy.Containers.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Containers.Infrastructure.Migrations
 {
     [DbContext(typeof(ContainersDbContext))]
-    partial class ContainersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260426223517_AddFriendlyNameAndOsLabelToContainers")]
+    partial class AddFriendlyNameAndOsLabelToContainers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Containers.Infrastructure/Migrations/20260426223517_AddFriendlyNameAndOsLabelToContainers.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260426223517_AddFriendlyNameAndOsLabelToContainers.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Containers.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFriendlyNameAndOsLabelToContainers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FriendlyName",
+                table: "Containers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "OsLabel",
+                table: "Containers",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FriendlyName",
+                table: "Containers");
+
+            migrationBuilder.DropColumn(
+                name: "OsLabel",
+                table: "Containers");
+        }
+    }
+}

--- a/src/Andy.Containers/FriendlyNameGenerator.cs
+++ b/src/Andy.Containers/FriendlyNameGenerator.cs
@@ -1,0 +1,105 @@
+namespace Andy.Containers;
+
+/// <summary>
+/// Generates short human-friendly identifiers for containers in the
+/// form <c>{adjective}-{animal}</c> (e.g. "amber-pelican").
+///
+/// Conductor #871. The friendly name is a complement to the 12-char
+/// short ExternalId — easy for the user to refer to in chat / docs
+/// / conversation without saying "the container with the long ID."
+/// Collisions are acceptable: the short ID disambiguates if two
+/// containers happen to share a friendly name.
+///
+/// Wordlist sized at ~64 × ~64 = ~4 K combinations. Enough that a
+/// typical user (≤ 50 simultaneous containers) won't hit a collision
+/// in practice; if they do, the IDs still distinguish them.
+/// </summary>
+public static class FriendlyNameGenerator
+{
+    /// <summary>
+    /// Returns a fresh friendly name. Uses <see cref="Random.Shared"/>
+    /// by default — pass a deterministic <see cref="Random"/> for
+    /// tests that need reproducible output.
+    /// </summary>
+    public static string Generate(Random? rng = null)
+    {
+        rng ??= Random.Shared;
+        var adjective = Adjectives[rng.Next(Adjectives.Length)];
+        var animal = Animals[rng.Next(Animals.Length)];
+        return $"{adjective}-{animal}";
+    }
+
+    /// <summary>
+    /// Returns a friendly name that does NOT appear in
+    /// <paramref name="taken"/>. Tries up to <paramref name="maxAttempts"/>
+    /// distinct random combinations; if all collide, appends a
+    /// numeric suffix to disambiguate (e.g. "amber-pelican-2").
+    ///
+    /// The wordlist gives ~4 K combinations. Birthday-bound math:
+    /// at 50 containers the collision probability is ~30%, so
+    /// callers MUST supply the existing set of names if they want
+    /// distinct output across the fleet. Conductor #871.
+    /// </summary>
+    public static string GenerateAvoiding(
+        ISet<string> taken,
+        Random? rng = null,
+        int maxAttempts = 32)
+    {
+        rng ??= Random.Shared;
+        for (var i = 0; i < maxAttempts; i++)
+        {
+            var candidate = Generate(rng);
+            if (!taken.Contains(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        // Fallback: pile-up territory. 32 random picks all collided
+        // — unlikely (would require >50% of the 4K space taken),
+        // but still possible on a heavily-populated host. Append a
+        // counter to a fresh pick.
+        var basePicked = Generate(rng);
+        var suffix = 2;
+        while (taken.Contains($"{basePicked}-{suffix}"))
+        {
+            suffix++;
+        }
+        return $"{basePicked}-{suffix}";
+    }
+
+    /// <summary>
+    /// 64 short, neutral, color/texture/mood adjectives. Curated to
+    /// avoid pejoratives, ambiguous slang, or anything that might
+    /// embarrass a user reading the name aloud in a meeting.
+    /// </summary>
+    public static readonly string[] Adjectives =
+    [
+        "amber", "azure", "bold", "brave", "bright", "calm", "clever", "cobalt",
+        "cosmic", "crimson", "crystal", "cyber", "dapper", "dark", "deep", "drifting",
+        "dusky", "eager", "echoing", "electric", "emerald", "epic", "fair", "feisty",
+        "fierce", "frosty", "gentle", "ghost", "golden", "graceful", "grand", "happy",
+        "hazel", "honest", "indigo", "jade", "jolly", "lively", "loyal", "lucid",
+        "lunar", "marble", "mellow", "merry", "mighty", "mint", "modest", "noble",
+        "obsidian", "olive", "orbit", "patient", "peaceful", "pearl", "polar", "quick",
+        "radiant", "rapid", "ruby", "rustic", "sage", "scarlet", "silent", "silver",
+    ];
+
+    /// <summary>
+    /// 64 short animal names. Bias toward non-mammalian / quirky
+    /// picks so the same handful of names doesn't dominate
+    /// generated output. No domesticated species (no "cat" / "dog")
+    /// to keep the names visually distinctive.
+    /// </summary>
+    public static readonly string[] Animals =
+    [
+        "albatross", "antelope", "badger", "bison", "caribou", "chimera", "cobra", "condor",
+        "coral", "crane", "crocus", "dolphin", "dragon", "echidna", "elk", "falcon",
+        "ferret", "finch", "fox", "gazelle", "gecko", "griffin", "hare", "hawk",
+        "heron", "hyena", "ibex", "iguana", "jaguar", "jay", "kestrel", "koala",
+        "kraken", "leopard", "lion", "lynx", "manta", "marlin", "narwhal", "newt",
+        "ocelot", "octopus", "orca", "osprey", "otter", "owl", "panda", "panther",
+        "pelican", "phoenix", "puffin", "puma", "quokka", "raven", "salamander", "seal",
+        "shark", "stoat", "swan", "tiger", "viper", "vulture", "walrus", "wolverine",
+    ];
+}

--- a/src/Andy.Containers/Models/Container.cs
+++ b/src/Andy.Containers/Models/Container.cs
@@ -37,6 +37,24 @@ public class Container
     // transition the linked UserStory's state on run completion.
     public Guid? StoryId { get; set; }
 
+    /// <summary>
+    /// Human-friendly identifier generated at create time
+    /// (<c>{adjective}-{animal}</c>, e.g. "amber-pelican"). Stable
+    /// across the container's lifetime; never collides with the
+    /// short ExternalId (12-char hash) but is much easier to refer
+    /// to in conversation / docs / chat. Conductor #871.
+    /// </summary>
+    public string? FriendlyName { get; set; }
+
+    /// <summary>
+    /// OS label populated post-creation by reading
+    /// <c>/etc/os-release</c> inside the container. Format follows
+    /// <c>{NAME} {VERSION_ID}</c> (e.g. "Debian 12", "Alpine 3.19").
+    /// Best-effort: probe failures leave this null without blocking
+    /// provisioning. Conductor #871.
+    /// </summary>
+    public string? OsLabel { get; set; }
+
     public ICollection<ContainerSession> Sessions { get; set; } = new List<ContainerSession>();
     public ICollection<ContainerEvent> Events { get; set; } = new List<ContainerEvent>();
     public ICollection<ContainerGitRepository> GitRepositories { get; set; } = new List<ContainerGitRepository>();

--- a/src/Andy.Containers/OsReleaseParser.cs
+++ b/src/Andy.Containers/OsReleaseParser.cs
@@ -1,0 +1,77 @@
+namespace Andy.Containers;
+
+/// <summary>
+/// Parses the contents of <c>/etc/os-release</c> into a short
+/// human label like "Debian 12" or "Alpine 3.19".
+///
+/// Conductor #871. The format is the freedesktop.org spec:
+/// shell-style KEY=VALUE lines, values may be quoted. We pull
+/// <c>NAME</c> + <c>VERSION_ID</c> and stitch them. If
+/// <c>VERSION_ID</c> is missing (some rolling distros), we fall
+/// back to <c>NAME</c> alone. If the input is unparseable,
+/// returns null — the caller treats that as "OS unknown" and
+/// renders nothing.
+/// </summary>
+public static class OsReleaseParser
+{
+    public static string? ParseLabel(string? osReleaseContents)
+    {
+        if (string.IsNullOrWhiteSpace(osReleaseContents))
+        {
+            return null;
+        }
+
+        string? name = null;
+        string? versionId = null;
+
+        foreach (var rawLine in osReleaseContents.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line.StartsWith("#"))
+            {
+                continue;
+            }
+
+            var eq = line.IndexOf('=');
+            if (eq <= 0)
+            {
+                continue;
+            }
+
+            var key = line[..eq].Trim();
+            var value = Unquote(line[(eq + 1)..].Trim());
+
+            if (key == "NAME")
+            {
+                name = value;
+            }
+            else if (key == "VERSION_ID")
+            {
+                versionId = value;
+            }
+        }
+
+        if (string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
+        return string.IsNullOrEmpty(versionId)
+            ? name
+            : $"{name} {versionId}";
+    }
+
+    private static string Unquote(string value)
+    {
+        if (value.Length >= 2)
+        {
+            var first = value[0];
+            var last = value[^1];
+            if ((first == '"' || first == '\'') && first == last)
+            {
+                return value[1..^1];
+            }
+        }
+        return value;
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTests.cs
@@ -674,4 +674,110 @@ public class ContainerOrchestrationServiceTests : IDisposable
         results.Should().HaveCount(1);
         results[0].Name.Should().Be("cli-1");
     }
+
+    // Conductor #871. Friendly name is generated at create time;
+    // OS label is filled by the provisioning worker post-create
+    // (covered separately in OsReleaseParserTests).
+
+    [Fact]
+    public async Task CreateContainer_StampsAFriendlyName()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+        _mockInfraProvider.Setup(p => p.CreateContainerAsync(It.IsAny<ContainerSpec>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ContainerProvisionResult { ExternalId = "ext-1", Status = ContainerStatus.Running });
+
+        var request = new CreateContainerRequest
+        {
+            Name = "labeled",
+            TemplateId = template.Id,
+            ProviderId = provider.Id
+        };
+
+        var container = await _service.CreateContainerAsync(request, CancellationToken.None);
+
+        container.FriendlyName.Should().NotBeNullOrEmpty();
+        container.FriendlyName.Should().MatchRegex("^[a-z]+-[a-z]+(-\\d+)?$",
+            "FriendlyName must be {adjective}-{animal} (with optional numeric suffix on collision)");
+    }
+
+    [Fact]
+    public async Task CreateContainer_DoesNotReuseFriendlyNameOfLiveContainer()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+        _mockInfraProvider.Setup(p => p.CreateContainerAsync(It.IsAny<ContainerSpec>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ContainerProvisionResult { ExternalId = "ext-1", Status = ContainerStatus.Running });
+
+        // Pre-load the DB with one of every {adj}-{animal} pair.
+        // The generator can't pick a fresh combination, so it
+        // MUST land on the suffix fallback ("foo-bar-2"). This
+        // proves the orchestrator threads `taken` correctly into
+        // GenerateAvoiding — without that wiring the generator
+        // would happily re-pick a colliding name.
+        foreach (var adj in Andy.Containers.FriendlyNameGenerator.Adjectives)
+        foreach (var animal in Andy.Containers.FriendlyNameGenerator.Animals)
+        {
+            _db.Containers.Add(new Container
+            {
+                Name = $"seed-{adj}-{animal}",
+                TemplateId = template.Id,
+                ProviderId = provider.Id,
+                OwnerId = "system",
+                Status = ContainerStatus.Running,
+                FriendlyName = $"{adj}-{animal}"
+            });
+        }
+        await _db.SaveChangesAsync();
+
+        var request = new CreateContainerRequest
+        {
+            Name = "the-new-one",
+            TemplateId = template.Id,
+            ProviderId = provider.Id
+        };
+
+        var container = await _service.CreateContainerAsync(request, CancellationToken.None);
+
+        container.FriendlyName.Should().EndWith("-2",
+            "every base name was taken, so the orchestrator must surface the numeric-suffix fallback");
+    }
+
+    [Fact]
+    public async Task CreateContainer_ReusesNamesOfDestroyedContainers()
+    {
+        // Destroyed containers don't show in the user's fleet, so
+        // their friendly names are free to recycle. Keeps the
+        // namespace from accumulating dead reservations.
+        var (template, provider) = await SeedTemplateAndProvider();
+        _mockInfraProvider.Setup(p => p.CreateContainerAsync(It.IsAny<ContainerSpec>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ContainerProvisionResult { ExternalId = "ext-1", Status = ContainerStatus.Running });
+
+        // Same exhaustion as above, but everything is Destroyed.
+        foreach (var adj in Andy.Containers.FriendlyNameGenerator.Adjectives)
+        foreach (var animal in Andy.Containers.FriendlyNameGenerator.Animals)
+        {
+            _db.Containers.Add(new Container
+            {
+                Name = $"dead-{adj}-{animal}",
+                TemplateId = template.Id,
+                ProviderId = provider.Id,
+                OwnerId = "system",
+                Status = ContainerStatus.Destroyed,
+                FriendlyName = $"{adj}-{animal}"
+            });
+        }
+        await _db.SaveChangesAsync();
+
+        var request = new CreateContainerRequest
+        {
+            Name = "rises-again",
+            TemplateId = template.Id,
+            ProviderId = provider.Id
+        };
+
+        var container = await _service.CreateContainerAsync(request, CancellationToken.None);
+
+        // Suffix-free: the destroyed names didn't block the picker.
+        container.FriendlyName.Should().NotEndWith("-2");
+        container.FriendlyName.Should().MatchRegex("^[a-z]+-[a-z]+$");
+    }
 }

--- a/tests/Andy.Containers.Client.Tests/ContainersClientTests.cs
+++ b/tests/Andy.Containers.Client.Tests/ContainersClientTests.cs
@@ -31,8 +31,8 @@ public class ContainersClientTests
     [Fact]
     public void ContainerDto_RecordEquality()
     {
-        var dto1 = new ContainersClient.ContainerDto("id1", "test", "Running", null, "user1", null, null, null, null, null, null, null, null, null);
-        var dto2 = new ContainersClient.ContainerDto("id1", "test", "Running", null, "user1", null, null, null, null, null, null, null, null, null);
+        var dto1 = new ContainersClient.ContainerDto("id1", "test", "Running", null, "user1", null, null, null, null, null, null, null, null, null, null, null);
+        var dto2 = new ContainersClient.ContainerDto("id1", "test", "Running", null, "user1", null, null, null, null, null, null, null, null, null, null, null);
 
         dto1.Should().Be(dto2);
     }
@@ -42,7 +42,7 @@ public class ContainersClientTests
     {
         var items = new[]
         {
-            new ContainersClient.ContainerDto("1", "c1", "Running", null, "u1", null, null, null, null, null, null, null, null, null)
+            new ContainersClient.ContainerDto("1", "c1", "Running", null, "u1", null, null, null, null, null, null, null, null, null, null, null)
         };
         var result = new ContainersClient.PaginatedResult<ContainersClient.ContainerDto>(items, 1);
 

--- a/tests/Andy.Containers.Tests/ContainersClientTests.cs
+++ b/tests/Andy.Containers.Tests/ContainersClientTests.cs
@@ -41,9 +41,9 @@ public class ContainersClientTests
     public void ContainerDto_RecordEquality()
     {
         var dto1 = new ContainersClient.ContainerDto("id1", "test", "Running", null, "user1",
-            null, null, null, null, null, null, null, null, null);
+            null, null, null, null, null, null, null, null, null, null, null);
         var dto2 = new ContainersClient.ContainerDto("id1", "test", "Running", null, "user1",
-            null, null, null, null, null, null, null, null, null);
+            null, null, null, null, null, null, null, null, null, null, null);
 
         dto1.Should().Be(dto2);
     }
@@ -52,9 +52,9 @@ public class ContainersClientTests
     public void ContainerDto_RecordInequality()
     {
         var dto1 = new ContainersClient.ContainerDto("id1", "test", "Running", null, "user1",
-            null, null, null, null, null, null, null, null, null);
+            null, null, null, null, null, null, null, null, null, null, null);
         var dto2 = new ContainersClient.ContainerDto("id2", "test", "Stopped", null, "user1",
-            null, null, null, null, null, null, null, null, null);
+            null, null, null, null, null, null, null, null, null, null, null);
 
         dto1.Should().NotBe(dto2);
     }
@@ -65,7 +65,7 @@ public class ContainersClientTests
         var items = new[]
         {
             new ContainersClient.ContainerDto("1", "c1", "Running", null, "u1",
-                null, null, null, null, null, null, null, null, null)
+                null, null, null, null, null, null, null, null, null, null, null)
         };
         var result = new ContainersClient.PaginatedResult<ContainersClient.ContainerDto>(items, 42);
 

--- a/tests/Andy.Containers.Tests/FriendlyNameGeneratorTests.cs
+++ b/tests/Andy.Containers.Tests/FriendlyNameGeneratorTests.cs
@@ -1,0 +1,123 @@
+using Andy.Containers;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Tests;
+
+// Conductor #871. The friendly-name generator is the user-visible
+// handle for every container ("amber-pelican"). These tests pin
+// three contracts:
+//   1. Generated names match the {adjective}-{animal} shape.
+//   2. The wordlists themselves contain no duplicates (otherwise
+//      the math below would lie).
+//   3. GenerateAvoiding(taken) really does avoid `taken`, even
+//      when `taken` covers most of the namespace.
+//
+// The user explicitly asked for collision regression coverage —
+// "make sure we have testing not to have name collisions."
+public class FriendlyNameGeneratorTests
+{
+    [Fact]
+    public void Generate_ReturnsAdjectiveDashAnimal()
+    {
+        var name = FriendlyNameGenerator.Generate(new Random(42));
+
+        name.Should().Contain("-");
+        var parts = name.Split('-');
+        parts.Should().HaveCount(2);
+        FriendlyNameGenerator.Adjectives.Should().Contain(parts[0]);
+        FriendlyNameGenerator.Animals.Should().Contain(parts[1]);
+    }
+
+    [Fact]
+    public void Adjectives_ContainsNoDuplicates()
+    {
+        FriendlyNameGenerator.Adjectives.Should()
+            .OnlyHaveUniqueItems("a duplicate adjective inflates the perceived namespace and biases generation");
+    }
+
+    [Fact]
+    public void Animals_ContainsNoDuplicates()
+    {
+        FriendlyNameGenerator.Animals.Should()
+            .OnlyHaveUniqueItems("a duplicate animal inflates the perceived namespace and biases generation");
+    }
+
+    [Fact]
+    public void Wordlist_HasAtLeastTwoThousandCombinations()
+    {
+        // The story-level cap a user can hit is ~32 simultaneous
+        // containers (per the per-user quota). At 2K+ combinations
+        // and `GenerateAvoiding`, collisions become mathematically
+        // unreachable. If someone shrinks the lists, this test
+        // fails so we have to revisit the suffix-fallback path.
+        var combinations = FriendlyNameGenerator.Adjectives.Length
+            * FriendlyNameGenerator.Animals.Length;
+        combinations.Should().BeGreaterThan(2000);
+    }
+
+    [Fact]
+    public void GenerateAvoiding_ProducesNoCollisions_OverThousandDraws()
+    {
+        // Stress test: simulate filling up the namespace one
+        // container at a time. Each draw must avoid all prior
+        // draws. We stop short of fully exhausting the wordlist
+        // because once nearly-full the generator legitimately
+        // needs the suffix fallback — that's covered separately.
+        var rng = new Random(1234);
+        var seen = new HashSet<string>();
+
+        for (var i = 0; i < 1000; i++)
+        {
+            var name = FriendlyNameGenerator.GenerateAvoiding(seen, rng);
+            seen.Add(name).Should()
+                .BeTrue($"draw #{i} returned a name already in the avoid set: {name}");
+        }
+    }
+
+    [Fact]
+    public void GenerateAvoiding_FallsBackToSuffix_WhenNamespaceExhausted()
+    {
+        // Pre-populate `taken` with every possible {adj}-{animal}
+        // combination. The generator can't find a fresh pick, so
+        // it must append "-2".
+        var taken = new HashSet<string>();
+        foreach (var adj in FriendlyNameGenerator.Adjectives)
+        foreach (var animal in FriendlyNameGenerator.Animals)
+        {
+            taken.Add($"{adj}-{animal}");
+        }
+
+        var fresh = FriendlyNameGenerator.GenerateAvoiding(taken, new Random(7));
+
+        fresh.Should().EndWith("-2", "exhausted namespace must fall back to a numeric suffix");
+        taken.Should().NotContain(fresh, "the fallback name must still be unique");
+    }
+
+    [Fact]
+    public void GenerateAvoiding_IncrementsSuffix_WhenSuffixedNameAlsoTaken()
+    {
+        // Same exhaustion, plus the "-2" variants are also taken.
+        // The generator must walk to "-3".
+        var taken = new HashSet<string>();
+        foreach (var adj in FriendlyNameGenerator.Adjectives)
+        foreach (var animal in FriendlyNameGenerator.Animals)
+        {
+            taken.Add($"{adj}-{animal}");
+            taken.Add($"{adj}-{animal}-2");
+        }
+
+        var fresh = FriendlyNameGenerator.GenerateAvoiding(taken, new Random(7));
+
+        fresh.Should().EndWith("-3");
+    }
+
+    [Fact]
+    public void GenerateAvoiding_ReturnsImmediately_WhenAvoidSetIsEmpty()
+    {
+        var name = FriendlyNameGenerator.GenerateAvoiding(new HashSet<string>(), new Random(0));
+
+        name.Should().NotBeNullOrEmpty();
+        name.Should().Contain("-");
+    }
+}

--- a/tests/Andy.Containers.Tests/OsReleaseParserTests.cs
+++ b/tests/Andy.Containers.Tests/OsReleaseParserTests.cs
@@ -1,0 +1,128 @@
+using Andy.Containers;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Tests;
+
+// Conductor #871. Locks the OS-label probe contract: input is
+// the raw contents of /etc/os-release as written by every distro
+// we plausibly run (Debian, Ubuntu, Alpine, Fedora, Arch, …).
+// Output is a single short label the UI can show next to the
+// friendly name. A null return means "we couldn't tell" — the UI
+// renders nothing rather than guessing.
+public class OsReleaseParserTests
+{
+    [Fact]
+    public void ParseLabel_DebianStyle_ReturnsNameAndVersionId()
+    {
+        // Debian 12 ships os-release like this. Real sample.
+        const string contents = """
+            PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
+            NAME="Debian GNU/Linux"
+            VERSION_ID="12"
+            VERSION="12 (bookworm)"
+            VERSION_CODENAME=bookworm
+            ID=debian
+            HOME_URL="https://www.debian.org/"
+            """;
+
+        OsReleaseParser.ParseLabel(contents).Should().Be("Debian GNU/Linux 12");
+    }
+
+    [Fact]
+    public void ParseLabel_AlpineStyle_StripsQuotesAndStitches()
+    {
+        const string contents = """
+            NAME="Alpine Linux"
+            ID=alpine
+            VERSION_ID=3.19.1
+            PRETTY_NAME="Alpine Linux v3.19"
+            HOME_URL="https://alpinelinux.org/"
+            """;
+
+        OsReleaseParser.ParseLabel(contents).Should().Be("Alpine Linux 3.19.1");
+    }
+
+    [Fact]
+    public void ParseLabel_UbuntuStyle_HandlesUnquotedVersionId()
+    {
+        const string contents = """
+            NAME="Ubuntu"
+            VERSION="24.04.1 LTS (Noble Numbat)"
+            ID=ubuntu
+            VERSION_ID="24.04"
+            """;
+
+        OsReleaseParser.ParseLabel(contents).Should().Be("Ubuntu 24.04");
+    }
+
+    [Fact]
+    public void ParseLabel_RollingDistroWithoutVersionId_ReturnsNameAlone()
+    {
+        // Arch deliberately omits VERSION_ID because it rolls.
+        const string contents = """
+            NAME="Arch Linux"
+            ID=arch
+            BUILD_ID=rolling
+            PRETTY_NAME="Arch Linux"
+            """;
+
+        OsReleaseParser.ParseLabel(contents).Should().Be("Arch Linux");
+    }
+
+    [Fact]
+    public void ParseLabel_NullInput_ReturnsNull()
+    {
+        OsReleaseParser.ParseLabel(null).Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseLabel_EmptyInput_ReturnsNull()
+    {
+        OsReleaseParser.ParseLabel("").Should().BeNull();
+        OsReleaseParser.ParseLabel("   \n  ").Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseLabel_NoNameKey_ReturnsNull()
+    {
+        // Without NAME, we can't say anything useful — return
+        // null so the UI renders no label rather than "12".
+        const string contents = "VERSION_ID=12\nID=debian";
+
+        OsReleaseParser.ParseLabel(contents).Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseLabel_IgnoresCommentsAndBlankLines()
+    {
+        const string contents = """
+
+            # this is a comment
+            NAME="Debian"
+            # another comment
+            VERSION_ID=12
+
+            """;
+
+        OsReleaseParser.ParseLabel(contents).Should().Be("Debian 12");
+    }
+
+    [Fact]
+    public void ParseLabel_HandlesSingleQuotedValues()
+    {
+        // Per the spec, both quote styles are valid.
+        const string contents = "NAME='Custom Distro'\nVERSION_ID='1.0'";
+
+        OsReleaseParser.ParseLabel(contents).Should().Be("Custom Distro 1.0");
+    }
+
+    [Fact]
+    public void ParseLabel_GarbageInput_ReturnsNull()
+    {
+        // The probe path appends `|| true` so we can get back
+        // arbitrary garbage from misbehaving images. Should not
+        // throw; should return null.
+        OsReleaseParser.ParseLabel("not\xa key=value file at all").Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `FriendlyName` (short `{adjective}-{animal}` handle, stable for lifetime) and `OsLabel` (`Debian 12` / `Alpine 3.19` probed from `/etc/os-release`) to the `Container` entity
- `ContainerOrchestrationService.CreateContainerAsync` generates the friendly name with collision avoidance against the live fleet's existing names; destroyed rows recycle. Falls back to a numeric suffix only when the ~4K namespace is exhausted
- `ContainerProvisioningWorker` runs a best-effort `cat /etc/os-release` exec after the welcome banner; failure leaves `OsLabel` null and does NOT block provisioning
- `ContainersClient.ContainerDto` gains the two new fields so the Conductor side can read them

## Migration

`AddFriendlyNameAndOsLabelToContainers` — both columns nullable text. Pre-existing containers stay `NULL` on both; the UI renders no label in that case.

## Tests (all three layers per CLAUDE.md)

- `FriendlyNameGeneratorTests` — 8 cases: shape, no-dupe wordlists, namespace ≥ 2K combinations, 1000-draw stress with zero collisions, suffix fallback, suffix increment, empty-set fast path
- `OsReleaseParserTests` — 10 cases: Debian / Alpine / Ubuntu / Arch styles, null / empty / garbage input, comments, single-quoted values, missing `NAME`
- `ContainerOrchestrationServiceTests` — 3 new cases: stamps a friendly name; refuses to recycle a name from a *live* container (forces the suffix path); *does* recycle names from `Destroyed` containers

**1037 unit tests pass.** The 3 `Andy.Containers.Integration.Tests` failures require the Apple `container` CLI and are unrelated to this slice.

## Refs

- Conductor #871 (this story)
- Conductor #878 — per-user 32-container cap; the wordlist size assumes a low-tens cap, so this PR finalises that assumption
- Conductor PR 2/2 (Conductor side) — wires `FriendlyName` / `OsLabel` / full template name / short ID into the container card and workspace header

## Test plan

- [ ] CI green (build + xUnit on both `.NET 8.0` paths)
- [ ] Apply migration to a dev DB, create a container, confirm `FriendlyName` populated and `OsLabel` populated within ~30s
- [ ] Pre-existing containers (created before this PR) continue to load with `NULL` identity fields
- [ ] Conductor PR 2/2 deserializes both fields without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)