### PR TITLE
X2: seed EnvironmentProfile catalog from config/environments/global/*.yaml (#91)

### DIFF
--- a/config/environments/README.md
+++ b/config/environments/README.md
@@ -1,0 +1,37 @@
+# EnvironmentProfile catalog (Epic X)
+
+YAML files under `global/` are loaded by `EnvironmentProfileSeeder` at API
+startup and upserted into `EnvironmentProfile` rows by `code`. The seeder is
+**idempotent**: existing rows are never overwritten, so operator hand-edits
+made via the catalog API (X3, once it lands) survive restarts. To force a
+re-seed, delete the row in the catalog and restart.
+
+## Schema
+
+```yaml
+code:           # Slug, unique across the catalog. Maps to EnvironmentProfile.Name.
+display_name:   # Human-readable label.
+kind:           # HeadlessContainer | Terminal | Desktop
+base_image_ref: # OCI reference (e.g. ghcr.io/rivoli-ai/andy-headless:latest)
+
+capabilities:
+  network_allowlist: # Hostnames or "*" wildcards. [] means no egress.
+    - "..."
+  secrets_scope:     # None | RunScoped | WorkspaceScoped | OrganizationScoped
+  has_gui:           # bool
+  audit_mode:        # None | Standard | Strict
+```
+
+Field names use `snake_case` in YAML; the seeder maps them to the
+`PascalCase` properties on `EnvironmentProfile` /
+`EnvironmentCapabilities` automatically.
+
+## Adding a profile
+
+1. Drop a `your-profile.yaml` in `global/`.
+2. Restart the API; the seeder loads it on boot.
+3. Verify with `GET /containers/api/environments` once X3 ships, or by
+   inspecting the `EnvironmentProfiles` table directly.
+
+Malformed files are logged and skipped — the host never aborts startup
+on a bad seed entry.

--- a/config/environments/global/desktop.yaml
+++ b/config/environments/global/desktop.yaml
@@ -1,0 +1,20 @@
+# X2 (rivoli-ai/andy-containers#91). Desktop profile — full GUI
+# (X server / VNC) for agents that need to drive a browser, IDE, or
+# graphical tool. SSO-scoped credentials because long-lived desktop
+# sessions outlive single runs and need org-broad auth.
+code: desktop
+display_name: Desktop session
+kind: Desktop
+base_image_ref: ghcr.io/rivoli-ai/andy-desktop:latest
+
+capabilities:
+  # Wildcard egress — desktop sessions are interactive; a browser
+  # alone needs the open web. Audit defaults to Standard since the
+  # human in the loop is the primary control.
+  network_allowlist:
+    - "*"
+  # SSO-scoped per the issue contract; OrganizationScoped is the
+  # closest enum value (org-broad credentials, not per-run-scoped).
+  secrets_scope: OrganizationScoped
+  has_gui: true
+  audit_mode: Standard

--- a/config/environments/global/headless-container.yaml
+++ b/config/environments/global/headless-container.yaml
@@ -1,0 +1,20 @@
+# X2 (rivoli-ai/andy-containers#91). Headless container profile — the
+# default for triage / plan / execute agents that don't need a TTY or
+# GUI. Strict audit because every tool call is captured pre-redaction.
+code: headless-container
+display_name: Headless container
+kind: HeadlessContainer
+base_image_ref: ghcr.io/rivoli-ai/andy-headless:latest
+
+capabilities:
+  # Restricted egress for unattended agents — only platform services and
+  # canonical package mirrors. Operators can broaden this per-deployment
+  # via X3 once the catalog endpoint lands.
+  network_allowlist:
+    - registry.rivoli.ai
+    - api.github.com
+    - pypi.org
+    - nuget.org
+  secrets_scope: WorkspaceScoped
+  has_gui: false
+  audit_mode: Strict

--- a/config/environments/global/terminal.yaml
+++ b/config/environments/global/terminal.yaml
@@ -1,0 +1,18 @@
+# X2 (rivoli-ai/andy-containers#91). Terminal profile — the user
+# attaches via TTY (PTY exec) and drives the agent interactively.
+# Standard audit; broader network because human-in-the-loop sessions
+# routinely reach arbitrary documentation and registries.
+code: terminal
+display_name: Terminal session
+kind: Terminal
+base_image_ref: ghcr.io/rivoli-ai/andy-terminal:latest
+
+capabilities:
+  # Wildcard egress: a TTY session is bounded by a human, not by an
+  # agent loop, so the network policy is permissive. Workspaces that
+  # need locked-down profiles override this via X3 / X5.
+  network_allowlist:
+    - "*"
+  secrets_scope: WorkspaceScoped
+  has_gui: false
+  audit_mode: Standard

--- a/src/Andy.Containers.Api/Data/EnvironmentProfileSeeder.cs
+++ b/src/Andy.Containers.Api/Data/EnvironmentProfileSeeder.cs
@@ -1,0 +1,249 @@
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Andy.Containers.Api.Data;
+
+/// <summary>
+/// X2 (rivoli-ai/andy-containers#91). Loads the global EnvironmentProfile
+/// catalog from <c>config/environments/global/*.yaml</c> at startup and
+/// upserts each by <see cref="EnvironmentProfile.Name"/>. Idempotent —
+/// re-running on a populated DB produces no duplicates and never
+/// overwrites operator hand-edits made via the API (X3+); only fields
+/// that are still at their seed defaults get refreshed.
+/// </summary>
+/// <remarks>
+/// Search-paths logic mirrors <see cref="Controllers.TemplatesController"/>'s
+/// so the seeder finds files when the host is launched from the project
+/// directory or the repo root. A malformed file is logged and skipped —
+/// host startup never aborts on a bad seed entry.
+/// </remarks>
+public static class EnvironmentProfileSeeder
+{
+    private static readonly IDeserializer Yaml = new DeserializerBuilder()
+        .WithNamingConvention(UnderscoredNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    /// <summary>
+    /// Load and upsert all profile YAMLs found under
+    /// <c>config/environments/global</c>. Returns the number of rows
+    /// inserted or updated for diagnostics; the host doesn't act on it
+    /// beyond logging.
+    /// </summary>
+    public static async Task<int> SeedAsync(
+        ContainersDbContext db,
+        IHostEnvironment env,
+        ILogger logger,
+        CancellationToken ct = default)
+    {
+        var directory = ResolveSeedDirectory(env);
+        if (directory is null)
+        {
+            logger.LogInformation(
+                "EnvironmentProfileSeeder: no config/environments/global directory found; skipping seed.");
+            return 0;
+        }
+
+        var files = Directory.GetFiles(directory, "*.yaml", SearchOption.TopDirectoryOnly);
+        if (files.Length == 0)
+        {
+            logger.LogInformation(
+                "EnvironmentProfileSeeder: {Directory} has no *.yaml files; nothing to seed.", directory);
+            return 0;
+        }
+
+        var changes = 0;
+        foreach (var path in files.OrderBy(p => p, StringComparer.Ordinal))
+        {
+            try
+            {
+                var yaml = await File.ReadAllTextAsync(path, ct);
+                var record = Yaml.Deserialize<SeedRecord>(yaml);
+                if (record is null)
+                {
+                    logger.LogWarning(
+                        "EnvironmentProfileSeeder: {Path} parsed to null; skipping.", path);
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(record.Code) ||
+                    string.IsNullOrWhiteSpace(record.DisplayName) ||
+                    string.IsNullOrWhiteSpace(record.BaseImageRef))
+                {
+                    logger.LogWarning(
+                        "EnvironmentProfileSeeder: {Path} missing required fields (code/display_name/base_image_ref); skipping.",
+                        path);
+                    continue;
+                }
+
+                if (!Enum.TryParse<EnvironmentKind>(record.Kind, ignoreCase: true, out var kind))
+                {
+                    logger.LogWarning(
+                        "EnvironmentProfileSeeder: {Path} has unknown kind '{Kind}'; skipping.",
+                        path, record.Kind);
+                    continue;
+                }
+
+                var existing = await db.EnvironmentProfiles
+                    .FirstOrDefaultAsync(p => p.Name == record.Code, ct);
+
+                if (existing is null)
+                {
+                    db.EnvironmentProfiles.Add(new EnvironmentProfile
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = record.Code,
+                        DisplayName = record.DisplayName,
+                        Kind = kind,
+                        BaseImageRef = record.BaseImageRef,
+                        Capabilities = MapCapabilities(record.Capabilities, logger, path),
+                    });
+                    changes++;
+                    logger.LogInformation(
+                        "EnvironmentProfileSeeder: seeded new profile '{Code}' from {Path}.",
+                        record.Code, path);
+                }
+                else
+                {
+                    // Idempotent re-run: keep existing rows untouched. The
+                    // operator-edit-preservation contract means we don't
+                    // overwrite display_name / base_image_ref / capabilities
+                    // once a row exists. To force a refresh, the operator
+                    // deletes the row via the API and re-runs.
+                    logger.LogDebug(
+                        "EnvironmentProfileSeeder: profile '{Code}' already exists; leaving untouched.",
+                        record.Code);
+                }
+            }
+            catch (YamlException ex)
+            {
+                logger.LogWarning(ex,
+                    "EnvironmentProfileSeeder: malformed YAML in {Path}; skipping. {Message}",
+                    path, ex.Message);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "EnvironmentProfileSeeder: failed to seed {Path}; skipping. {Message}",
+                    path, ex.Message);
+            }
+        }
+
+        if (changes > 0)
+        {
+            await db.SaveChangesAsync(ct);
+            logger.LogInformation(
+                "EnvironmentProfileSeeder: persisted {Count} new EnvironmentProfile row(s).", changes);
+        }
+
+        return changes;
+    }
+
+    private static EnvironmentCapabilities MapCapabilities(
+        SeedCapabilities? raw, ILogger logger, string path)
+    {
+        if (raw is null) return new EnvironmentCapabilities();
+
+        var caps = new EnvironmentCapabilities
+        {
+            NetworkAllowlist = raw.NetworkAllowlist?.ToList() ?? new(),
+            HasGui = raw.HasGui,
+        };
+
+        if (!string.IsNullOrWhiteSpace(raw.SecretsScope))
+        {
+            if (Enum.TryParse<SecretsScope>(raw.SecretsScope, ignoreCase: true, out var s))
+            {
+                caps.SecretsScope = s;
+            }
+            else
+            {
+                logger.LogWarning(
+                    "EnvironmentProfileSeeder: {Path} has unknown secrets_scope '{Value}'; falling back to default.",
+                    path, raw.SecretsScope);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(raw.AuditMode))
+        {
+            if (Enum.TryParse<AuditMode>(raw.AuditMode, ignoreCase: true, out var a))
+            {
+                caps.AuditMode = a;
+            }
+            else
+            {
+                logger.LogWarning(
+                    "EnvironmentProfileSeeder: {Path} has unknown audit_mode '{Value}'; falling back to default.",
+                    path, raw.AuditMode);
+            }
+        }
+
+        return caps;
+    }
+
+    /// <summary>
+    /// Walk likely roots so the seeder works under <c>dotnet run</c> from
+    /// the project dir, from the repo root, or from a publish output. Same
+    /// shape as <c>TemplatesController.GetConfigSearchPaths</c>; kept
+    /// duplicated rather than coupling the controller to the seeder, so
+    /// extracting the seeder into a worker process later is a single move.
+    /// </summary>
+    internal static string? ResolveSeedDirectory(IHostEnvironment env)
+    {
+        foreach (var candidate in EnumerateCandidates(env))
+        {
+            if (Directory.Exists(candidate)) return candidate;
+        }
+        return null;
+    }
+
+    private static IEnumerable<string> EnumerateCandidates(IHostEnvironment env)
+    {
+        // Project dir (../..) — matches `dotnet run` from src/Andy.Containers.Api.
+        yield return Path.GetFullPath(
+            Path.Combine(env.ContentRootPath, "..", "..", "config", "environments", "global"));
+        // Repo root.
+        yield return Path.Combine(env.ContentRootPath, "config", "environments", "global");
+        // Walk up to find it (handles publish output / docker /app).
+        var dir = env.ContentRootPath;
+        for (var i = 0; i < 5; i++)
+        {
+            var parent = Directory.GetParent(dir)?.FullName;
+            if (parent is null) yield break;
+            var candidate = Path.Combine(parent, "config", "environments", "global");
+            if (Directory.Exists(candidate))
+            {
+                yield return candidate;
+                yield break;
+            }
+            dir = parent;
+        }
+    }
+
+    // YAML wire shape — mirrors the file format described in
+    // config/environments/global/README.md. Mapped to EnvironmentProfile
+    // explicitly in MapCapabilities so the catalog entity keeps its
+    // semantic types (enums vs. strings).
+    private sealed class SeedRecord
+    {
+        public string Code { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
+        public string Kind { get; set; } = string.Empty;
+        public string BaseImageRef { get; set; } = string.Empty;
+        public SeedCapabilities? Capabilities { get; set; }
+    }
+
+    private sealed class SeedCapabilities
+    {
+        public List<string>? NetworkAllowlist { get; set; }
+        public string? SecretsScope { get; set; }
+        public bool HasGui { get; set; }
+        public string? AuditMode { get; set; }
+    }
+}

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -298,6 +298,15 @@ try
         else
             await db.Database.EnsureCreatedAsync();
         await DataSeeder.SeedAsync(db);
+
+        // X2 (rivoli-ai/andy-containers#91). Load the EnvironmentProfile
+        // catalog from config/environments/global/*.yaml. Idempotent —
+        // existing rows are left alone so operator hand-edits via the
+        // X3 catalog API are preserved across restarts.
+        var seederLogger = scope.ServiceProvider
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger(typeof(EnvironmentProfileSeeder));
+        await EnvironmentProfileSeeder.SeedAsync(db, app.Environment, seederLogger);
     }
 
     app.UseHttpsRedirection();

--- a/tests/Andy.Containers.Api.Tests/Data/EnvironmentProfileSeederTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Data/EnvironmentProfileSeederTests.cs
@@ -1,0 +1,212 @@
+using Andy.Containers.Api.Data;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Data;
+
+// X2 (rivoli-ai/andy-containers#91). The seeder loads YAML at startup,
+// upserts by Name, and must never crash the host on a bad file. These
+// tests pin those three invariants by pointing the seeder at a per-test
+// temp directory we control byte-for-byte — no dependency on the real
+// config/environments/global files at the repo root.
+public class EnvironmentProfileSeederTests : IDisposable
+{
+    private readonly string _seedDir;
+    private readonly Mock<IHostEnvironment> _env = new();
+
+    public EnvironmentProfileSeederTests()
+    {
+        _seedDir = Path.Combine(
+            Path.GetTempPath(),
+            $"env-seeder-{Guid.NewGuid():N}",
+            "config", "environments", "global");
+        Directory.CreateDirectory(_seedDir);
+
+        // The seeder walks up looking for config/environments/global; we
+        // give it a content root one level deeper than the directory we
+        // actually populated so its first candidate (../../config/...)
+        // hits our temp path.
+        var contentRoot = Path.GetFullPath(Path.Combine(_seedDir, "..", "..", "..", "src", "Andy.Containers.Api"));
+        Directory.CreateDirectory(contentRoot);
+        _env.Setup(e => e.ContentRootPath).Returns(contentRoot);
+    }
+
+    public void Dispose()
+    {
+        // Walk up to the per-test root and delete the whole tree.
+        var root = Directory.GetParent(Directory.GetParent(_seedDir)!.FullName)!.FullName;
+        if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
+    public async Task SeedAsync_FreshDb_InsertsAllProfilesWithExpectedCapabilities()
+    {
+        WriteSeed("headless-container.yaml", HeadlessContainerYaml);
+        WriteSeed("terminal.yaml", TerminalYaml);
+        WriteSeed("desktop.yaml", DesktopYaml);
+
+        using var db = InMemoryDbHelper.CreateContext();
+        var changes = await EnvironmentProfileSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+
+        changes.Should().Be(3);
+        var profiles = await db.EnvironmentProfiles.OrderBy(p => p.Name).ToListAsync();
+        profiles.Should().HaveCount(3);
+        profiles.Select(p => p.Name).Should().BeEquivalentTo(new[]
+        {
+            "desktop", "headless-container", "terminal",
+        });
+
+        var headless = profiles.Single(p => p.Name == "headless-container");
+        headless.Kind.Should().Be(EnvironmentKind.HeadlessContainer);
+        headless.BaseImageRef.Should().Be("ghcr.io/rivoli-ai/andy-headless:latest");
+        headless.Capabilities.HasGui.Should().BeFalse();
+        headless.Capabilities.SecretsScope.Should().Be(SecretsScope.WorkspaceScoped);
+        headless.Capabilities.AuditMode.Should().Be(AuditMode.Strict);
+        headless.Capabilities.NetworkAllowlist.Should().Contain("registry.rivoli.ai");
+
+        var desktop = profiles.Single(p => p.Name == "desktop");
+        desktop.Capabilities.HasGui.Should().BeTrue();
+        desktop.Capabilities.SecretsScope.Should().Be(SecretsScope.OrganizationScoped);
+        desktop.Capabilities.NetworkAllowlist.Should().BeEquivalentTo(new[] { "*" });
+    }
+
+    [Fact]
+    public async Task SeedAsync_RerunOnSeededDb_IsIdempotent_NoDuplicates()
+    {
+        WriteSeed("headless-container.yaml", HeadlessContainerYaml);
+
+        using var db = InMemoryDbHelper.CreateContext();
+        var first = await EnvironmentProfileSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+        var second = await EnvironmentProfileSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+
+        first.Should().Be(1);
+        second.Should().Be(0, "the second pass must observe the existing row and skip");
+        (await db.EnvironmentProfiles.CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SeedAsync_RerunPreservesOperatorEdits()
+    {
+        // Operator (X3 catalog API) flipped audit_mode to None on a seeded
+        // row. A subsequent restart must not stomp that change.
+        WriteSeed("headless-container.yaml", HeadlessContainerYaml);
+        using var db = InMemoryDbHelper.CreateContext();
+        await EnvironmentProfileSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+
+        var row = await db.EnvironmentProfiles.SingleAsync();
+        row.Capabilities.AuditMode = AuditMode.None;
+        row.DisplayName = "Operator-renamed";
+        await db.SaveChangesAsync();
+
+        await EnvironmentProfileSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+
+        var reloaded = await db.EnvironmentProfiles.SingleAsync();
+        reloaded.Capabilities.AuditMode.Should().Be(AuditMode.None);
+        reloaded.DisplayName.Should().Be("Operator-renamed");
+    }
+
+    [Fact]
+    public async Task SeedAsync_MalformedYaml_LogsAndSkips_DoesNotThrow()
+    {
+        WriteSeed("good.yaml", HeadlessContainerYaml);
+        WriteSeed("broken.yaml", "code: oops\n  bad: indent:: ::\n");
+
+        using var db = InMemoryDbHelper.CreateContext();
+        var changes = await EnvironmentProfileSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+
+        changes.Should().Be(1, "only the well-formed file should land");
+        (await db.EnvironmentProfiles.SingleAsync()).Name.Should().Be("headless-container");
+    }
+
+    [Fact]
+    public async Task SeedAsync_MissingRequiredFields_LogsAndSkips()
+    {
+        WriteSeed("incomplete.yaml", "code: only-a-code\n");
+
+        using var db = InMemoryDbHelper.CreateContext();
+        var changes = await EnvironmentProfileSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+
+        changes.Should().Be(0);
+        (await db.EnvironmentProfiles.AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SeedAsync_UnknownKind_LogsAndSkips()
+    {
+        WriteSeed("alien.yaml",
+            "code: alien\n" +
+            "display_name: Alien\n" +
+            "kind: AlienShape\n" +
+            "base_image_ref: ghcr.io/x:y\n");
+
+        using var db = InMemoryDbHelper.CreateContext();
+        var changes = await EnvironmentProfileSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+
+        changes.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SeedAsync_NoSeedDirectory_ReturnsZeroWithoutThrowing()
+    {
+        // Wipe the directory entirely so the resolver finds nothing.
+        Directory.Delete(_seedDir, recursive: true);
+
+        using var db = InMemoryDbHelper.CreateContext();
+        var changes = await EnvironmentProfileSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+
+        changes.Should().Be(0);
+    }
+
+    private void WriteSeed(string fileName, string yaml)
+    {
+        File.WriteAllText(Path.Combine(_seedDir, fileName), yaml);
+    }
+
+    private const string HeadlessContainerYaml = """
+        code: headless-container
+        display_name: Headless container
+        kind: HeadlessContainer
+        base_image_ref: ghcr.io/rivoli-ai/andy-headless:latest
+        capabilities:
+          network_allowlist:
+            - registry.rivoli.ai
+            - api.github.com
+            - pypi.org
+            - nuget.org
+          secrets_scope: WorkspaceScoped
+          has_gui: false
+          audit_mode: Strict
+        """;
+
+    private const string TerminalYaml = """
+        code: terminal
+        display_name: Terminal session
+        kind: Terminal
+        base_image_ref: ghcr.io/rivoli-ai/andy-terminal:latest
+        capabilities:
+          network_allowlist:
+            - "*"
+          secrets_scope: WorkspaceScoped
+          has_gui: false
+          audit_mode: Standard
+        """;
+
+    private const string DesktopYaml = """
+        code: desktop
+        display_name: Desktop session
+        kind: Desktop
+        base_image_ref: ghcr.io/rivoli-ai/andy-desktop:latest
+        capabilities:
+          network_allowlist:
+            - "*"
+          secrets_scope: OrganizationScoped
+          has_gui: true
+          audit_mode: Standard
+        """;
+}


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#91

## Summary

Three baseline \`EnvironmentProfile\` rows now seed automatically from YAML on every fresh DB:

- **\`config/environments/global/headless-container.yaml\`** — \`WorkspaceScoped\` secrets, \`Strict\` audit, restricted egress (registry / GitHub API / pypi / nuget). The default for triage / plan / execute agents.
- **\`config/environments/global/terminal.yaml\`** — \`WorkspaceScoped\`, \`Standard\` audit, wildcard egress; human-in-the-loop bound.
- **\`config/environments/global/desktop.yaml\`** — \`OrganizationScoped\` (≈ SSO-scoped per the issue contract), \`Standard\` audit, wildcard egress, GUI on.

\`EnvironmentProfileSeeder\` parses each file via YamlDotNet (snake_case → PascalCase), upserts by \`Name\`, and is idempotent: existing rows are left untouched so operator hand-edits via the X3 catalog API will survive restarts. Path resolver mirrors \`TemplatesController.GetConfigSearchPaths\` so it works under \`dotnet run\` from the project dir, the repo root, or a publish output. Wired into \`Program.cs\` right after \`DataSeeder.SeedAsync\` in the startup scope.

Failure modes — malformed YAML, missing required fields, unknown enum values, missing seed directory — all log and skip. The host never aborts startup on a bad seed entry.

## Notes

- The issue placed the seeder in \`Andy.Containers.Infrastructure/Seeding\`. I put it next to \`DataSeeder\` in \`Andy.Containers.Api/Data\` instead so all startup seeders live in one place.
- The issue's \`audit_mode: full\`/\`log\` and \`secrets_scope: sso-scoped\` strings don't map directly to the X1 enum values. Mapped: \`full\` → \`Strict\`, \`log\` → \`Standard\`, \`sso-scoped\` → \`OrganizationScoped\` (closest semantic). YAML uses the enum names directly (e.g. \`WorkspaceScoped\`) so the file is unambiguous.
- \`base_image_ref\` values follow the placeholder pattern from the issue (\`ghcr.io/rivoli-ai/andy-{headless,terminal,desktop}:latest\`). Operators override these via the X3 API once it ships.

## Test plan

- [x] \`EnvironmentProfileSeederTests\` (7): fresh DB inserts all three with expected capabilities; idempotent re-run produces no duplicates; operator-edit preservation across re-seed; malformed YAML logs and skips; missing required fields skip; unknown kind skips; missing seed directory returns 0.
- [x] Full unit suite: 1124 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)