### PR TITLE
AP8: MCP tool surface for runs — create / get / cancel / events (#110)

### DIFF
--- a/src/Andy.Containers.Api/Mcp/RunsMcpTools.cs
+++ b/src/Andy.Containers.Api/Mcp/RunsMcpTools.cs
@@ -1,0 +1,393 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Configurator;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Messaging;
+using Andy.Containers.Messaging.Events;
+using Andy.Containers.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace Andy.Containers.Api.Mcp;
+
+/// <summary>
+/// AP8 (rivoli-ai/andy-containers#110). MCP surface for Epic AP's agent
+/// runs: <c>run.create</c>, <c>run.get</c>, <c>run.cancel</c>,
+/// <c>run.events</c>. Mirrors the <c>/api/runs</c> HTTP endpoints in shape
+/// and side-effects so MCP clients see the same lifecycle the REST clients
+/// see — same RunDto, same outbox subjects, same state-machine guarantees.
+/// </summary>
+/// <remarks>
+/// Permissions are enforced inline against the user's primary org via
+/// <see cref="IOrganizationMembershipService"/> — the same convention
+/// <see cref="ContainersMcpTools"/> uses. Admins bypass org checks.
+/// Tools return <c>null</c> on permission denial / 404 / illegal state
+/// transitions to keep the surface uniform; full error envelopes are
+/// HTTP-only.
+/// </remarks>
+[McpServerToolType]
+public class RunsMcpTools
+{
+    private readonly ContainersDbContext _db;
+    private readonly IRunConfigurator _configurator;
+    private readonly IRunModeDispatcher _dispatcher;
+    private readonly IRunCancellationRegistry _cancellation;
+    private readonly ICurrentUserService _currentUser;
+    private readonly IOrganizationMembershipService _orgMembership;
+    private readonly ILogger<RunsMcpTools> _logger;
+
+    // Mirror the HTTP cancel-grace ceiling (RunsController.CancelGrace).
+    // Most cancels resolve in <100ms; 30s is the hung-exec backstop.
+    private static readonly TimeSpan CancelGrace = TimeSpan.FromSeconds(30);
+
+    // Outbox poll interval for run.events. Short enough that a fresh
+    // event lands in the stream within a hundred ms or two; not so
+    // short that we hammer the DB with empty selects on a quiet run.
+    private static readonly TimeSpan EventsPollInterval = TimeSpan.FromMilliseconds(250);
+
+    public RunsMcpTools(
+        ContainersDbContext db,
+        IRunConfigurator configurator,
+        IRunModeDispatcher dispatcher,
+        IRunCancellationRegistry cancellation,
+        ICurrentUserService currentUser,
+        IOrganizationMembershipService orgMembership,
+        ILogger<RunsMcpTools> logger)
+    {
+        _db = db;
+        _configurator = configurator;
+        _dispatcher = dispatcher;
+        _cancellation = cancellation;
+        _currentUser = currentUser;
+        _orgMembership = orgMembership;
+        _logger = logger;
+    }
+
+    [McpServerTool(Name = "run.create"), Description(
+        "Create an agent run. Persists the run as Pending, builds the headless config, and hands off to the mode dispatcher. " +
+        "Returns the RunDto reflecting whatever state the run reached before this call returns. " +
+        "Requires run:write.")]
+    public async Task<RunDto?> Create(
+        [Description("Agent slug from andy-agents (e.g. 'triage-agent').")] string agentId,
+        [Description("Mode: 'Headless', 'Terminal', or 'Desktop'.")] string mode,
+        [Description("EnvironmentProfile id (GUID).")] string environmentProfileId,
+        [Description("Optional agent revision pin; null/0 = head.")] int? agentRevision = null,
+        [Description("Optional workspace id (GUID).")] string? workspaceId = null,
+        [Description("Optional branch name.")] string? branch = null,
+        [Description("Optional policy id (GUID).")] string? policyId = null,
+        [Description("Optional ADR-0001 root causation id (GUID); minted if omitted.")] string? correlationId = null,
+        CancellationToken ct = default)
+    {
+        if (!await EnsurePermission(Permissions.RunWrite, ct)) return null;
+
+        if (!Enum.TryParse<RunMode>(mode, ignoreCase: true, out var parsedMode))
+        {
+            _logger.LogWarning("run.create rejected: unknown mode '{Mode}'", mode);
+            return null;
+        }
+
+        if (!Guid.TryParse(environmentProfileId, out var profileId) || profileId == Guid.Empty)
+        {
+            _logger.LogWarning("run.create rejected: environmentProfileId '{Id}' is not a non-empty GUID", environmentProfileId);
+            return null;
+        }
+
+        WorkspaceRef workspaceRef = new();
+        if (!string.IsNullOrWhiteSpace(workspaceId))
+        {
+            if (!Guid.TryParse(workspaceId, out var wid) || wid == Guid.Empty)
+            {
+                _logger.LogWarning("run.create rejected: workspaceId '{Id}' is not a non-empty GUID", workspaceId);
+                return null;
+            }
+            workspaceRef = new WorkspaceRef { WorkspaceId = wid, Branch = branch };
+        }
+
+        Guid? parsedPolicyId = null;
+        if (!string.IsNullOrWhiteSpace(policyId))
+        {
+            if (!Guid.TryParse(policyId, out var pid)) return null;
+            parsedPolicyId = pid;
+        }
+
+        Guid? parsedCorrelationId = null;
+        if (!string.IsNullOrWhiteSpace(correlationId))
+        {
+            if (!Guid.TryParse(correlationId, out var cid)) return null;
+            parsedCorrelationId = cid;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = agentId,
+            AgentRevision = agentRevision,
+            Mode = parsedMode,
+            EnvironmentProfileId = profileId,
+            WorkspaceRef = workspaceRef,
+            PolicyId = parsedPolicyId,
+            CorrelationId = parsedCorrelationId ?? Guid.NewGuid(),
+            Status = RunStatus.Pending,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        _db.Runs.Add(run);
+        await _db.SaveChangesAsync(ct);
+
+        // Same handoff sequence as RunsController.Create: configurator
+        // writes the andy-cli config, then the dispatcher takes over.
+        // Both are best-effort — failures leave the row in a non-terminal
+        // state for a later retry rather than rolling back submission.
+        var configResult = await _configurator.ConfigureAsync(run, ct);
+        if (!configResult.IsSuccess)
+        {
+            _logger.LogWarning(
+                "run.create: Run {RunId} persisted as Pending but configurator failed: {Error}.",
+                run.Id, configResult.Error);
+        }
+        else
+        {
+            var dispatch = await _dispatcher.DispatchAsync(run, configResult.Path!, ct);
+            if (dispatch.Kind is RunDispatchKind.Failed or RunDispatchKind.NotImplemented)
+            {
+                _logger.LogWarning(
+                    "run.create: Run {RunId} dispatch returned {Kind}: {Error}",
+                    run.Id, dispatch.Kind, dispatch.Error);
+            }
+        }
+
+        return RunDto.FromEntity(run);
+    }
+
+    [McpServerTool(Name = "run.get"), Description(
+        "Fetch a run by id. Returns null when the run is unknown or the caller lacks run:read.")]
+    public async Task<RunDto?> Get(
+        [Description("Run id (GUID).")] string runId,
+        CancellationToken ct = default)
+    {
+        if (!await EnsurePermission(Permissions.RunRead, ct)) return null;
+        if (!Guid.TryParse(runId, out var id)) return null;
+
+        var run = await _db.Runs.AsNoTracking().FirstOrDefaultAsync(r => r.Id == id, ct);
+        return run is null ? null : RunDto.FromEntity(run);
+    }
+
+    [McpServerTool(Name = "run.cancel"), Description(
+        "Cancel a non-terminal run. Signals the active runner via the cancellation registry and awaits its terminal write " +
+        "up to a 30s grace; falls back to flipping the row directly when no runner is active. " +
+        "Returns null when the run is unknown, already terminal, or the caller lacks run:execute.")]
+    public async Task<RunDto?> Cancel(
+        [Description("Run id (GUID).")] string runId,
+        CancellationToken ct = default)
+    {
+        if (!await EnsurePermission(Permissions.RunExecute, ct)) return null;
+        if (!Guid.TryParse(runId, out var id)) return null;
+
+        var run = await _db.Runs.FirstOrDefaultAsync(r => r.Id == id, ct);
+        if (run is null) return null;
+
+        if (!RunStatusTransitions.CanTransition(run.Status, RunStatus.Cancelled))
+        {
+            // MCP contract surfaces 'already terminal' as null. Callers
+            // get the same information by reading the run via run.get.
+            return null;
+        }
+
+        if (_cancellation.TryCancel(run.Id))
+        {
+            var terminal = await _cancellation.WaitForTerminalAsync(run.Id, CancelGrace, ct);
+            await _db.Entry(run).ReloadAsync(ct);
+
+            if (!terminal)
+            {
+                _logger.LogWarning(
+                    "run.cancel: Run {RunId} cancel grace ({GraceSeconds}s) expired before runner terminal write; forcing Cancelled.",
+                    run.Id, (int)CancelGrace.TotalSeconds);
+                ForceCancel(run);
+                await _db.SaveChangesAsync(ct);
+            }
+
+            return RunDto.FromEntity(run);
+        }
+
+        ForceCancel(run);
+        await _db.SaveChangesAsync(ct);
+        return RunDto.FromEntity(run);
+    }
+
+    [McpServerTool(Name = "run.events"), Description(
+        "Stream lifecycle events for a run on andy.containers.events.run.{id}.* — finished, failed, cancelled, timeout. " +
+        "Yields any backfill (events that already landed in the outbox) then live events as they commit. " +
+        "Stops when the run reaches a terminal state or the caller cancels. Requires run:read.")]
+    public async IAsyncEnumerable<RunEventDto> Events(
+        [Description("Run id (GUID).")] string runId,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        if (!await EnsurePermission(Permissions.RunRead, ct)) yield break;
+        if (!Guid.TryParse(runId, out var id)) yield break;
+
+        var subjectPrefix = $"andy.containers.events.run.{id}.";
+        DateTimeOffset? cursor = null;
+        var sawTerminal = false;
+
+        while (!ct.IsCancellationRequested)
+        {
+            // Fetch any new outbox rows for this run, ordered by creation.
+            // We key the cursor on CreatedAt + ascending id ordering by
+            // pulling a bounded batch and ordering client-side — same
+            // constraint OutboxDispatcher hits with SQLite (DateTimeOffset
+            // ORDER BY isn't translatable). 64 rows / tick is plenty for
+            // a single-run view.
+            var query = _db.OutboxEntries
+                .AsNoTracking()
+                .Where(e => e.Subject.StartsWith(subjectPrefix));
+            if (cursor is not null)
+            {
+                query = query.Where(e => e.CreatedAt > cursor.Value);
+            }
+
+            var batch = (await query.Take(64).ToListAsync(ct))
+                .OrderBy(e => e.CreatedAt)
+                .ToList();
+
+            foreach (var entry in batch)
+            {
+                var dto = RunEventDto.FromOutbox(entry);
+                if (dto is null) continue;
+                cursor = entry.CreatedAt;
+                yield return dto;
+            }
+
+            if (sawTerminal && batch.Count == 0)
+            {
+                // We saw the terminal status on a prior tick AND this
+                // tick produced nothing new — every event committed
+                // before the terminal write has been delivered.
+                yield break;
+            }
+
+            // Re-check the row's status. Reading the OutboxEntry alone
+            // isn't sufficient because the controller's force-cancel
+            // path may flip the row before its outbox row appears
+            // (they commit together, but the read-fan-out can interleave).
+            var current = await _db.Runs
+                .AsNoTracking()
+                .Where(r => r.Id == id)
+                .Select(r => (RunStatus?)r.Status)
+                .FirstOrDefaultAsync(ct);
+            if (current is null)
+            {
+                // Run was deleted out from under us — close cleanly.
+                yield break;
+            }
+            if (RunStatusTransitions.IsTerminal(current.Value))
+            {
+                sawTerminal = true;
+                // One more pass to drain any event that landed between
+                // this cursor and the terminal write before we exit.
+                continue;
+            }
+
+            try
+            {
+                await Task.Delay(EventsPollInterval, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                yield break;
+            }
+        }
+    }
+
+    private async Task<bool> EnsurePermission(string permission, CancellationToken ct)
+    {
+        if (_currentUser.IsAdmin()) return true;
+
+        var userId = _currentUser.GetUserId();
+        if (string.IsNullOrEmpty(userId)) return false;
+
+        var orgId = _currentUser.GetOrganizationId();
+        if (orgId is null)
+        {
+            // No primary org → can't evaluate org-scoped permission.
+            // Match the existing MCP convention (deny on missing org).
+            return false;
+        }
+
+        return await _orgMembership.HasPermissionAsync(userId, orgId.Value, permission, ct);
+    }
+
+    private void ForceCancel(Run run)
+    {
+        if (RunStatusTransitions.CanTransition(run.Status, RunStatus.Cancelled))
+        {
+            run.TransitionTo(RunStatus.Cancelled);
+        }
+
+        _db.AppendAgentRunEvent(run, RunEventKind.Cancelled);
+    }
+}
+
+/// <summary>
+/// AP8 wire-shape for an event yielded by <c>run.events</c>. One DTO per
+/// outbox row. Carries the parsed <see cref="RunEventPayload"/> fields plus
+/// the wire metadata MCP consumers want without making them re-parse JSON.
+/// </summary>
+public sealed record RunEventDto
+{
+    public required Guid RunId { get; init; }
+    public required string Subject { get; init; }
+    /// <summary>One of <c>finished</c>, <c>failed</c>, <c>cancelled</c>, <c>timeout</c>.</summary>
+    public required string Kind { get; init; }
+    /// <summary>Mirrors the run's status at emission (e.g. <c>Cancelled</c>, <c>Succeeded</c>).</summary>
+    public required string Status { get; init; }
+    public int? ExitCode { get; init; }
+    public double? DurationSeconds { get; init; }
+    public required DateTimeOffset Timestamp { get; init; }
+    public required Guid CorrelationId { get; init; }
+
+    /// <summary>
+    /// Parse an <see cref="OutboxEntry"/> into a <see cref="RunEventDto"/>.
+    /// Returns null on a malformed payload — callers skip rather than
+    /// surfacing a parse error mid-stream.
+    /// </summary>
+    public static RunEventDto? FromOutbox(OutboxEntry entry)
+    {
+        RunEventPayload? payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize<RunEventPayload>(entry.PayloadJson, EventJson.Options);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        if (payload is null) return null;
+
+        // Subject suffix after the last '.' is the kind: e.g.
+        // andy.containers.events.run.{id}.cancelled → "cancelled".
+        var lastDot = entry.Subject.LastIndexOf('.');
+        var kind = lastDot >= 0 && lastDot < entry.Subject.Length - 1
+            ? entry.Subject[(lastDot + 1)..]
+            : entry.Subject;
+
+        return new RunEventDto
+        {
+            RunId = payload.RunId,
+            Subject = entry.Subject,
+            Kind = kind,
+            Status = payload.Status,
+            ExitCode = payload.ExitCode,
+            DurationSeconds = payload.DurationSeconds,
+            Timestamp = entry.CreatedAt,
+            CorrelationId = entry.CorrelationId,
+        };
+    }
+}

--- a/src/Andy.Containers/Models/Permissions.cs
+++ b/src/Andy.Containers/Models/Permissions.cs
@@ -22,6 +22,14 @@ public static class Permissions
     // API Key permissions
     public const string ApiKeyManage = "api-key:manage";
     public const string ApiKeyAdmin = "api-key:admin";
+
+    // Run permissions (Epic AP). RunsController already gates on these
+    // strings; AP8 adds them to the catalog so MCP tools can check via
+    // IOrganizationMembershipService and Editor/Viewer roles get the
+    // expected default scopes.
+    public const string RunWrite = "run:write";
+    public const string RunRead = "run:read";
+    public const string RunExecute = "run:execute";
 }
 
 public static class OrgRoles
@@ -38,16 +46,19 @@ public static class OrgRoles
             Permissions.TemplateCreate, Permissions.TemplateRead,
             Permissions.TemplatePublish, Permissions.TemplateManage,
             Permissions.ProviderRead, Permissions.ProviderManage,
-            Permissions.ApiKeyManage, Permissions.ApiKeyAdmin
+            Permissions.ApiKeyManage, Permissions.ApiKeyAdmin,
+            Permissions.RunWrite, Permissions.RunRead, Permissions.RunExecute
         ],
         Editor => [
             Permissions.ImageCreate, Permissions.ImageRead, Permissions.ImageBuild,
             Permissions.TemplateCreate, Permissions.TemplateRead, Permissions.TemplateManage,
-            Permissions.ApiKeyManage
+            Permissions.ApiKeyManage,
+            Permissions.RunWrite, Permissions.RunRead, Permissions.RunExecute
         ],
         Viewer => [
             Permissions.ImageRead, Permissions.TemplateRead, Permissions.ProviderRead,
-            Permissions.ApiKeyManage
+            Permissions.ApiKeyManage,
+            Permissions.RunRead
         ],
         _ => []
     };

--- a/tests/Andy.Containers.Api.Tests/Mcp/RunsMcpToolsTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Mcp/RunsMcpToolsTests.cs
@@ -1,0 +1,397 @@
+using Andy.Containers.Api.Mcp;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Configurator;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Messaging.Events;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Mcp;
+
+// AP8 (rivoli-ai/andy-containers#110). RunsMcpTools mirrors the RunsController
+// surface for MCP clients. These tests pin the contract that matters:
+// permission gating, validation parity with the controller, and the
+// event-stream's terminal-stop guarantee. The tools call the real
+// IRunCancellationRegistry so the runner-signal path doesn't drift from
+// what AP7 wired into the HTTP layer.
+public class RunsMcpToolsTests : IDisposable
+{
+    private readonly ContainersDbContext _db;
+    private readonly Mock<IRunConfigurator> _configurator;
+    private readonly Mock<IRunModeDispatcher> _dispatcher;
+    private readonly RunCancellationRegistry _cancellation;
+    private readonly Mock<ICurrentUserService> _currentUser;
+    private readonly Mock<IOrganizationMembershipService> _orgMembership;
+    private readonly RunsMcpTools _tools;
+    private readonly Guid _orgId = Guid.NewGuid();
+
+    public RunsMcpToolsTests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+
+        _configurator = new Mock<IRunConfigurator>();
+        _configurator
+            .Setup(c => c.ConfigureAsync(It.IsAny<Run>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RunConfiguratorResult.Ok("/tmp/noop/config.json"));
+
+        _dispatcher = new Mock<IRunModeDispatcher>();
+        _dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<Run>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RunDispatchOutcome.Started(new HeadlessRunOutcome
+            {
+                Kind = RunEventKind.Finished,
+                Status = RunStatus.Succeeded,
+                ExitCode = 0,
+            }));
+
+        _cancellation = new RunCancellationRegistry();
+
+        _currentUser = new Mock<ICurrentUserService>();
+        _currentUser.Setup(u => u.GetUserId()).Returns("test-user");
+        _currentUser.Setup(u => u.IsAdmin()).Returns(false);
+        _currentUser.Setup(u => u.GetOrganizationId()).Returns(_orgId);
+
+        _orgMembership = new Mock<IOrganizationMembershipService>();
+        // Default: user has every run permission. Specific tests flip
+        // individual perms to false to exercise denial paths.
+        _orgMembership
+            .Setup(o => o.HasPermissionAsync(
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _tools = new RunsMcpTools(
+            _db, _configurator.Object, _dispatcher.Object, _cancellation,
+            _currentUser.Object, _orgMembership.Object,
+            NullLogger<RunsMcpTools>.Instance);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    // run.create
+
+    [Fact]
+    public async Task Create_HappyPath_PersistsRunAndCallsDispatcher()
+    {
+        var profileId = Guid.NewGuid();
+
+        var dto = await _tools.Create(
+            agentId: "triage-agent",
+            mode: "Headless",
+            environmentProfileId: profileId.ToString());
+
+        dto.Should().NotBeNull();
+        dto!.AgentId.Should().Be("triage-agent");
+        dto.Mode.Should().Be(RunMode.Headless);
+        dto.EnvironmentProfileId.Should().Be(profileId);
+
+        var persisted = await _db.Runs.FirstOrDefaultAsync(r => r.Id == dto.Id);
+        persisted.Should().NotBeNull();
+
+        _configurator.Verify(c => c.ConfigureAsync(It.IsAny<Run>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _dispatcher.Verify(d => d.DispatchAsync(It.IsAny<Run>(), "/tmp/noop/config.json", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_NonAdminWithoutRunWrite_ReturnsNullAndDoesNotPersist()
+    {
+        _orgMembership
+            .Setup(o => o.HasPermissionAsync(
+                It.IsAny<string>(), _orgId, Permissions.RunWrite, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var dto = await _tools.Create(
+            agentId: "x", mode: "Headless", environmentProfileId: Guid.NewGuid().ToString());
+
+        dto.Should().BeNull();
+        (await _db.Runs.AnyAsync()).Should().BeFalse(
+            "permission denial must not produce a Pending row");
+        _dispatcher.Verify(d => d.DispatchAsync(
+            It.IsAny<Run>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Create_AdminBypassesOrgPermissionCheck()
+    {
+        _currentUser.Setup(u => u.IsAdmin()).Returns(true);
+        _orgMembership
+            .Setup(o => o.HasPermissionAsync(
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var dto = await _tools.Create(
+            agentId: "x", mode: "Headless", environmentProfileId: Guid.NewGuid().ToString());
+
+        dto.Should().NotBeNull("admin shortcut precedes the org permission lookup");
+    }
+
+    [Theory]
+    [InlineData("not-a-mode")]
+    [InlineData("")]
+    public async Task Create_InvalidMode_ReturnsNull(string mode)
+    {
+        var dto = await _tools.Create(
+            agentId: "x", mode: mode, environmentProfileId: Guid.NewGuid().ToString());
+
+        dto.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("not-a-guid")]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
+    public async Task Create_InvalidEnvironmentProfileId_ReturnsNull(string profileId)
+    {
+        var dto = await _tools.Create(
+            agentId: "x", mode: "Headless", environmentProfileId: profileId);
+
+        dto.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Create_ConfiguratorFails_StillReturnsPendingDto()
+    {
+        _configurator
+            .Setup(c => c.ConfigureAsync(It.IsAny<Run>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RunConfiguratorResult.Fail("simulated"));
+
+        var dto = await _tools.Create(
+            agentId: "x", mode: "Headless", environmentProfileId: Guid.NewGuid().ToString());
+
+        dto.Should().NotBeNull();
+        dto!.Status.Should().Be(RunStatus.Pending);
+        _dispatcher.Verify(d => d.DispatchAsync(
+            It.IsAny<Run>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "dispatcher must not be invoked when the configurator fails");
+    }
+
+    // run.get
+
+    [Fact]
+    public async Task Get_ExistingRun_ReturnsDto()
+    {
+        var run = SeedRun(RunStatus.Running);
+
+        var dto = await _tools.Get(run.Id.ToString());
+
+        dto.Should().NotBeNull();
+        dto!.Id.Should().Be(run.Id);
+        dto.Status.Should().Be(RunStatus.Running);
+    }
+
+    [Fact]
+    public async Task Get_NonexistentRun_ReturnsNull()
+    {
+        var dto = await _tools.Get(Guid.NewGuid().ToString());
+
+        dto.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Get_InvalidGuid_ReturnsNull()
+    {
+        var dto = await _tools.Get("not-a-guid");
+
+        dto.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Get_NonAdminWithoutRunRead_ReturnsNull()
+    {
+        var run = SeedRun(RunStatus.Running);
+        _orgMembership
+            .Setup(o => o.HasPermissionAsync(
+                It.IsAny<string>(), _orgId, Permissions.RunRead, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var dto = await _tools.Get(run.Id.ToString());
+
+        dto.Should().BeNull();
+    }
+
+    // run.cancel
+
+    [Fact]
+    public async Task Cancel_PendingRun_ReturnsCancelledDto_EmitsEvent()
+    {
+        var run = SeedRun(RunStatus.Pending);
+
+        var dto = await _tools.Cancel(run.Id.ToString());
+
+        dto.Should().NotBeNull();
+        dto!.Status.Should().Be(RunStatus.Cancelled);
+
+        var entry = _db.OutboxEntries.Should().ContainSingle().Subject;
+        entry.Subject.Should().EndWith($".{run.Id}.cancelled");
+    }
+
+    [Fact]
+    public async Task Cancel_TerminalRun_ReturnsNull()
+    {
+        var run = SeedRun(RunStatus.Succeeded);
+
+        var dto = await _tools.Cancel(run.Id.ToString());
+
+        dto.Should().BeNull("MCP surfaces 'already terminal' as null per the tool docstring");
+        _db.OutboxEntries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Cancel_NonexistentRun_ReturnsNull()
+    {
+        var dto = await _tools.Cancel(Guid.NewGuid().ToString());
+
+        dto.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Cancel_NonAdminWithoutRunExecute_ReturnsNull_DoesNotFlipRow()
+    {
+        var run = SeedRun(RunStatus.Pending);
+        _orgMembership
+            .Setup(o => o.HasPermissionAsync(
+                It.IsAny<string>(), _orgId, Permissions.RunExecute, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var dto = await _tools.Cancel(run.Id.ToString());
+
+        dto.Should().BeNull();
+        var persisted = await _db.Runs.FindAsync(run.Id);
+        persisted!.Status.Should().Be(RunStatus.Pending,
+            "denied cancels must not mutate the run");
+    }
+
+    [Fact]
+    public async Task Cancel_ActiveRunner_SignalsRegistry_AwaitsTerminal()
+    {
+        var run = SeedRun(RunStatus.Running);
+        var registration = _cancellation.Register(run.Id, CancellationToken.None);
+
+        // Simulate the runner's own terminate-on-cancel after a beat.
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(10);
+            run.TransitionTo(RunStatus.Cancelled);
+            _db.AppendAgentRunEvent(run, RunEventKind.Cancelled);
+            await _db.SaveChangesAsync();
+            registration.Dispose();
+        });
+
+        var dto = await _tools.Cancel(run.Id.ToString());
+
+        dto.Should().NotBeNull();
+        dto!.Status.Should().Be(RunStatus.Cancelled);
+        _db.OutboxEntries.Should().ContainSingle(
+            "the runner's TerminateAsync emits the event; the MCP tool doesn't double-emit");
+    }
+
+    // run.events
+
+    [Fact]
+    public async Task Events_TerminalRunWithBackfill_YieldsAllEventsThenStops()
+    {
+        var run = SeedRun(RunStatus.Succeeded);
+        // Two backfilled outbox rows, one a wrong-run noise row that must
+        // be filtered out by the subject prefix check.
+        _db.AppendAgentRunEvent(run, RunEventKind.Finished, exitCode: 0, durationSeconds: 1.5);
+        var unrelated = SeedRun(RunStatus.Failed);
+        _db.AppendAgentRunEvent(unrelated, RunEventKind.Failed);
+        await _db.SaveChangesAsync();
+
+        var collected = new List<RunEventDto>();
+        await foreach (var evt in _tools.Events(run.Id.ToString()))
+        {
+            collected.Add(evt);
+        }
+
+        collected.Should().ContainSingle()
+            .Which.Subject.Should().Be($"andy.containers.events.run.{run.Id}.finished");
+        collected[0].Kind.Should().Be("finished");
+        collected[0].ExitCode.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Events_StopsOnTerminalAfterDrain()
+    {
+        var run = SeedRun(RunStatus.Running);
+
+        // Start the stream, then transition + emit + flip terminal.
+        var streamCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var streamTask = Task.Run(async () =>
+        {
+            var collected = new List<RunEventDto>();
+            await foreach (var evt in _tools.Events(run.Id.ToString(), streamCts.Token))
+            {
+                collected.Add(evt);
+            }
+            return collected;
+        });
+
+        // Wait one poll cycle so the consumer is in the loop.
+        await Task.Delay(50);
+
+        run.TransitionTo(RunStatus.Cancelled);
+        _db.AppendAgentRunEvent(run, RunEventKind.Cancelled);
+        await _db.SaveChangesAsync();
+
+        var collected = await streamTask;
+
+        collected.Should().ContainSingle().Which.Kind.Should().Be("cancelled");
+        streamCts.IsCancellationRequested.Should().BeFalse(
+            "the stream must close on terminal observation rather than the timeout");
+    }
+
+    [Fact]
+    public async Task Events_NonAdminWithoutRunRead_YieldsNothing()
+    {
+        var run = SeedRun(RunStatus.Pending);
+        _orgMembership
+            .Setup(o => o.HasPermissionAsync(
+                It.IsAny<string>(), _orgId, Permissions.RunRead, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var collected = new List<RunEventDto>();
+        await foreach (var evt in _tools.Events(run.Id.ToString()))
+        {
+            collected.Add(evt);
+        }
+
+        collected.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Events_InvalidGuid_YieldsNothing()
+    {
+        var collected = new List<RunEventDto>();
+        await foreach (var evt in _tools.Events("not-a-guid"))
+        {
+            collected.Add(evt);
+        }
+
+        collected.Should().BeEmpty();
+    }
+
+    private Run SeedRun(RunStatus status)
+    {
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "seed-agent",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            Status = status,
+        };
+        _db.Runs.Add(run);
+        _db.SaveChanges();
+        return run;
+    }
+}


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#110

## Summary

Four new \`[McpServerTool]\` methods on a new \`RunsMcpTools\` class, mirroring the \`/api/runs\` HTTP endpoints:

- **\`run.create\`** (\`run:write\`) — persists Pending, runs the configurator, hands off to the AP5 dispatcher. Same orchestration as \`RunsController.Create\`.
- **\`run.get\`** (\`run:read\`) — returns \`RunDto\`.
- **\`run.cancel\`** (\`run:execute\`) — reuses AP7's \`IRunCancellationRegistry\`: signals the runner, awaits terminal up to 30s, falls back to forcing the row + emitting the cancelled outbox event.
- **\`run.events\`** (\`run:read\`) — novel: polls \`OutboxEntries\` for \`andy.containers.events.run.{id}.*\` rows and yields a typed \`RunEventDto\`. Stops on terminal status (with a final drain pass) or caller cancel.

Also adds \`run:write\` / \`run:read\` / \`run:execute\` to the \`Permissions\` catalog. \`RunsController\` already strings-references those scopes; AP8 elevates them to constants and wires them into the Admin/Editor/Viewer role mappings (Editor inherits all three; Viewer inherits only \`run:read\`).

## Notes & follow-ups

- The MCP cancel/create logic duplicates ~30 lines of the HTTP controller. Extracting an \`IRunsService\` is a sensible follow-up once we know whether AP9 (CLI) wants to share the same path.
- AP8's spec says \"create requires write scope, others read scope\". I mapped \`run.cancel\` to \`run:execute\` to match the HTTP layer rather than the literal \"read\" reading — the literal interpretation would let any viewer stop runs, which doesn't match \`RunsController\`'s gating.
- \`run.events\` polls the outbox table at 250ms. A NATS-subscription path is an obvious upgrade once durable per-call subscriptions become a thing.

## Test plan

- [x] \`RunsMcpToolsTests\` (21 cases): create happy/denied/admin-bypass/invalid-mode/invalid-profile/configurator-fail; get existing/missing/invalid/denied; cancel pending/terminal/missing/denied/active-runner; events backfill+stop, mid-stream terminal stop, denied, invalid GUID.
- [x] \`Andy.Containers.Api.Tests\`: 753 passed, 1 skipped (Ap6Aq3 smoke).
- [x] \`Andy.Containers.Tests\`: 334 passed.
- [ ] Apple integration tests fail without the \`container\` CLI installed; unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)