### PR TITLE
X3: catalog endpoint GET /api/environments (#92)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/EnvironmentsController.cs
+++ b/src/Andy.Containers.Api/Controllers/EnvironmentsController.cs
@@ -1,0 +1,98 @@
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using Andy.Rbac.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Containers.Api.Controllers;
+
+/// <summary>
+/// X3 (rivoli-ai/andy-containers#92). Read-only catalog of
+/// <see cref="EnvironmentProfile"/>s. Profiles are governance artifacts —
+/// seeded by <see cref="Data.EnvironmentProfileSeeder"/> at startup and
+/// not user-creatable today. CRUD lands when an operator UI requires
+/// it.
+/// </summary>
+/// <remarks>
+/// The epic spec writes the path as <c>/containers/api/environments</c>;
+/// the <c>containers/</c> prefix is a gateway/ingress concern, so the
+/// controller route is the bare <c>api/environments</c>.
+/// </remarks>
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class EnvironmentsController : ControllerBase
+{
+    private readonly ContainersDbContext _db;
+
+    public EnvironmentsController(ContainersDbContext db)
+    {
+        _db = db;
+    }
+
+    [HttpGet]
+    [RequirePermission(Permissions.EnvironmentRead)]
+    public async Task<IActionResult> List(
+        [FromQuery] string? kind,
+        [FromQuery] int skip = 0,
+        [FromQuery] int take = 50,
+        CancellationToken ct = default)
+    {
+        if (skip < 0) skip = 0;
+        if (take <= 0 || take > 200) take = 50;
+
+        EnvironmentKind? kindFilter = null;
+        if (!string.IsNullOrWhiteSpace(kind))
+        {
+            if (!Enum.TryParse<EnvironmentKind>(kind, ignoreCase: true, out var parsed))
+            {
+                return BadRequest(new
+                {
+                    error = $"Unknown environment kind '{kind}'. " +
+                            $"Expected one of: {string.Join(", ", Enum.GetNames<EnvironmentKind>())}.",
+                });
+            }
+            kindFilter = parsed;
+        }
+
+        var query = _db.EnvironmentProfiles.AsNoTracking().AsQueryable();
+        if (kindFilter.HasValue)
+        {
+            query = query.Where(p => p.Kind == kindFilter.Value);
+        }
+
+        var total = await query.CountAsync(ct);
+        var rows = await query
+            .OrderBy(p => p.Name)
+            .Skip(skip).Take(take)
+            .ToListAsync(ct);
+
+        var items = rows.Select(EnvironmentProfileDto.FromEntity).ToList();
+        return Ok(new { items, totalCount = total });
+    }
+
+    [HttpGet("{id:guid}")]
+    [RequirePermission(Permissions.EnvironmentRead)]
+    public async Task<IActionResult> Get(Guid id, CancellationToken ct)
+    {
+        var profile = await _db.EnvironmentProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == id, ct);
+        if (profile is null) return NotFound();
+        return Ok(EnvironmentProfileDto.FromEntity(profile));
+    }
+
+    [HttpGet("by-code/{code}")]
+    [RequirePermission(Permissions.EnvironmentRead)]
+    public async Task<IActionResult> GetByCode(string code, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(code)) return NotFound();
+
+        var profile = await _db.EnvironmentProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Name == code, ct);
+        if (profile is null) return NotFound();
+        return Ok(EnvironmentProfileDto.FromEntity(profile));
+    }
+}

--- a/src/Andy.Containers/Models/EnvironmentProfileDto.cs
+++ b/src/Andy.Containers/Models/EnvironmentProfileDto.cs
@@ -1,0 +1,47 @@
+namespace Andy.Containers.Models;
+
+/// <summary>
+/// X3 (rivoli-ai/andy-containers#92). Wire-shape for the
+/// <c>GET /api/environments</c> catalog. Mirrors
+/// <see cref="EnvironmentProfile"/> with the structured
+/// <see cref="EnvironmentCapabilities"/> envelope flattened into the
+/// payload — clients see a typed capability block, not the raw JSON
+/// column. Kept distinct from the entity so the wire shape can grow
+/// (links, computed fields) without re-shaping the EF model.
+/// </summary>
+public sealed class EnvironmentProfileDto
+{
+    public Guid Id { get; init; }
+
+    /// <summary>Slug — stable across renames (e.g. <c>headless-container</c>).</summary>
+    public string Code { get; init; } = string.Empty;
+
+    public string DisplayName { get; init; } = string.Empty;
+
+    /// <summary>Serialised <see cref="EnvironmentKind"/> for API/CLI/MCP consumers.</summary>
+    public string Kind { get; init; } = string.Empty;
+
+    public string BaseImageRef { get; init; } = string.Empty;
+
+    public EnvironmentCapabilities Capabilities { get; init; } = new();
+
+    public DateTimeOffset CreatedAt { get; init; }
+
+    public static EnvironmentProfileDto FromEntity(EnvironmentProfile profile)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+        return new EnvironmentProfileDto
+        {
+            Id = profile.Id,
+            Code = profile.Name,
+            DisplayName = profile.DisplayName,
+            Kind = profile.Kind.ToString(),
+            BaseImageRef = profile.BaseImageRef,
+            // Capabilities is owned-by-EF and shape-stable; safe to surface
+            // by reference. EF tracks no further mutation once the entity
+            // is fetched read-only via AsNoTracking.
+            Capabilities = profile.Capabilities,
+            CreatedAt = profile.CreatedAt,
+        };
+    }
+}

--- a/src/Andy.Containers/Models/Permissions.cs
+++ b/src/Andy.Containers/Models/Permissions.cs
@@ -30,6 +30,13 @@ public static class Permissions
     public const string RunWrite = "run:write";
     public const string RunRead = "run:read";
     public const string RunExecute = "run:execute";
+
+    // Environment-profile permissions (Epic X). Catalog is read-only
+    // today (X3) — write/manage scopes will land if/when an operator
+    // UI requires CRUD on the seeded profiles. EnvironmentRead is
+    // granted to every role since the catalog is governance metadata
+    // every authenticated user benefits from seeing.
+    public const string EnvironmentRead = "environment:read";
 }
 
 public static class OrgRoles
@@ -47,18 +54,21 @@ public static class OrgRoles
             Permissions.TemplatePublish, Permissions.TemplateManage,
             Permissions.ProviderRead, Permissions.ProviderManage,
             Permissions.ApiKeyManage, Permissions.ApiKeyAdmin,
-            Permissions.RunWrite, Permissions.RunRead, Permissions.RunExecute
+            Permissions.RunWrite, Permissions.RunRead, Permissions.RunExecute,
+            Permissions.EnvironmentRead
         ],
         Editor => [
             Permissions.ImageCreate, Permissions.ImageRead, Permissions.ImageBuild,
             Permissions.TemplateCreate, Permissions.TemplateRead, Permissions.TemplateManage,
             Permissions.ApiKeyManage,
-            Permissions.RunWrite, Permissions.RunRead, Permissions.RunExecute
+            Permissions.RunWrite, Permissions.RunRead, Permissions.RunExecute,
+            Permissions.EnvironmentRead
         ],
         Viewer => [
             Permissions.ImageRead, Permissions.TemplateRead, Permissions.ProviderRead,
             Permissions.ApiKeyManage,
-            Permissions.RunRead
+            Permissions.RunRead,
+            Permissions.EnvironmentRead
         ],
         _ => []
     };

--- a/tests/Andy.Containers.Api.Tests/Controllers/EnvironmentsControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/EnvironmentsControllerTests.cs
@@ -1,0 +1,229 @@
+using Andy.Containers.Api.Controllers;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Controllers;
+
+// X3 (rivoli-ai/andy-containers#92). Read-only catalog endpoint:
+// list / get-by-id / get-by-code, with kind filter + pagination on
+// list. Tests use direct controller instantiation against an in-memory
+// DbContext, matching WorkspacesControllerTests / RunsControllerTests.
+// Auth-pipeline behaviour ([RequirePermission]) is exercised by the
+// Andy.Rbac filter tests; here we cover controller logic only.
+public class EnvironmentsControllerTests : IDisposable
+{
+    private readonly ContainersDbContext _db;
+    private readonly EnvironmentsController _controller;
+
+    public EnvironmentsControllerTests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+        _controller = new EnvironmentsController(_db);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task List_ReturnsAllSeededProfiles_WithTotal()
+    {
+        SeedThreeProfiles();
+
+        var result = await _controller.List(kind: null, skip: 0, take: 50);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var (items, total) = ExtractPage(ok.Value!);
+        total.Should().Be(3);
+        items.Select(p => p.Code).Should().BeEquivalentTo(new[]
+        {
+            "desktop", "headless-container", "terminal",
+        });
+    }
+
+    [Fact]
+    public async Task List_OrdersByCode()
+    {
+        SeedThreeProfiles();
+
+        var result = await _controller.List(kind: null, skip: 0, take: 50);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var (items, _) = ExtractPage(ok.Value!);
+        items.Select(p => p.Code).Should().ContainInOrder(
+            "desktop", "headless-container", "terminal");
+    }
+
+    [Theory]
+    [InlineData("HeadlessContainer", "headless-container")]
+    [InlineData("headlesscontainer", "headless-container")]   // case-insensitive
+    [InlineData("Terminal", "terminal")]
+    [InlineData("Desktop", "desktop")]
+    public async Task List_KindFilter_NarrowsToMatchingProfiles(string kind, string expectedCode)
+    {
+        SeedThreeProfiles();
+
+        var result = await _controller.List(kind: kind, skip: 0, take: 50);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var (items, total) = ExtractPage(ok.Value!);
+        total.Should().Be(1);
+        items.Single().Code.Should().Be(expectedCode);
+    }
+
+    [Fact]
+    public async Task List_UnknownKind_ReturnsBadRequest()
+    {
+        SeedThreeProfiles();
+
+        var result = await _controller.List(kind: "AlienShape", skip: 0, take: 50);
+
+        result.Should().BeOfType<BadRequestObjectResult>(
+            "an unknown kind is a typo, not an empty result — surface it");
+    }
+
+    [Fact]
+    public async Task List_PaginationCapsTake_AndClampsSkip()
+    {
+        SeedThreeProfiles();
+
+        // skip < 0 must clamp to 0; take > 200 must clamp to 50; total
+        // still reflects the unfiltered count.
+        var result = await _controller.List(kind: null, skip: -5, take: 9999);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var (items, total) = ExtractPage(ok.Value!);
+        total.Should().Be(3);
+        items.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task Get_ExistingId_ReturnsDtoWithStructuredCapabilities()
+    {
+        var seeded = SeedThreeProfiles();
+        var headless = seeded.Single(p => p.Name == "headless-container");
+
+        var result = await _controller.Get(headless.Id, CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<EnvironmentProfileDto>().Subject;
+        dto.Code.Should().Be("headless-container");
+        dto.Kind.Should().Be("HeadlessContainer");
+        dto.Capabilities.HasGui.Should().BeFalse();
+        dto.Capabilities.SecretsScope.Should().Be(SecretsScope.WorkspaceScoped);
+        dto.Capabilities.AuditMode.Should().Be(AuditMode.Strict);
+        dto.Capabilities.NetworkAllowlist.Should().Contain("registry.rivoli.ai");
+    }
+
+    [Fact]
+    public async Task Get_UnknownId_ReturnsNotFound()
+    {
+        var result = await _controller.Get(Guid.NewGuid(), CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task GetByCode_ExistingCode_ReturnsDto()
+    {
+        SeedThreeProfiles();
+
+        var result = await _controller.GetByCode("desktop", CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<EnvironmentProfileDto>().Subject;
+        dto.Capabilities.HasGui.Should().BeTrue();
+        dto.Capabilities.SecretsScope.Should().Be(SecretsScope.OrganizationScoped);
+    }
+
+    [Fact]
+    public async Task GetByCode_UnknownCode_ReturnsNotFound()
+    {
+        SeedThreeProfiles();
+
+        var result = await _controller.GetByCode("nonexistent", CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task GetByCode_BlankCode_ReturnsNotFound()
+    {
+        var result = await _controller.GetByCode("   ", CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>(
+            "blank input is treated as a missing-row lookup, not a 400");
+    }
+
+    private List<EnvironmentProfile> SeedThreeProfiles()
+    {
+        var profiles = new[]
+        {
+            new EnvironmentProfile
+            {
+                Id = Guid.NewGuid(),
+                Name = "headless-container",
+                DisplayName = "Headless container",
+                Kind = EnvironmentKind.HeadlessContainer,
+                BaseImageRef = "ghcr.io/rivoli-ai/andy-headless:latest",
+                Capabilities = new EnvironmentCapabilities
+                {
+                    NetworkAllowlist = new List<string>
+                    {
+                        "registry.rivoli.ai", "api.github.com", "pypi.org", "nuget.org",
+                    },
+                    SecretsScope = SecretsScope.WorkspaceScoped,
+                    HasGui = false,
+                    AuditMode = AuditMode.Strict,
+                },
+            },
+            new EnvironmentProfile
+            {
+                Id = Guid.NewGuid(),
+                Name = "terminal",
+                DisplayName = "Terminal session",
+                Kind = EnvironmentKind.Terminal,
+                BaseImageRef = "ghcr.io/rivoli-ai/andy-terminal:latest",
+                Capabilities = new EnvironmentCapabilities
+                {
+                    NetworkAllowlist = new List<string> { "*" },
+                    SecretsScope = SecretsScope.WorkspaceScoped,
+                    HasGui = false,
+                    AuditMode = AuditMode.Standard,
+                },
+            },
+            new EnvironmentProfile
+            {
+                Id = Guid.NewGuid(),
+                Name = "desktop",
+                DisplayName = "Desktop session",
+                Kind = EnvironmentKind.Desktop,
+                BaseImageRef = "ghcr.io/rivoli-ai/andy-desktop:latest",
+                Capabilities = new EnvironmentCapabilities
+                {
+                    NetworkAllowlist = new List<string> { "*" },
+                    SecretsScope = SecretsScope.OrganizationScoped,
+                    HasGui = true,
+                    AuditMode = AuditMode.Standard,
+                },
+            },
+        };
+
+        _db.EnvironmentProfiles.AddRange(profiles);
+        _db.SaveChanges();
+        return profiles.ToList();
+    }
+
+    // List returns an anonymous { items, totalCount } envelope; reflect
+    // the two fields rather than asserting on the anonymous type so the
+    // tests stay readable.
+    private static (List<EnvironmentProfileDto> Items, int Total) ExtractPage(object payload)
+    {
+        var t = payload.GetType();
+        var items = (IEnumerable<EnvironmentProfileDto>)t.GetProperty("items")!.GetValue(payload)!;
+        var total = (int)t.GetProperty("totalCount")!.GetValue(payload)!;
+        return (items.ToList(), total);
+    }
+}


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#92

## Summary

Read-only catalog over the X2-seeded \`EnvironmentProfile\` rows. Three actions on a new \`EnvironmentsController\`, all gated on \`[RequirePermission("environment:read")]\`:

- **\`GET /api/environments\`** — \`kind\` filter + \`skip/take\` pagination, project-standard \`{ items, totalCount }\` envelope. \`skip<0\` clamps to 0; \`take\` outside \`(0, 200]\` clamps to 50. Unknown \`kind\` → 400 (typo, not empty).
- **\`GET /api/environments/{id:guid}\`** — by id; 404 on miss.
- **\`GET /api/environments/by-code/{code}\`** — by stable slug; used by the X5 agent-enforcement check and the X6/X7 MCP/CLI surfaces.

\`EnvironmentProfileDto\` flattens the \`OwnsOne\` capability JSON into a structured \`Capabilities\` block — clients see the typed envelope, not the raw column. \`environment:read\` is added to the \`Permissions\` catalog and granted to Admin / Editor / Viewer (the catalog is governance metadata every authenticated user benefits from seeing).

Path note: the epic spec writes \`/containers/api/environments\`. The \`containers/\` prefix is a gateway/ingress concern; the controller route is the bare \`api/environments\`.

## Test plan

- [x] 13 \`EnvironmentsControllerTests\`: list returns total + dto-shape; ordering by code; \`kind\` filter via Theory (HeadlessContainer / case-insensitive / Terminal / Desktop); unknown kind → 400; pagination clamping; get by id round-trip with structured capabilities; get-missing → 404; by-code round-trip; by-code missing → 404; by-code blank → 404.
- [x] Full unit suite: 1137 passed, 1 skipped.

## Notes

- I used direct controller instantiation with \`InMemoryDbHelper\` (matching \`WorkspacesControllerTests\` / \`RunsControllerTests\`) rather than the issue's \`WebApplicationFactory\` suggestion — that pattern isn't established in this codebase. The auth-pipeline behaviour (401/403) is exercised by the \`Andy.Rbac\` filter tests; here we cover controller logic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)