### PR TITLE
AP9: andy-containers-cli runs {create,get,cancel,events} (#111)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/RunsController.cs
+++ b/src/Andy.Containers.Api/Controllers/RunsController.cs
@@ -1,7 +1,9 @@
+using System.Text.Json;
 using Andy.Containers.Api.Services;
 using Andy.Containers.Configurator;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Messaging;
 using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
 using Andy.Rbac.Authorization;
@@ -228,5 +230,45 @@ public class RunsController : ControllerBase
         }
 
         _db.AppendAgentRunEvent(run, RunEventKind.Cancelled);
+    }
+
+    /// <summary>
+    /// AP9 (rivoli-ai/andy-containers#111). Stream lifecycle events for a
+    /// run as newline-delimited JSON. Each line is a serialised
+    /// <see cref="RunEventDto"/>; the response closes when the run reaches
+    /// a terminal status (after a final drain pass) or the caller
+    /// disconnects. Used by <c>andy-containers-cli runs events</c>.
+    /// </summary>
+    /// <remarks>
+    /// We write the response body directly rather than returning
+    /// <c>IAsyncEnumerable&lt;RunEventDto&gt;</c> so each event is flushed
+    /// to the wire as it lands — the default JSON streaming serializer
+    /// buffers and would only flush at chunk boundaries, which defeats
+    /// the live-stream UX. Returns 404 if the run is unknown so callers
+    /// don't sit on an empty stream forever.
+    /// </remarks>
+    [HttpGet("{id:guid}/events")]
+    [RequirePermission("run:read")]
+    public async Task Events(Guid id, CancellationToken ct)
+    {
+        var exists = await _db.Runs.AsNoTracking().AnyAsync(r => r.Id == id, ct);
+        if (!exists)
+        {
+            Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
+        }
+
+        Response.StatusCode = StatusCodes.Status200OK;
+        Response.ContentType = "application/x-ndjson";
+        Response.Headers.Append("Cache-Control", "no-cache");
+        Response.Headers.Append("X-Accel-Buffering", "no");
+
+        await foreach (var evt in RunEventStream.AsyncEnumerate(_db, id, ct: ct))
+        {
+            var json = JsonSerializer.Serialize(evt, EventJson.Options);
+            await Response.WriteAsync(json, ct);
+            await Response.WriteAsync("\n", ct);
+            await Response.Body.FlushAsync(ct);
+        }
     }
 }

--- a/src/Andy.Containers.Api/Mcp/RunsMcpTools.cs
+++ b/src/Andy.Containers.Api/Mcp/RunsMcpTools.cs
@@ -232,76 +232,12 @@ public class RunsMcpTools
         if (!await EnsurePermission(Permissions.RunRead, ct)) yield break;
         if (!Guid.TryParse(runId, out var id)) yield break;
 
-        var subjectPrefix = $"andy.containers.events.run.{id}.";
-        DateTimeOffset? cursor = null;
-        var sawTerminal = false;
-
-        while (!ct.IsCancellationRequested)
+        // AP9 (rivoli-ai/andy-containers#111). Shared outbox-poll loop —
+        // identical semantics to the HTTP NDJSON endpoint and the CLI
+        // events command.
+        await foreach (var evt in RunEventStream.AsyncEnumerate(_db, id, EventsPollInterval, ct))
         {
-            // Fetch any new outbox rows for this run, ordered by creation.
-            // We key the cursor on CreatedAt + ascending id ordering by
-            // pulling a bounded batch and ordering client-side — same
-            // constraint OutboxDispatcher hits with SQLite (DateTimeOffset
-            // ORDER BY isn't translatable). 64 rows / tick is plenty for
-            // a single-run view.
-            var query = _db.OutboxEntries
-                .AsNoTracking()
-                .Where(e => e.Subject.StartsWith(subjectPrefix));
-            if (cursor is not null)
-            {
-                query = query.Where(e => e.CreatedAt > cursor.Value);
-            }
-
-            var batch = (await query.Take(64).ToListAsync(ct))
-                .OrderBy(e => e.CreatedAt)
-                .ToList();
-
-            foreach (var entry in batch)
-            {
-                var dto = RunEventDto.FromOutbox(entry);
-                if (dto is null) continue;
-                cursor = entry.CreatedAt;
-                yield return dto;
-            }
-
-            if (sawTerminal && batch.Count == 0)
-            {
-                // We saw the terminal status on a prior tick AND this
-                // tick produced nothing new — every event committed
-                // before the terminal write has been delivered.
-                yield break;
-            }
-
-            // Re-check the row's status. Reading the OutboxEntry alone
-            // isn't sufficient because the controller's force-cancel
-            // path may flip the row before its outbox row appears
-            // (they commit together, but the read-fan-out can interleave).
-            var current = await _db.Runs
-                .AsNoTracking()
-                .Where(r => r.Id == id)
-                .Select(r => (RunStatus?)r.Status)
-                .FirstOrDefaultAsync(ct);
-            if (current is null)
-            {
-                // Run was deleted out from under us — close cleanly.
-                yield break;
-            }
-            if (RunStatusTransitions.IsTerminal(current.Value))
-            {
-                sawTerminal = true;
-                // One more pass to drain any event that landed between
-                // this cursor and the terminal write before we exit.
-                continue;
-            }
-
-            try
-            {
-                await Task.Delay(EventsPollInterval, ct);
-            }
-            catch (OperationCanceledException)
-            {
-                yield break;
-            }
+            yield return evt;
         }
     }
 
@@ -334,60 +270,3 @@ public class RunsMcpTools
     }
 }
 
-/// <summary>
-/// AP8 wire-shape for an event yielded by <c>run.events</c>. One DTO per
-/// outbox row. Carries the parsed <see cref="RunEventPayload"/> fields plus
-/// the wire metadata MCP consumers want without making them re-parse JSON.
-/// </summary>
-public sealed record RunEventDto
-{
-    public required Guid RunId { get; init; }
-    public required string Subject { get; init; }
-    /// <summary>One of <c>finished</c>, <c>failed</c>, <c>cancelled</c>, <c>timeout</c>.</summary>
-    public required string Kind { get; init; }
-    /// <summary>Mirrors the run's status at emission (e.g. <c>Cancelled</c>, <c>Succeeded</c>).</summary>
-    public required string Status { get; init; }
-    public int? ExitCode { get; init; }
-    public double? DurationSeconds { get; init; }
-    public required DateTimeOffset Timestamp { get; init; }
-    public required Guid CorrelationId { get; init; }
-
-    /// <summary>
-    /// Parse an <see cref="OutboxEntry"/> into a <see cref="RunEventDto"/>.
-    /// Returns null on a malformed payload — callers skip rather than
-    /// surfacing a parse error mid-stream.
-    /// </summary>
-    public static RunEventDto? FromOutbox(OutboxEntry entry)
-    {
-        RunEventPayload? payload;
-        try
-        {
-            payload = JsonSerializer.Deserialize<RunEventPayload>(entry.PayloadJson, EventJson.Options);
-        }
-        catch (JsonException)
-        {
-            return null;
-        }
-
-        if (payload is null) return null;
-
-        // Subject suffix after the last '.' is the kind: e.g.
-        // andy.containers.events.run.{id}.cancelled → "cancelled".
-        var lastDot = entry.Subject.LastIndexOf('.');
-        var kind = lastDot >= 0 && lastDot < entry.Subject.Length - 1
-            ? entry.Subject[(lastDot + 1)..]
-            : entry.Subject;
-
-        return new RunEventDto
-        {
-            RunId = payload.RunId,
-            Subject = entry.Subject,
-            Kind = kind,
-            Status = payload.Status,
-            ExitCode = payload.ExitCode,
-            DurationSeconds = payload.DurationSeconds,
-            Timestamp = entry.CreatedAt,
-            CorrelationId = entry.CorrelationId,
-        };
-    }
-}

--- a/src/Andy.Containers.Api/Services/RunEventStream.cs
+++ b/src/Andy.Containers.Api/Services/RunEventStream.cs
@@ -1,0 +1,110 @@
+using System.Runtime.CompilerServices;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// AP8/AP9 (rivoli-ai/andy-containers#110, #111). Shared outbox-polling
+/// stream of <see cref="RunEventDto"/> values for a given run id. The MCP
+/// <c>run.events</c> tool, the HTTP <c>GET /api/runs/{id}/events</c>
+/// endpoint, and the CLI <c>runs events</c> command all consume this so
+/// the polling loop, terminal-stop logic, and cursor semantics live in
+/// exactly one place.
+/// </summary>
+/// <remarks>
+/// The helper polls <see cref="ContainersDbContext.OutboxEntries"/> for
+/// rows with subject prefix <c>andy.containers.events.run.{id}.</c>,
+/// yielding each successfully-parsed <see cref="RunEventDto"/>. It stops
+/// when the run reaches a terminal status (after a final drain pass so a
+/// terminal write that committed in the same transaction as the last
+/// event still surfaces) or the run row disappears.
+/// </remarks>
+public static class RunEventStream
+{
+    /// <summary>Default poll cadence; short enough to feel live, long enough not to hammer the DB.</summary>
+    public static readonly TimeSpan DefaultPollInterval = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>Bounded batch size per poll. A single run shouldn't accumulate this many backfill events.</summary>
+    private const int BatchSize = 64;
+
+    public static async IAsyncEnumerable<RunEventDto> AsyncEnumerate(
+        ContainersDbContext db,
+        Guid runId,
+        TimeSpan? pollInterval = null,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+
+        var interval = pollInterval ?? DefaultPollInterval;
+        var subjectPrefix = $"andy.containers.events.run.{runId}.";
+        DateTimeOffset? cursor = null;
+        var sawTerminal = false;
+
+        while (!ct.IsCancellationRequested)
+        {
+            // Fetch any new outbox rows for this run, ordered by creation.
+            // Cursor on CreatedAt + bounded batch + client-side ordering
+            // matches OutboxDispatcher's SQLite-friendly pattern (provider
+            // can't translate DateTimeOffset ORDER BY).
+            var query = db.OutboxEntries
+                .AsNoTracking()
+                .Where(e => e.Subject.StartsWith(subjectPrefix));
+            if (cursor is not null)
+            {
+                query = query.Where(e => e.CreatedAt > cursor.Value);
+            }
+
+            var batch = (await query.Take(BatchSize).ToListAsync(ct))
+                .OrderBy(e => e.CreatedAt)
+                .ToList();
+
+            foreach (var entry in batch)
+            {
+                var dto = RunEventDto.FromOutbox(entry);
+                if (dto is null) continue;
+                cursor = entry.CreatedAt;
+                yield return dto;
+            }
+
+            if (sawTerminal && batch.Count == 0)
+            {
+                // Saw terminal on a prior tick AND this tick produced
+                // nothing new — every event committed before the terminal
+                // write has been delivered.
+                yield break;
+            }
+
+            // Re-check the row's status. Reading the OutboxEntry alone
+            // isn't sufficient because force-cancel paths flip the row
+            // and the event row in the same SaveChangesAsync; the read
+            // fan-out can still interleave.
+            var current = await db.Runs
+                .AsNoTracking()
+                .Where(r => r.Id == runId)
+                .Select(r => (RunStatus?)r.Status)
+                .FirstOrDefaultAsync(ct);
+            if (current is null)
+            {
+                yield break;
+            }
+            if (RunStatusTransitions.IsTerminal(current.Value))
+            {
+                sawTerminal = true;
+                // One more pass to drain any event that landed between
+                // this batch and the terminal write before we exit.
+                continue;
+            }
+
+            try
+            {
+                await Task.Delay(interval, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                yield break;
+            }
+        }
+    }
+}

--- a/src/Andy.Containers.Cli/Commands/RunCommands.cs
+++ b/src/Andy.Containers.Cli/Commands/RunCommands.cs
@@ -1,0 +1,211 @@
+using System.CommandLine;
+using Andy.Containers.Client;
+using Andy.Containers.Models;
+using Spectre.Console;
+
+namespace Andy.Containers.Cli.Commands;
+
+/// <summary>
+/// AP9 (rivoli-ai/andy-containers#111). <c>andy-containers-cli runs ...</c>
+/// — four subcommands wrapping the <c>/api/runs</c> surface from AP1-AP7
+/// plus the AP9 NDJSON events endpoint. Pattern mirrors
+/// <see cref="ContainerCommands"/>: one static factory per subcommand,
+/// composed into a parent <c>runs</c> command.
+/// </summary>
+public static class RunCommands
+{
+    public static Command Create()
+    {
+        var cmd = new Command("runs", "Manage agent runs (Epic AP)");
+        cmd.AddCommand(CreateCreateCommand());
+        cmd.AddCommand(CreateGetCommand());
+        cmd.AddCommand(CreateCancelCommand());
+        cmd.AddCommand(CreateEventsCommand());
+        return cmd;
+    }
+
+    private static Command CreateCreateCommand()
+    {
+        var cmd = new Command("create", "Submit a new agent run");
+
+        var agentArg = new Argument<string>("agent", "Agent slug from andy-agents (e.g. 'triage-agent').");
+        var modeOpt = new Option<string>("--mode", () => "Headless", "Run mode: Headless, Terminal, Desktop.");
+        var profileOpt = new Option<string>("--environment-profile", "EnvironmentProfile id (GUID).") { IsRequired = true };
+        var revisionOpt = new Option<int?>("--agent-revision", "Optional agent revision pin; omit for head.");
+        var workspaceOpt = new Option<string?>("--workspace", "Optional workspace id (GUID).");
+        var branchOpt = new Option<string?>("--branch", "Optional branch within the workspace.");
+        var policyOpt = new Option<string?>("--policy", "Optional policy id (GUID).");
+        var correlationOpt = new Option<string?>("--correlation-id", "Optional ADR-0001 correlation root (GUID); minted if omitted.");
+
+        cmd.AddArgument(agentArg);
+        cmd.AddOption(modeOpt);
+        cmd.AddOption(profileOpt);
+        cmd.AddOption(revisionOpt);
+        cmd.AddOption(workspaceOpt);
+        cmd.AddOption(branchOpt);
+        cmd.AddOption(policyOpt);
+        cmd.AddOption(correlationOpt);
+
+        cmd.SetHandler(async (context) =>
+        {
+            var agent = context.ParseResult.GetValueForArgument(agentArg);
+            var modeStr = context.ParseResult.GetValueForOption(modeOpt) ?? "Headless";
+            var profileStr = context.ParseResult.GetValueForOption(profileOpt)!;
+
+            if (!Enum.TryParse<RunMode>(modeStr, ignoreCase: true, out var mode))
+            {
+                AnsiConsole.MarkupLine($"[red]Invalid mode '{Markup.Escape(modeStr)}'.[/] Use Headless, Terminal, or Desktop.");
+                context.ExitCode = 2;
+                return;
+            }
+            if (!Guid.TryParse(profileStr, out var profileId) || profileId == Guid.Empty)
+            {
+                AnsiConsole.MarkupLine($"[red]--environment-profile must be a non-empty GUID.[/]");
+                context.ExitCode = 2;
+                return;
+            }
+
+            var request = new CreateRunRequest
+            {
+                AgentId = agent,
+                AgentRevision = context.ParseResult.GetValueForOption(revisionOpt),
+                Mode = mode,
+                EnvironmentProfileId = profileId,
+                PolicyId = ParseOptionalGuid(context.ParseResult.GetValueForOption(policyOpt)),
+                CorrelationId = ParseOptionalGuid(context.ParseResult.GetValueForOption(correlationOpt)),
+            };
+
+            var workspaceStr = context.ParseResult.GetValueForOption(workspaceOpt);
+            if (!string.IsNullOrWhiteSpace(workspaceStr))
+            {
+                if (!Guid.TryParse(workspaceStr, out var wid) || wid == Guid.Empty)
+                {
+                    AnsiConsole.MarkupLine($"[red]--workspace must be a non-empty GUID.[/]");
+                    context.ExitCode = 2;
+                    return;
+                }
+                request.WorkspaceRef = new WorkspaceRefRequest
+                {
+                    WorkspaceId = wid,
+                    Branch = context.ParseResult.GetValueForOption(branchOpt),
+                };
+            }
+
+            var client = ClientFactory.Create();
+            var run = await client.CreateRunAsync(request, context.GetCancellationToken());
+            PrintRunDetail(run);
+        });
+
+        return cmd;
+    }
+
+    private static Command CreateGetCommand()
+    {
+        var cmd = new Command("get", "Show run details");
+        var idArg = new Argument<string>("id", "Run id (GUID).");
+        cmd.AddArgument(idArg);
+        cmd.SetHandler(async (context) =>
+        {
+            var id = context.ParseResult.GetValueForArgument(idArg);
+            var ct = context.GetCancellationToken();
+            var client = ClientFactory.Create();
+            var run = await client.GetRunAsync(id, ct);
+            PrintRunDetail(run);
+        });
+        return cmd;
+    }
+
+    private static Command CreateCancelCommand()
+    {
+        var cmd = new Command("cancel", "Cancel a non-terminal run");
+        var idArg = new Argument<string>("id", "Run id (GUID).");
+        cmd.AddArgument(idArg);
+        cmd.SetHandler(async (context) =>
+        {
+            var id = context.ParseResult.GetValueForArgument(idArg);
+            var ct = context.GetCancellationToken();
+            var client = ClientFactory.Create();
+            RunDto? run = null;
+            await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots)
+                .StartAsync("Cancelling run...", async _ => { run = await client.CancelRunAsync(id, ct); });
+            AnsiConsole.MarkupLine($"[green]Run cancelled.[/] Status: [yellow]{run!.Status}[/]");
+            PrintRunDetail(run);
+        });
+        return cmd;
+    }
+
+    private static Command CreateEventsCommand()
+    {
+        var cmd = new Command("events", "Stream lifecycle events for a run until it terminates");
+        var idArg = new Argument<string>("id", "Run id (GUID).");
+        cmd.AddArgument(idArg);
+        cmd.SetHandler(async (context) =>
+        {
+            var id = context.ParseResult.GetValueForArgument(idArg);
+            var ct = context.GetCancellationToken();
+            var client = ClientFactory.Create();
+            AnsiConsole.MarkupLine($"[dim]Streaming events for run {id[..Math.Min(8, id.Length)]} (Ctrl+C to stop)...[/]");
+
+            await foreach (var evt in client.StreamRunEventsAsync(id, ct))
+            {
+                var color = evt.Kind switch
+                {
+                    "finished" => "green",
+                    "failed" => "red",
+                    "cancelled" => "yellow",
+                    "timeout" => "magenta",
+                    _ => "white"
+                };
+                var ts = evt.Timestamp.ToLocalTime().ToString("HH:mm:ss.fff");
+                var exit = evt.ExitCode is { } ec ? $" exit={ec}" : "";
+                var dur = evt.DurationSeconds is { } d ? $" dur={d:F1}s" : "";
+                AnsiConsole.MarkupLine(
+                    $"[dim]{ts}[/] [{color}]{evt.Kind}[/] status={Markup.Escape(evt.Status)}{exit}{dur}");
+            }
+
+            AnsiConsole.MarkupLine("[dim]Stream closed (run reached terminal state).[/]");
+        });
+        return cmd;
+    }
+
+    private static Guid? ParseOptionalGuid(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        return Guid.TryParse(value, out var g) ? g : null;
+    }
+
+    private static void PrintRunDetail(RunDto run)
+    {
+        var statusColor = run.Status switch
+        {
+            RunStatus.Running => "green",
+            RunStatus.Pending or RunStatus.Provisioning => "cyan",
+            RunStatus.Succeeded => "green",
+            RunStatus.Cancelled => "yellow",
+            RunStatus.Failed or RunStatus.Timeout => "red",
+            _ => "dim"
+        };
+
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .HideHeaders()
+            .AddColumn("")
+            .AddColumn("");
+
+        table.AddRow("Id", run.Id.ToString());
+        table.AddRow("Agent", Markup.Escape(run.AgentId));
+        if (run.AgentRevision is not null) table.AddRow("Revision", run.AgentRevision.ToString()!);
+        table.AddRow("Mode", run.Mode.ToString());
+        table.AddRow("Status", $"[{statusColor}]{run.Status}[/]");
+        if (run.ContainerId is not null) table.AddRow("Container", run.ContainerId.ToString()!);
+        table.AddRow("Created", run.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss"));
+        if (run.StartedAt is not null) table.AddRow("Started", run.StartedAt.Value.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss"));
+        if (run.EndedAt is not null) table.AddRow("Ended", run.EndedAt.Value.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss"));
+        if (run.ExitCode is not null) table.AddRow("Exit", run.ExitCode.ToString()!);
+        if (!string.IsNullOrEmpty(run.Error)) table.AddRow("Error", $"[red]{Markup.Escape(run.Error)}[/]");
+        table.AddRow("Correlation", run.CorrelationId.ToString());
+
+        AnsiConsole.Write(table);
+    }
+}

--- a/src/Andy.Containers.Cli/Program.cs
+++ b/src/Andy.Containers.Cli/Program.cs
@@ -31,6 +31,9 @@ rootCommand.AddCommand(ContainerCommands.CreateExecCommand());
 rootCommand.AddCommand(ContainerCommands.CreateStatsCommand());
 rootCommand.AddCommand(ConnectCommand.Create());
 
+// Run commands (AP9 — rivoli-ai/andy-containers#111).
+rootCommand.AddCommand(RunCommands.Create());
+
 // Workspace commands (stubs for future)
 var workspaceCommand = new Command("workspace", "Manage workspaces");
 workspaceCommand.AddCommand(new Command("create", "Create a workspace"));

--- a/src/Andy.Containers.Client/ContainersClient.cs
+++ b/src/Andy.Containers.Client/ContainersClient.cs
@@ -1,7 +1,10 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Andy.Containers.Messaging;
+using Andy.Containers.Models;
 
 namespace Andy.Containers.Client;
 
@@ -103,6 +106,88 @@ public sealed class ContainersClient
         var r = await _http.GetAsync("api/providers", ct);
         await EnsureSuccessAsync(r, ct);
         return (await r.Content.ReadFromJsonAsync<ProviderDto[]>(_json, ct))!;
+    }
+
+    // Runs (AP9 — rivoli-ai/andy-containers#111).
+    //
+    // Wire shapes are the server-side DTOs from Andy.Containers.Models:
+    // RunDto and RunEventDto. Deserializing those keeps the client and
+    // server schemas in lockstep at compile time — schema drift becomes
+    // a build break instead of a runtime KeyNotFoundException. The
+    // client lib already references Andy.Containers for Permissions
+    // constants, so this is no extra dependency.
+
+    public async Task<RunDto> CreateRunAsync(CreateRunRequest request, CancellationToken ct = default)
+    {
+        var r = await _http.PostAsJsonAsync("api/runs", request, _json, ct);
+        await EnsureSuccessAsync(r, ct);
+        return (await r.Content.ReadFromJsonAsync<RunDto>(_json, ct))!;
+    }
+
+    public async Task<RunDto> GetRunAsync(string id, CancellationToken ct = default)
+    {
+        var r = await _http.GetAsync($"api/runs/{id}", ct);
+        await EnsureSuccessAsync(r, ct);
+        return (await r.Content.ReadFromJsonAsync<RunDto>(_json, ct))!;
+    }
+
+    public async Task<RunDto> CancelRunAsync(string id, CancellationToken ct = default)
+    {
+        var r = await _http.PostAsync($"api/runs/{id}/cancel", null, ct);
+        await EnsureSuccessAsync(r, ct);
+        return (await r.Content.ReadFromJsonAsync<RunDto>(_json, ct))!;
+    }
+
+    /// <summary>
+    /// Stream lifecycle events for a run from
+    /// <c>GET /api/runs/{id}/events</c>. The server writes NDJSON
+    /// (one <see cref="RunEventDto"/> per line) and closes the
+    /// response when the run reaches a terminal status. Caller cancels
+    /// by disposing the enumerator or signalling <paramref name="ct"/>.
+    /// </summary>
+    public async IAsyncEnumerable<RunEventDto> StreamRunEventsAsync(
+        string id,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        // HttpCompletionOption.ResponseHeadersRead unblocks Send before
+        // the body arrives so we can iterate as bytes land — without it
+        // HttpClient buffers the whole response and the streaming UX
+        // collapses to one batch at terminal.
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"api/runs/{id}/events");
+        using var response = await _http.SendAsync(
+            request, HttpCompletionOption.ResponseHeadersRead, ct);
+        await EnsureSuccessAsync(response, ct);
+
+        // EventJson is the canonical wire-shape options (snake_case +
+        // ADR-0001-aligned converters). Using the server-side shared
+        // options keeps the client deserialization aligned with what
+        // the server actually wrote.
+        var jsonOptions = EventJson.Options;
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        using var reader = new StreamReader(stream);
+
+        while (!ct.IsCancellationRequested)
+        {
+            var line = await reader.ReadLineAsync(ct);
+            if (line is null) yield break;
+            if (line.Length == 0) continue;
+
+            RunEventDto? evt;
+            try
+            {
+                evt = JsonSerializer.Deserialize<RunEventDto>(line, jsonOptions);
+            }
+            catch (JsonException)
+            {
+                // Skip malformed lines rather than killing the stream;
+                // the server should never produce them, but a partial
+                // line at disconnect would otherwise blow up the CLI.
+                continue;
+            }
+
+            if (evt is not null) yield return evt;
+        }
     }
 
     private static async Task EnsureSuccessAsync(HttpResponseMessage response, CancellationToken ct)

--- a/src/Andy.Containers/Models/RunEventDto.cs
+++ b/src/Andy.Containers/Models/RunEventDto.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+using Andy.Containers.Messaging;
+using Andy.Containers.Messaging.Events;
+
+namespace Andy.Containers.Models;
+
+/// <summary>
+/// AP8/AP9 wire-shape for an event yielded by <c>run.events</c> (MCP tool),
+/// <c>GET /api/runs/{id}/events</c> (HTTP NDJSON stream), and
+/// <c>andy-containers-cli runs events</c>. One DTO per
+/// <see cref="OutboxEntry"/>. Carries the parsed <see cref="RunEventPayload"/>
+/// fields plus the wire metadata consumers want without making them re-parse
+/// JSON.
+/// </summary>
+public sealed record RunEventDto
+{
+    public required Guid RunId { get; init; }
+    public required string Subject { get; init; }
+    /// <summary>One of <c>finished</c>, <c>failed</c>, <c>cancelled</c>, <c>timeout</c>.</summary>
+    public required string Kind { get; init; }
+    /// <summary>Mirrors the run's status at emission (e.g. <c>Cancelled</c>, <c>Succeeded</c>).</summary>
+    public required string Status { get; init; }
+    public int? ExitCode { get; init; }
+    public double? DurationSeconds { get; init; }
+    public required DateTimeOffset Timestamp { get; init; }
+    public required Guid CorrelationId { get; init; }
+
+    /// <summary>
+    /// Parse an <see cref="OutboxEntry"/> into a <see cref="RunEventDto"/>.
+    /// Returns null on a malformed payload — callers skip rather than
+    /// surfacing a parse error mid-stream.
+    /// </summary>
+    public static RunEventDto? FromOutbox(OutboxEntry entry)
+    {
+        RunEventPayload? payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize<RunEventPayload>(entry.PayloadJson, EventJson.Options);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        if (payload is null) return null;
+
+        // Subject suffix after the last '.' is the kind: e.g.
+        // andy.containers.events.run.{id}.cancelled → "cancelled".
+        var lastDot = entry.Subject.LastIndexOf('.');
+        var kind = lastDot >= 0 && lastDot < entry.Subject.Length - 1
+            ? entry.Subject[(lastDot + 1)..]
+            : entry.Subject;
+
+        return new RunEventDto
+        {
+            RunId = payload.RunId,
+            Subject = entry.Subject,
+            Kind = kind,
+            Status = payload.Status,
+            ExitCode = payload.ExitCode,
+            DurationSeconds = payload.DurationSeconds,
+            Timestamp = entry.CreatedAt,
+            CorrelationId = entry.CorrelationId,
+        };
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
@@ -4,6 +4,7 @@ using Andy.Containers.Api.Tests.Helpers;
 using Andy.Containers.Configurator;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Messaging;
 using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
 using FluentAssertions;
@@ -388,6 +389,64 @@ public class RunsControllerTests : IDisposable
         var entry = _db.OutboxEntries.Should().ContainSingle(
             "grace-expired path must still produce a terminal subject for downstream consumers").Subject;
         entry.Subject.Should().EndWith($".{run.Id}.cancelled");
+    }
+
+    // AP9 (#111). NDJSON events endpoint: 404 for missing runs, otherwise
+    // streams one RunEventDto per line. We exercise it directly against
+    // a MemoryStream-backed Response.Body — no WebApplicationFactory needed.
+
+    [Fact]
+    public async Task Events_NonexistentRun_ReturnsNotFound_NoBody()
+    {
+        var responseStream = new MemoryStream();
+        _controller.ControllerContext = new Microsoft.AspNetCore.Mvc.ControllerContext
+        {
+            HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext
+            {
+                Response = { Body = responseStream },
+            },
+        };
+
+        await _controller.Events(Guid.NewGuid(), CancellationToken.None);
+
+        _controller.Response.StatusCode.Should().Be(404);
+        responseStream.Length.Should().Be(0,
+            "404 must not stream NDJSON; the CLI distinguishes 'unknown run' from 'no events yet'");
+    }
+
+    [Fact]
+    public async Task Events_TerminalRunWithBackfill_WritesNdjson()
+    {
+        var run = SeedRun(RunStatus.Succeeded);
+        _db.AppendAgentRunEvent(run, RunEventKind.Finished, exitCode: 0, durationSeconds: 0.25);
+        await _db.SaveChangesAsync();
+
+        var responseStream = new MemoryStream();
+        _controller.ControllerContext = new Microsoft.AspNetCore.Mvc.ControllerContext
+        {
+            HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext
+            {
+                Response = { Body = responseStream },
+            },
+        };
+
+        await _controller.Events(run.Id, CancellationToken.None);
+
+        _controller.Response.StatusCode.Should().Be(200);
+        _controller.Response.ContentType.Should().Be("application/x-ndjson");
+
+        responseStream.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(responseStream);
+        var body = await reader.ReadToEndAsync();
+        var lines = body.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        lines.Should().ContainSingle();
+
+        var evt = System.Text.Json.JsonSerializer.Deserialize<RunEventDto>(
+            lines[0], EventJson.Options);
+        evt.Should().NotBeNull();
+        evt!.RunId.Should().Be(run.Id);
+        evt.Kind.Should().Be("finished");
+        evt.ExitCode.Should().Be(0);
     }
 
     private Run SeedRun(RunStatus status)

--- a/tests/Andy.Containers.Api.Tests/Services/RunEventStreamTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/RunEventStreamTests.cs
@@ -1,0 +1,159 @@
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Messaging.Events;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+// AP9 (rivoli-ai/andy-containers#111). RunEventStream is the shared
+// outbox-poll loop consumed by the MCP run.events tool, the HTTP
+// NDJSON endpoint, and the CLI. These tests pin the contract that
+// matters — terminal-stop, drain pass, prefix filter — independently
+// of any of those callers so each consumer can rely on the helper.
+public class RunEventStreamTests : IDisposable
+{
+    private readonly ContainersDbContext _db;
+    // Tight poll so terminal-stop tests don't add seconds of latency.
+    private static readonly TimeSpan FastPoll = TimeSpan.FromMilliseconds(20);
+
+    public RunEventStreamTests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task TerminalRunWithBackfill_YieldsAllThenStops()
+    {
+        var run = SeedRun(RunStatus.Succeeded);
+        _db.AppendAgentRunEvent(run, RunEventKind.Finished, exitCode: 0, durationSeconds: 1.5);
+        await _db.SaveChangesAsync();
+
+        var collected = new List<RunEventDto>();
+        await foreach (var evt in RunEventStream.AsyncEnumerate(_db, run.Id, FastPoll))
+        {
+            collected.Add(evt);
+        }
+
+        collected.Should().ContainSingle();
+        collected[0].Subject.Should().Be($"andy.containers.events.run.{run.Id}.finished");
+        collected[0].ExitCode.Should().Be(0);
+        collected[0].DurationSeconds.Should().Be(1.5);
+    }
+
+    [Fact]
+    public async Task FiltersByRunIdPrefix_DoesNotEmitOtherRunsEvents()
+    {
+        var target = SeedRun(RunStatus.Succeeded);
+        var other = SeedRun(RunStatus.Failed);
+        _db.AppendAgentRunEvent(target, RunEventKind.Finished);
+        _db.AppendAgentRunEvent(other, RunEventKind.Failed);
+        await _db.SaveChangesAsync();
+
+        var collected = new List<RunEventDto>();
+        await foreach (var evt in RunEventStream.AsyncEnumerate(_db, target.Id, FastPoll))
+        {
+            collected.Add(evt);
+        }
+
+        collected.Should().ContainSingle()
+            .Which.RunId.Should().Be(target.Id);
+    }
+
+    [Fact]
+    public async Task UnknownRun_TerminatesImmediately()
+    {
+        // Run row not in DB → helper exits cleanly without yielding.
+        var collected = new List<RunEventDto>();
+        await foreach (var evt in RunEventStream.AsyncEnumerate(_db, Guid.NewGuid(), FastPoll))
+        {
+            collected.Add(evt);
+        }
+
+        collected.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LiveTerminalTransition_DrainsEventsBeforeExit()
+    {
+        // Reproduce the AP8 race: while the consumer is in its poll
+        // loop, the runner commits Cancelled + the cancelled outbox row
+        // in the same transaction. The drain pass must catch that row
+        // before exiting on terminal observation.
+        var run = SeedRun(RunStatus.Running);
+
+        var streamTask = Task.Run(async () =>
+        {
+            var collected = new List<RunEventDto>();
+            await foreach (var evt in RunEventStream.AsyncEnumerate(_db, run.Id, FastPoll))
+            {
+                collected.Add(evt);
+            }
+            return collected;
+        });
+
+        // Give the loop one poll cycle, then commit terminal state.
+        await Task.Delay(50);
+        run.TransitionTo(RunStatus.Cancelled);
+        _db.AppendAgentRunEvent(run, RunEventKind.Cancelled);
+        await _db.SaveChangesAsync();
+
+        var collected = await streamTask;
+
+        collected.Should().ContainSingle()
+            .Which.Kind.Should().Be("cancelled");
+    }
+
+    [Fact]
+    public async Task CallerCancellation_ClosesEnumeration()
+    {
+        var run = SeedRun(RunStatus.Running);
+        using var cts = new CancellationTokenSource();
+
+        var enumerationTask = Task.Run(async () =>
+        {
+            var collected = new List<RunEventDto>();
+            try
+            {
+                await foreach (var evt in RunEventStream.AsyncEnumerate(_db, run.Id, FastPoll, cts.Token))
+                {
+                    collected.Add(evt);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Either swallowed by the helper or raised by Task.Delay —
+                // both are valid; the test only cares that we exit.
+            }
+            return collected;
+        });
+
+        await Task.Delay(50);
+        cts.Cancel();
+
+        var collected = await enumerationTask;
+        collected.Should().BeEmpty(
+            "no events were emitted before cancel; the loop must close cleanly anyway");
+    }
+
+    private Run SeedRun(RunStatus status)
+    {
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "stream-test",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            Status = status,
+        };
+        _db.Runs.Add(run);
+        _db.SaveChanges();
+        return run;
+    }
+}

--- a/tests/Andy.Containers.Client.Tests/ContainersClientTests.cs
+++ b/tests/Andy.Containers.Client.Tests/ContainersClientTests.cs
@@ -1,6 +1,8 @@
 using Andy.Containers.Client;
+using Andy.Containers.Models;
 using FluentAssertions;
 using System.Net;
+using System.Text;
 using Xunit;
 
 namespace Andy.Containers.Client.Tests;
@@ -48,5 +50,127 @@ public class ContainersClientTests
 
         result.Items.Should().HaveCount(1);
         result.TotalCount.Should().Be(1);
+    }
+
+    // AP9 (rivoli-ai/andy-containers#111). The CLI's `runs events` command
+    // depends on this NDJSON parser handling chunked, line-delimited JSON
+    // gracefully. We feed canned bytes through a fake HttpMessageHandler
+    // and assert the IAsyncEnumerable yields one DTO per line.
+
+    [Fact]
+    public async Task StreamRunEventsAsync_ParsesNdjson_YieldsDtoPerLine()
+    {
+        var runId = Guid.NewGuid();
+        var ndjson =
+            $"{{\"run_id\":\"{runId}\",\"subject\":\"andy.containers.events.run.{runId}.finished\"," +
+            "\"kind\":\"finished\",\"status\":\"Succeeded\",\"exit_code\":0,\"duration_seconds\":1.5," +
+            "\"timestamp\":\"2026-04-27T12:00:00+00:00\",\"correlation_id\":\"00000000-0000-0000-0000-000000000001\"}\n" +
+            $"{{\"run_id\":\"{runId}\",\"subject\":\"andy.containers.events.run.{runId}.cancelled\"," +
+            "\"kind\":\"cancelled\",\"status\":\"Cancelled\",\"exit_code\":null,\"duration_seconds\":null," +
+            "\"timestamp\":\"2026-04-27T12:00:01+00:00\",\"correlation_id\":\"00000000-0000-0000-0000-000000000001\"}\n";
+
+        var http = new HttpClient(new CannedHandler(ndjson, "application/x-ndjson"))
+        {
+            BaseAddress = new Uri("https://example.local/"),
+        };
+        var client = new ContainersClient(http);
+
+        var events = new List<RunEventDto>();
+        await foreach (var evt in client.StreamRunEventsAsync(runId.ToString()))
+        {
+            events.Add(evt);
+        }
+
+        events.Should().HaveCount(2);
+        events[0].Kind.Should().Be("finished");
+        events[0].ExitCode.Should().Be(0);
+        events[1].Kind.Should().Be("cancelled");
+        events[1].ExitCode.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task StreamRunEventsAsync_EmptyBody_YieldsNothing()
+    {
+        var http = new HttpClient(new CannedHandler("", "application/x-ndjson"))
+        {
+            BaseAddress = new Uri("https://example.local/"),
+        };
+        var client = new ContainersClient(http);
+
+        var events = new List<RunEventDto>();
+        await foreach (var evt in client.StreamRunEventsAsync(Guid.NewGuid().ToString()))
+        {
+            events.Add(evt);
+        }
+
+        events.Should().BeEmpty(
+            "an immediate-close NDJSON response (e.g. terminal run with no backfill) is valid");
+    }
+
+    [Fact]
+    public async Task StreamRunEventsAsync_MalformedLine_SkipsAndContinues()
+    {
+        var runId = Guid.NewGuid();
+        var ndjson =
+            "{not-valid-json\n" +
+            $"{{\"run_id\":\"{runId}\",\"subject\":\"andy.containers.events.run.{runId}.finished\"," +
+            "\"kind\":\"finished\",\"status\":\"Succeeded\",\"exit_code\":0,\"duration_seconds\":1.0," +
+            "\"timestamp\":\"2026-04-27T12:00:00+00:00\",\"correlation_id\":\"00000000-0000-0000-0000-000000000001\"}\n";
+
+        var http = new HttpClient(new CannedHandler(ndjson, "application/x-ndjson"))
+        {
+            BaseAddress = new Uri("https://example.local/"),
+        };
+        var client = new ContainersClient(http);
+
+        var events = new List<RunEventDto>();
+        await foreach (var evt in client.StreamRunEventsAsync(runId.ToString()))
+        {
+            events.Add(evt);
+        }
+
+        events.Should().ContainSingle(
+            "the well-formed line after the malformed one must still surface");
+    }
+
+    [Fact]
+    public async Task StreamRunEventsAsync_404Response_ThrowsContainersApiException()
+    {
+        var http = new HttpClient(new CannedHandler("not found", "text/plain", HttpStatusCode.NotFound))
+        {
+            BaseAddress = new Uri("https://example.local/"),
+        };
+        var client = new ContainersClient(http);
+
+        var act = async () =>
+        {
+            await foreach (var _ in client.StreamRunEventsAsync(Guid.NewGuid().ToString()))
+            {
+            }
+        };
+
+        await act.Should().ThrowAsync<ContainersApiException>()
+            .Where(e => e.StatusCode == HttpStatusCode.NotFound);
+    }
+
+    private sealed class CannedHandler : HttpMessageHandler
+    {
+        private readonly byte[] _body;
+        private readonly string _contentType;
+        private readonly HttpStatusCode _status;
+
+        public CannedHandler(string body, string contentType, HttpStatusCode status = HttpStatusCode.OK)
+        {
+            _body = Encoding.UTF8.GetBytes(body);
+            _contentType = contentType;
+            _status = status;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var content = new ByteArrayContent(_body);
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(_contentType);
+            return Task.FromResult(new HttpResponseMessage(_status) { Content = content });
+        }
     }
 }


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#111

## Summary

Adds the per-service CLI surface for Epic AP runs in three stacked layers, with a shared helper so the MCP tool, the new HTTP endpoint, and the CLI all use one polling loop:

1. **\`RunEventStream.AsyncEnumerate\`** (\`src/Andy.Containers.Api/Services/\`) — replaces the inline outbox-poll AP8 wrote into \`RunsMcpTools.Events\`. \`RunEventDto\` moves to \`Andy.Containers.Models\` so the client lib can deserialize it without depending on \`Andy.Containers.Api\`.
2. **\`GET /api/runs/{id}/events\`** — NDJSON stream gated on \`run:read\`. Each line is one \`RunEventDto\`; response closes when the run hits terminal (with a final drain pass) or the caller disconnects. 404 if the run is unknown so the CLI doesn't sit on an empty stream forever.
3. **\`ContainersClient\`** gains \`CreateRunAsync\` / \`GetRunAsync\` / \`CancelRunAsync\` / \`StreamRunEventsAsync\`. Streaming uses \`HttpCompletionOption.ResponseHeadersRead\` and parses NDJSON line-by-line, skipping malformed lines.
4. **\`RunCommands\`** in the CLI wires \`runs create | get | cancel | events\`. \`events\` renders each event as a colour-coded line (timestamp / kind / status / exit / duration).

## Refactor note

\`RunsMcpTools.Events\` now delegates to \`RunEventStream.AsyncEnumerate\` — same observable behaviour, single source of truth. The AP8 PR's note about extracting shared run logic is partially addressed: the events stream is shared; cancel/create still duplicate.

## Test plan

- [x] \`RunEventStreamTests\` (5 cases): terminal-with-backfill, prefix filter, unknown-run, live terminal drain, caller-cancel close.
- [x] \`RunsControllerTests\` adds two AP9 cases for the NDJSON endpoint (404 path + happy-path body via \`MemoryStream\`-backed \`HttpContext\` — no \`WebApplicationFactory\`).
- [x] \`ContainersClientTests\` adds four \`StreamRunEventsAsync\` cases via a fake \`HttpMessageHandler\` (NDJSON parse, empty body, malformed-line skip, 404 propagation).
- [x] Existing \`RunsMcpToolsTests\` (21) still pass after the events-helper refactor.
- [x] Full unit suite: 1102 passed, 1 skipped.
- [x] Manual: \`andy-containers-cli runs --help\`, \`runs create --help\` show the expected options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)