### PR TITLE
AP7: cancel path — signal runner via registry, await terminal write (#109)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/RunsController.cs
+++ b/src/Andy.Containers.Api/Controllers/RunsController.cs
@@ -1,6 +1,8 @@
 using Andy.Containers.Api.Services;
 using Andy.Containers.Configurator;
 using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
 using Andy.Rbac.Authorization;
 using Microsoft.AspNetCore.Authorization;
@@ -21,20 +23,30 @@ namespace Andy.Containers.Api.Controllers;
 [Authorize]
 public class RunsController : ControllerBase
 {
+    // AP7 (rivoli-ai/andy-containers#109). Grace window for awaiting the
+    // runner's terminal write after we signal cancellation. The headless
+    // runner's catch-OperationCanceledException path calls TerminateAsync
+    // immediately, so most cancels resolve in <100ms — the 30s ceiling is
+    // for hung Docker exec streams that don't honour the linked CTS.
+    internal static readonly TimeSpan CancelGrace = TimeSpan.FromSeconds(30);
+
     private readonly ContainersDbContext _db;
     private readonly IRunConfigurator _configurator;
     private readonly IRunModeDispatcher _dispatcher;
+    private readonly IRunCancellationRegistry _cancellation;
     private readonly ILogger<RunsController> _logger;
 
     public RunsController(
         ContainersDbContext db,
         IRunConfigurator configurator,
         IRunModeDispatcher dispatcher,
+        IRunCancellationRegistry cancellation,
         ILogger<RunsController> logger)
     {
         _db = db;
         _configurator = configurator;
         _dispatcher = dispatcher;
+        _cancellation = cancellation;
         _logger = logger;
     }
 
@@ -139,22 +151,82 @@ public class RunsController : ControllerBase
             return NotFound();
         }
 
-        try
+        // AP1 state-machine guard. Cancelled is reachable from Pending,
+        // Provisioning, and Running; terminal states map to 409 so callers
+        // can distinguish "too late" from "no such run".
+        if (!RunStatusTransitions.CanTransition(run.Status, RunStatus.Cancelled))
         {
-            // Run.TransitionTo enforces the AP1 state-machine. Pending,
-            // Provisioning, and Running can all move to Cancelled; terminal
-            // states cannot — that's the 409 path below.
-            run.TransitionTo(RunStatus.Cancelled);
-        }
-        catch (InvalidOperationException ex)
-        {
-            return Conflict(new { error = ex.Message });
+            return Conflict(new
+            {
+                error = $"Run {run.Id} is in terminal status {run.Status}; cannot cancel.",
+            });
         }
 
+        // AP7 (rivoli-ai/andy-containers#109). Two paths:
+        //
+        // (a) An AP6 runner is active for this Run. We signal its linked
+        //     CTS via the registry; the runner's catch-OCE path calls
+        //     TerminateAsync, which transitions to Cancelled and appends
+        //     the cancelled outbox event. We await that terminal write
+        //     up to CancelGrace so the response reflects committed state.
+        //
+        // (b) No runner is registered (Pending row not yet picked up by
+        //     AP5, or runner already exited). We flip the row ourselves
+        //     and emit the cancelled outbox event so subscribers see a
+        //     terminal subject either way.
+        if (_cancellation.TryCancel(run.Id))
+        {
+            bool terminal;
+            try
+            {
+                terminal = await _cancellation.WaitForTerminalAsync(run.Id, CancelGrace, ct);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // Caller hung up. Don't escalate — the runner will still
+                // observe its own cancellation and write terminal state.
+                throw;
+            }
+
+            await _db.Entry(run).ReloadAsync(ct);
+
+            if (!terminal)
+            {
+                // Runner ignored its CTS for 30s. Force the transition
+                // and emit the event ourselves so the row doesn't stay
+                // Running forever; AP9 metrics can flag this on the
+                // outbox side via a duplicate subject if the runner
+                // eventually wakes up.
+                _logger.LogWarning(
+                    "Run {RunId} cancel grace ({GraceSeconds}s) expired before runner terminal write; forcing Cancelled.",
+                    run.Id, (int)CancelGrace.TotalSeconds);
+                ForceCancel(run);
+                await _db.SaveChangesAsync(ct);
+            }
+
+            return Ok(RunDto.FromEntity(run));
+        }
+
+        // Pending-row path: no active runner to signal, flip directly.
+        ForceCancel(run);
         await _db.SaveChangesAsync(ct);
 
-        // AP3+ also needs to publish a cancel command so the running container
-        // actually stops; AP2 only flips the DB row. Document at the boundary.
         return Ok(RunDto.FromEntity(run));
+    }
+
+    // Best-effort transition + outbox emit. Used for the no-runner Pending
+    // path and the grace-expired escalation. CanTransition guards against
+    // the rare race where the runner's TerminateAsync committed between
+    // our reload and our save — in that case the row is already Cancelled
+    // and we leave it alone, but we still emit the outbox event so the
+    // caller's API contract ("cancel emits run.cancelled") holds.
+    private void ForceCancel(Run run)
+    {
+        if (RunStatusTransitions.CanTransition(run.Status, RunStatus.Cancelled))
+        {
+            run.TransitionTo(RunStatus.Cancelled);
+        }
+
+        _db.AppendAgentRunEvent(run, RunEventKind.Cancelled);
     }
 }

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -249,6 +249,11 @@ try
     builder.Services.AddSingleton<IHeadlessConfigWriter, HeadlessConfigWriter>();
     builder.Services.AddScoped<IRunConfigurator, RunConfigurator>();
 
+    // AP7 (rivoli-ai/andy-containers#109). In-process registry of active
+    // runs so the cancel endpoint can signal the AP6 runner across
+    // request scopes. Singleton — runner registrations span requests.
+    builder.Services.AddSingleton<IRunCancellationRegistry, RunCancellationRegistry>();
+
     // AP6 (rivoli-ai/andy-containers#108). Headless runner: spawns
     // andy-cli inside the run's container, captures exit code, publishes
     // the terminal run.* event to the outbox.

--- a/src/Andy.Containers.Api/Services/HeadlessRunner.cs
+++ b/src/Andy.Containers.Api/Services/HeadlessRunner.cs
@@ -14,6 +14,7 @@ public sealed class HeadlessRunner : IHeadlessRunner
 {
     private readonly IContainerService _containers;
     private readonly ContainersDbContext _db;
+    private readonly IRunCancellationRegistry _cancellation;
     private readonly ILogger<HeadlessRunner> _logger;
 
     // Outer-watchdog grace: AQ3 honours limits.timeout_seconds internally
@@ -32,10 +33,12 @@ public sealed class HeadlessRunner : IHeadlessRunner
     public HeadlessRunner(
         IContainerService containers,
         ContainersDbContext db,
+        IRunCancellationRegistry cancellation,
         ILogger<HeadlessRunner> logger)
     {
         _containers = containers;
         _db = db;
+        _cancellation = cancellation;
         _logger = logger;
     }
 
@@ -73,8 +76,16 @@ public sealed class HeadlessRunner : IHeadlessRunner
         SafeTransition(run, RunStatus.Running);
         await _db.SaveChangesAsync(ct);
 
+        // AP7 (rivoli-ai/andy-containers#109). Register so the cancel
+        // endpoint can signal this exec from a different request scope.
+        // Disposal removes the entry and signals waiters — the using
+        // statement guarantees that every exit path (success, cancel,
+        // throw) wakes RunsController.Cancel's WaitForTerminalAsync.
+        using var registration = _cancellation.Register(run.Id, ct);
+        var execToken = registration.Token;
+
         var command = $"andy-cli run --headless --config {ShellEscape(configPath)}";
-        var execTimeout = await ResolveExecTimeoutAsync(configPath, ct);
+        var execTimeout = await ResolveExecTimeoutAsync(configPath, execToken);
         ExecResult result;
         try
         {
@@ -82,14 +93,18 @@ public sealed class HeadlessRunner : IHeadlessRunner
                 "Spawning headless agent for Run {RunId} in container {ContainerId} with config {ConfigPath} (outer timeout {Seconds}s)",
                 run.Id, containerId, configPath, (int)execTimeout.TotalSeconds);
 
-            result = await _containers.ExecAsync(containerId, command, execTimeout, ct);
+            result = await _containers.ExecAsync(containerId, command, execTimeout, execToken);
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (execToken.IsCancellationRequested)
         {
+            // Either the caller cancelled (ct flows into the linked
+            // CTS) or the registry's TryCancel fired from the cancel
+            // endpoint. Both routes land here and produce the same
+            // Cancelled outcome — the runner doesn't distinguish.
             sw.Stop();
-            _logger.LogWarning("Headless spawn for Run {RunId} cancelled by caller", run.Id);
+            _logger.LogWarning("Headless spawn for Run {RunId} cancelled (caller or registry signal)", run.Id);
             return await TerminateAsync(run, RunEventKind.Cancelled, RunStatus.Cancelled,
-                exitCode: null, durationSeconds: sw.Elapsed.TotalSeconds, error: "Cancelled by caller", CancellationToken.None);
+                exitCode: null, durationSeconds: sw.Elapsed.TotalSeconds, error: "Cancelled", CancellationToken.None);
         }
         catch (OperationCanceledException ex)
         {

--- a/src/Andy.Containers.Api/Services/IRunCancellationRegistry.cs
+++ b/src/Andy.Containers.Api/Services/IRunCancellationRegistry.cs
@@ -1,0 +1,69 @@
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// AP7 (rivoli-ai/andy-containers#109). In-process registry of running
+/// agent-run handles, keyed by Run.Id. The headless runner registers a
+/// linked CTS at spawn so the cancel endpoint can signal it without
+/// reaching across DI scopes; the same registration carries a
+/// <see cref="System.Threading.Tasks.TaskCompletionSource"/> so the
+/// cancel endpoint can await the runner's terminal write before it
+/// returns the DTO.
+/// </summary>
+/// <remarks>
+/// Singleton-scoped because runner registrations span request scopes:
+/// AP6 today is synchronous (the controller awaits StartAsync), but the
+/// cancel POST arrives on a different request. The registry lives in
+/// process memory only — once AP5's queue moves runs to a worker and
+/// horizontal scale-out lands, this needs to be replaced with a control
+/// channel that survives across nodes (likely the andy-cli cancel
+/// command over the AQ3 control plane). Until then, single-node is fine.
+/// </remarks>
+public interface IRunCancellationRegistry
+{
+    /// <summary>
+    /// Register a run as actively executing. The returned handle owns
+    /// the linked CTS used to signal cancellation; pass
+    /// <see cref="IRunRegistration.Token"/> into ExecAsync. Disposing
+    /// the handle removes the entry and signals waiters that the run
+    /// has reached a terminal state — call from a <c>finally</c> so
+    /// every exit path (success, cancel, throw) signals.
+    /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    /// Thrown if a registration already exists for <paramref name="runId"/>.
+    /// AP6 starts at most one runner per Run; double-register indicates
+    /// a caller bug, not a normal race.
+    /// </exception>
+    IRunRegistration Register(Guid runId, CancellationToken outerToken);
+
+    /// <summary>
+    /// Signal cancellation to the registered runner for
+    /// <paramref name="runId"/>. Returns false when no runner is
+    /// active — callers (the cancel endpoint) take that as the
+    /// "no in-flight process to signal" branch.
+    /// </summary>
+    bool TryCancel(Guid runId);
+
+    /// <summary>
+    /// Await the runner's terminal write for <paramref name="runId"/>,
+    /// or the supplied timeout — whichever comes first. Returns true
+    /// on terminal observation, false on timeout. Returns true
+    /// immediately if the run is not registered (already terminal or
+    /// never registered), so callers don't have to special-case the
+    /// race between TryCancel and the runner's finally block.
+    /// </summary>
+    Task<bool> WaitForTerminalAsync(Guid runId, TimeSpan timeout, CancellationToken ct);
+}
+
+/// <summary>
+/// Active-run handle returned by <see cref="IRunCancellationRegistry.Register"/>.
+/// Disposing removes the entry and signals waiters.
+/// </summary>
+public interface IRunRegistration : IDisposable
+{
+    /// <summary>
+    /// Cancellation token linked to the registry's CTS and the caller's
+    /// outer token. Pass to ExecAsync so a TryCancel signal aborts the
+    /// in-flight Docker exec stream.
+    /// </summary>
+    CancellationToken Token { get; }
+}

--- a/src/Andy.Containers.Api/Services/RunCancellationRegistry.cs
+++ b/src/Andy.Containers.Api/Services/RunCancellationRegistry.cs
@@ -1,0 +1,134 @@
+using System.Collections.Concurrent;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// AP7 (rivoli-ai/andy-containers#109). Default in-process implementation
+/// of <see cref="IRunCancellationRegistry"/>. See the interface for the
+/// scaling caveat — this is single-node only.
+/// </summary>
+public sealed class RunCancellationRegistry : IRunCancellationRegistry
+{
+    private readonly ConcurrentDictionary<Guid, Entry> _entries = new();
+
+    public IRunRegistration Register(Guid runId, CancellationToken outerToken)
+    {
+        var entry = new Entry(runId, outerToken, this);
+        if (!_entries.TryAdd(runId, entry))
+        {
+            entry.Dispose();
+            throw new InvalidOperationException(
+                $"Run {runId} is already registered with the cancellation registry.");
+        }
+
+        return entry;
+    }
+
+    public bool TryCancel(Guid runId)
+    {
+        if (!_entries.TryGetValue(runId, out var entry))
+        {
+            return false;
+        }
+
+        entry.SignalCancel();
+        return true;
+    }
+
+    public Task<bool> WaitForTerminalAsync(Guid runId, TimeSpan timeout, CancellationToken ct)
+    {
+        if (!_entries.TryGetValue(runId, out var entry))
+        {
+            // No registration → either already terminal (the runner
+            // disposed before we got here) or never spawned. Either
+            // way, the caller should refetch the row to learn the
+            // current state — no waiting required.
+            return Task.FromResult(true);
+        }
+
+        return entry.WaitForTerminalAsync(timeout, ct);
+    }
+
+    private void Remove(Guid runId, Entry entry)
+    {
+        // ConcurrentDictionary.TryRemove with the value compare-exchange
+        // pattern guards against removing a stale entry if the runner
+        // somehow re-registered in between (which Register itself
+        // forbids, but be defensive).
+        var kvp = new KeyValuePair<Guid, Entry>(runId, entry);
+        ((ICollection<KeyValuePair<Guid, Entry>>)_entries).Remove(kvp);
+    }
+
+    private sealed class Entry : IRunRegistration
+    {
+        private readonly Guid _runId;
+        private readonly RunCancellationRegistry _owner;
+        private readonly CancellationTokenSource _cts;
+        private readonly TaskCompletionSource<bool> _terminal;
+        private int _disposed;
+
+        public Entry(Guid runId, CancellationToken outerToken, RunCancellationRegistry owner)
+        {
+            _runId = runId;
+            _owner = owner;
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(outerToken);
+            _terminal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public CancellationToken Token => _cts.Token;
+
+        public void SignalCancel()
+        {
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                return;
+            }
+
+            try
+            {
+                _cts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Disposal raced with cancel. The runner has already
+                // observed terminal — nothing left to signal.
+            }
+        }
+
+        public async Task<bool> WaitForTerminalAsync(TimeSpan timeout, CancellationToken ct)
+        {
+            if (_terminal.Task.IsCompleted)
+            {
+                return true;
+            }
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(timeout);
+
+            var completed = await Task.WhenAny(
+                _terminal.Task,
+                Task.Delay(Timeout.InfiniteTimeSpan, timeoutCts.Token)).ConfigureAwait(false);
+
+            if (completed == _terminal.Task)
+            {
+                return true;
+            }
+
+            // The delay fired — distinguish caller-cancel from timeout.
+            ct.ThrowIfCancellationRequested();
+            return false;
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            _owner.Remove(_runId, this);
+            _terminal.TrySetResult(true);
+            _cts.Dispose();
+        }
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
@@ -3,6 +3,7 @@ using Andy.Containers.Api.Services;
 using Andy.Containers.Api.Tests.Helpers;
 using Andy.Containers.Configurator;
 using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Infrastructure.Messaging;
 using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
 using FluentAssertions;
@@ -25,6 +26,7 @@ public class RunsControllerTests : IDisposable
     private readonly RunsController _controller;
     private readonly Mock<IRunConfigurator> _configurator;
     private readonly Mock<IRunModeDispatcher> _dispatcher;
+    private readonly RunCancellationRegistry _cancellation;
 
     public RunsControllerTests()
     {
@@ -48,7 +50,13 @@ public class RunsControllerTests : IDisposable
                 Status = RunStatus.Succeeded,
                 ExitCode = 0,
             }));
-        _controller = new RunsController(_db, _configurator.Object, _dispatcher.Object, NullLogger<RunsController>.Instance);
+        // AP7 wires the cancellation registry into Cancel. Use the real
+        // implementation — it's a leaf class with no other deps and
+        // mocking it would just duplicate its surface.
+        _cancellation = new RunCancellationRegistry();
+        _controller = new RunsController(
+            _db, _configurator.Object, _dispatcher.Object, _cancellation,
+            NullLogger<RunsController>.Instance);
     }
 
     public void Dispose()
@@ -262,8 +270,12 @@ public class RunsControllerTests : IDisposable
     }
 
     [Fact]
-    public async Task Cancel_PendingRun_TransitionsToCancelled_ReturnsOk()
+    public async Task Cancel_PendingRun_TransitionsToCancelled_EmitsCancelledEvent_ReturnsOk()
     {
+        // AP7 (#109): the cancel endpoint emits run.cancelled regardless
+        // of whether a runner was active. For a Pending row no runner
+        // has registered yet, so the controller flips the row directly
+        // and writes the outbox row from there.
         var run = SeedRun(RunStatus.Pending);
 
         var result = await _controller.Cancel(run.Id, CancellationToken.None);
@@ -276,6 +288,11 @@ public class RunsControllerTests : IDisposable
 
         var persisted = await _db.Runs.FindAsync(run.Id);
         persisted!.Status.Should().Be(RunStatus.Cancelled);
+
+        var entry = _db.OutboxEntries.Should().ContainSingle(
+            "AP7 emits exactly one run.cancelled event for the no-runner path").Subject;
+        entry.Subject.Should().Be($"andy.containers.events.run.{run.Id}.cancelled");
+        entry.CorrelationId.Should().Be(run.CorrelationId);
     }
 
     [Fact]
@@ -286,7 +303,9 @@ public class RunsControllerTests : IDisposable
         var result = await _controller.Cancel(run.Id, CancellationToken.None);
 
         result.Should().BeOfType<ConflictObjectResult>(
-            "Run.TransitionTo throws on illegal transitions and the controller maps to 409");
+            "Cancelled is unreachable from terminal states; the controller maps to 409");
+        _db.OutboxEntries.Should().BeEmpty(
+            "a 409 must not emit a phantom cancelled event");
     }
 
     [Fact]
@@ -295,6 +314,80 @@ public class RunsControllerTests : IDisposable
         var result = await _controller.Cancel(Guid.NewGuid(), CancellationToken.None);
 
         result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Cancel_ActiveRunner_SignalsRegistry_AwaitsTerminal_ReturnsOk()
+    {
+        // AP7 (#109). When a runner is registered, the controller signals
+        // its linked CTS and awaits the runner's terminal write. We
+        // simulate the runner by registering then disposing the entry —
+        // disposal is what the real runner does in its `using` finally
+        // block once TerminateAsync has committed.
+        var run = SeedRun(RunStatus.Running);
+        var registration = _cancellation.Register(run.Id, CancellationToken.None);
+
+        // Schedule the "runner" to dispose its registration shortly after
+        // the cancel POST observes the signal. Use a minimal delay so
+        // the test exercises the wait + reload path, not the immediate
+        // dispose-before-wait shortcut.
+        _ = Task.Run(async () =>
+        {
+            // Give the controller a beat to call WaitForTerminalAsync.
+            await Task.Delay(10);
+            // Real runner would have written the terminal row + outbox
+            // event in TerminateAsync; mirror that here.
+            run.TransitionTo(RunStatus.Cancelled);
+            _db.AppendAgentRunEvent(run, RunEventKind.Cancelled);
+            await _db.SaveChangesAsync();
+            registration.Dispose();
+        });
+
+        var result = await _controller.Cancel(run.Id, CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<RunDto>().Subject;
+        dto.Status.Should().Be(RunStatus.Cancelled);
+
+        var persisted = await _db.Runs.FindAsync(run.Id);
+        persisted!.Status.Should().Be(RunStatus.Cancelled);
+
+        var entry = _db.OutboxEntries.Should().ContainSingle(
+            "the runner's TerminateAsync emits the cancelled event; the controller doesn't double-emit").Subject;
+        entry.Subject.Should().EndWith($".{run.Id}.cancelled");
+    }
+
+    [Fact]
+    public async Task Cancel_GraceExpires_ForcesCancelledTransition_EmitsEvent()
+    {
+        // AP7 (#109). If the runner doesn't observe its CTS within the
+        // grace window, the controller forces the row to Cancelled and
+        // emits the outbox event itself so the row never strands in
+        // Running. Use a mock registry to flip WaitForTerminalAsync
+        // to false synchronously — clock-independent.
+        var run = SeedRun(RunStatus.Running);
+        var registry = new Mock<IRunCancellationRegistry>();
+        registry.Setup(r => r.TryCancel(run.Id)).Returns(true);
+        registry.Setup(r => r.WaitForTerminalAsync(
+                run.Id, It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var controller = new RunsController(
+            _db, _configurator.Object, _dispatcher.Object, registry.Object,
+            NullLogger<RunsController>.Instance);
+
+        var result = await controller.Cancel(run.Id, CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<RunDto>().Subject;
+        dto.Status.Should().Be(RunStatus.Cancelled);
+
+        var persisted = await _db.Runs.FindAsync(run.Id);
+        persisted!.Status.Should().Be(RunStatus.Cancelled);
+
+        var entry = _db.OutboxEntries.Should().ContainSingle(
+            "grace-expired path must still produce a terminal subject for downstream consumers").Subject;
+        entry.Subject.Should().EndWith($".{run.Id}.cancelled");
     }
 
     private Run SeedRun(RunStatus status)

--- a/tests/Andy.Containers.Api.Tests/Services/Ap6Aq3SmokeTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/Ap6Aq3SmokeTests.cs
@@ -80,7 +80,8 @@ public class Ap6Aq3SmokeTests : IDisposable
         await _db.SaveChangesAsync();
 
         var hostExec = new HostSubprocessContainerService(cliDll);
-        var runner = new HeadlessRunner(hostExec, _db, NullLoggerForRunner());
+        var runner = new HeadlessRunner(
+            hostExec, _db, new RunCancellationRegistry(), NullLoggerForRunner());
 
         var outcome = await runner.StartAsync(run, configPath);
 

--- a/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
@@ -21,12 +21,14 @@ public class HeadlessRunnerTests : IDisposable
 {
     private readonly ContainersDbContext _db;
     private readonly Mock<IContainerService> _containers = new();
+    private readonly RunCancellationRegistry _cancellation = new();
     private readonly HeadlessRunner _runner;
 
     public HeadlessRunnerTests()
     {
         _db = InMemoryDbHelper.CreateContext();
-        _runner = new HeadlessRunner(_containers.Object, _db, NullLogger<HeadlessRunner>.Instance);
+        _runner = new HeadlessRunner(
+            _containers.Object, _db, _cancellation, NullLogger<HeadlessRunner>.Instance);
     }
 
     public void Dispose() => _db.Dispose();
@@ -146,6 +148,66 @@ public class HeadlessRunnerTests : IDisposable
 
         outcome.Kind.Should().Be(RunEventKind.Cancelled);
         outcome.Status.Should().Be(RunStatus.Cancelled);
+    }
+
+    [Fact]
+    public async Task StartAsync_RegistryCancelDuringExec_TerminatesAsCancelled()
+    {
+        // AP7 (rivoli-ai/andy-containers#109). The cancel endpoint signals
+        // the runner via the registry; the linked CTS fires inside ExecAsync
+        // and the runner's catch-OCE path should produce a Cancelled
+        // outcome + outbox event regardless of how the spawn was kicked
+        // off (caller token vs. registry signal).
+        var run = SeedRun();
+        var spawnedTcs = new TaskCompletionSource<bool>();
+        _containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .Returns<Guid, string, TimeSpan, CancellationToken>(async (_, _, _, token) =>
+            {
+                spawnedTcs.TrySetResult(true);
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("delay should have thrown");
+            });
+
+        var startTask = _runner.StartAsync(run, "/tmp/x/config.json");
+
+        // Wait for ExecAsync to be in flight before signalling — the
+        // runner's registration only exists between the SaveChanges of
+        // the Running transition and the using-disposal at end of method.
+        await spawnedTcs.Task;
+
+        _cancellation.TryCancel(run.Id).Should().BeTrue(
+            "the runner registers itself before invoking ExecAsync");
+
+        var outcome = await startTask;
+
+        outcome.Kind.Should().Be(RunEventKind.Cancelled);
+        outcome.Status.Should().Be(RunStatus.Cancelled);
+
+        var persisted = await _db.Runs.FindAsync(run.Id);
+        persisted!.Status.Should().Be(RunStatus.Cancelled);
+        persisted.EndedAt.Should().NotBeNull();
+
+        var entry = await _db.OutboxEntries.SingleAsync();
+        entry.Subject.Should().EndWith(".cancelled");
+    }
+
+    [Fact]
+    public async Task StartAsync_RegistryEntryRemovedAfterTerminal()
+    {
+        // The registration is `using`-scoped so disposal happens whether
+        // the run succeeds, fails, or is cancelled. After StartAsync
+        // returns, TryCancel must report no active registration so a
+        // late cancel POST falls through to the controller's no-runner
+        // path (flip + emit) instead of waiting forever.
+        var run = SeedRun();
+        SetupExec(run.ContainerId!.Value, exitCode: 0);
+
+        await _runner.StartAsync(run, "/tmp/x/config.json");
+
+        _cancellation.TryCancel(run.Id).Should().BeFalse(
+            "registration must be removed after the runner terminates");
     }
 
     [Fact]

--- a/tests/Andy.Containers.Api.Tests/Services/RunCancellationRegistryTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/RunCancellationRegistryTests.cs
@@ -1,0 +1,135 @@
+using Andy.Containers.Api.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+// AP7 (rivoli-ai/andy-containers#109). The registry is the only piece of
+// shared state between the cancel endpoint and the headless runner; if
+// these invariants drift, cancels silently no-op or hang the request
+// thread. Each test pins one observable behaviour rather than the
+// implementation, so the registry can be re-shaped (e.g. swapped for a
+// distributed control channel) without rewriting the suite.
+public class RunCancellationRegistryTests
+{
+    [Fact]
+    public void Register_LinkedTokenObservesOuterCancellation()
+    {
+        var registry = new RunCancellationRegistry();
+        var runId = Guid.NewGuid();
+        using var outer = new CancellationTokenSource();
+
+        using var registration = registry.Register(runId, outer.Token);
+
+        registration.Token.IsCancellationRequested.Should().BeFalse();
+        outer.Cancel();
+        registration.Token.IsCancellationRequested.Should().BeTrue(
+            "the runner's exec token is linked to the caller's outer ct");
+    }
+
+    [Fact]
+    public void TryCancel_SignalsLinkedToken_AndReturnsTrue()
+    {
+        var registry = new RunCancellationRegistry();
+        var runId = Guid.NewGuid();
+        using var registration = registry.Register(runId, CancellationToken.None);
+
+        var cancelled = registry.TryCancel(runId);
+
+        cancelled.Should().BeTrue();
+        registration.Token.IsCancellationRequested.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryCancel_UnknownRun_ReturnsFalse()
+    {
+        var registry = new RunCancellationRegistry();
+
+        registry.TryCancel(Guid.NewGuid()).Should().BeFalse(
+            "the cancel endpoint relies on this signal to fall back to the no-runner path");
+    }
+
+    [Fact]
+    public void Register_DuplicateRunId_Throws()
+    {
+        var registry = new RunCancellationRegistry();
+        var runId = Guid.NewGuid();
+        using var first = registry.Register(runId, CancellationToken.None);
+
+        var act = () => registry.Register(runId, CancellationToken.None);
+
+        act.Should().Throw<InvalidOperationException>(
+            "AP6 starts at most one runner per Run; double-register is a caller bug");
+    }
+
+    [Fact]
+    public void Register_AfterDispose_AllowsReregistration()
+    {
+        var registry = new RunCancellationRegistry();
+        var runId = Guid.NewGuid();
+        var first = registry.Register(runId, CancellationToken.None);
+        first.Dispose();
+
+        var act = () => registry.Register(runId, CancellationToken.None);
+
+        act.Should().NotThrow(
+            "after a runner exits the slot must free up for the next attempt");
+    }
+
+    [Fact]
+    public async Task WaitForTerminalAsync_UnregisteredRun_ReturnsTrueImmediately()
+    {
+        var registry = new RunCancellationRegistry();
+
+        var result = await registry.WaitForTerminalAsync(
+            Guid.NewGuid(), TimeSpan.FromSeconds(5), CancellationToken.None);
+
+        result.Should().BeTrue(
+            "no registration ⇒ already terminal or never started; refetch the row");
+    }
+
+    [Fact]
+    public async Task WaitForTerminalAsync_DisposalSignalsWaiter()
+    {
+        var registry = new RunCancellationRegistry();
+        var runId = Guid.NewGuid();
+        var registration = registry.Register(runId, CancellationToken.None);
+
+        var waitTask = registry.WaitForTerminalAsync(
+            runId, TimeSpan.FromSeconds(5), CancellationToken.None);
+
+        registration.Dispose();
+
+        var result = await waitTask;
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task WaitForTerminalAsync_TimeoutReturnsFalse()
+    {
+        var registry = new RunCancellationRegistry();
+        var runId = Guid.NewGuid();
+        using var registration = registry.Register(runId, CancellationToken.None);
+
+        var result = await registry.WaitForTerminalAsync(
+            runId, TimeSpan.FromMilliseconds(50), CancellationToken.None);
+
+        result.Should().BeFalse("the runner never disposed within the grace");
+    }
+
+    [Fact]
+    public async Task WaitForTerminalAsync_CallerCancellation_ThrowsOperationCanceled()
+    {
+        var registry = new RunCancellationRegistry();
+        var runId = Guid.NewGuid();
+        using var registration = registry.Register(runId, CancellationToken.None);
+        using var cts = new CancellationTokenSource();
+
+        var waitTask = registry.WaitForTerminalAsync(runId, TimeSpan.FromSeconds(5), cts.Token);
+        cts.Cancel();
+
+        await FluentActions.Awaiting(() => waitTask)
+            .Should().ThrowAsync<OperationCanceledException>(
+                "caller hangup must propagate, not be swallowed as a timeout");
+    }
+}


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#109

## Summary

- New `IRunCancellationRegistry` (singleton) maps `Run.Id` → linked CTS + `TaskCompletionSource`. The headless runner registers in `StartAsync` (so `ExecAsync` runs against a token the cancel endpoint can fire) and disposes via `using` so every exit path — success, cancel, throw — wakes any waiting cancel request.
- `RunsController.Cancel` is reshaped to signal-and-wait: if a runner is registered, `TryCancel` fires its CTS and the controller awaits `WaitForTerminalAsync` up to a 30s grace before forcibly transitioning + emitting the outbox event itself. For the no-runner Pending path the controller flips and emits directly. Either way the API contract — one `andy.containers.events.run.{id}.cancelled` per cancel — holds.
- Fixes a pre-existing gap: the AP2 stub never emitted `run.cancelled` for Pending-row cancellations; AP7 closes that.

## Test plan

- [x] `RunCancellationRegistryTests` — Register/TryCancel/WaitForTerminalAsync semantics, double-register protection, dispose-after-wait, caller-cancel propagation.
- [x] `HeadlessRunnerTests.StartAsync_RegistryCancelDuringExec_TerminatesAsCancelled` — runner's catch-OCE path produces a cancelled outcome + outbox event when the registry fires its CTS mid-exec.
- [x] `HeadlessRunnerTests.StartAsync_RegistryEntryRemovedAfterTerminal` — `using` scope cleans up so a late cancel POST falls through to the no-runner path.
- [x] `RunsControllerTests.Cancel_ActiveRunner_SignalsRegistry_AwaitsTerminal_ReturnsOk` — signal + wait + reload + return.
- [x] `RunsControllerTests.Cancel_GraceExpires_ForcesCancelledTransition_EmitsEvent` — clock-independent (mocked registry returns `false` from `WaitForTerminalAsync`); confirms the row never strands in Running.
- [x] `RunsControllerTests.Cancel_PendingRun_…_EmitsCancelledEvent_ReturnsOk` — closes the existing missing-event gap.
- [x] `dotnet test` (Api.Tests + Containers.Tests + Client.Tests): 1062 passed, 1 skipped (Ap6Aq3 smoke). Apple integration tests fail without the `container` CLI installed; unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)