### PR TITLE
X4: headless runtime support — profile-driven image + GUI sidecar override (#93)

### DIFF
--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -103,6 +103,24 @@ public class ContainerOrchestrationService : IContainerService
         if (template is null)
             throw new ArgumentException("Template not found");
 
+        // X4 (rivoli-ai/andy-containers#93). Resolve the bound profile
+        // (if any). When set, the profile's BaseImageRef and Kind
+        // override the template's image and GUI behaviour: Headless /
+        // Terminal kinds skip the VNC sidecar entirely; Desktop keeps
+        // it. The template still drives resources, scripts, and
+        // dependencies — only image + sidecar surface flip.
+        EnvironmentProfile? profile = null;
+        if (request.EnvironmentProfileId.HasValue)
+        {
+            profile = await _db.EnvironmentProfiles
+                .FirstOrDefaultAsync(p => p.Id == request.EnvironmentProfileId.Value, ct);
+            if (profile is null)
+            {
+                throw new ArgumentException(
+                    $"EnvironmentProfile '{request.EnvironmentProfileId.Value}' not found.");
+            }
+        }
+
         // Resolve or route to provider
         InfrastructureProvider provider;
         if (request.ProviderId.HasValue)
@@ -388,12 +406,22 @@ public class ContainerOrchestrationService : IContainerService
                 envVars[kv.Key] = kv.Value;
         }
 
+        // X4: profile-driven overrides. When a profile is bound, its
+        // BaseImageRef wins over the template's BaseImage, and the
+        // sidecar GuiType is derived from profile.Kind (Desktop → "vnc",
+        // Headless / Terminal → "none"). Without a profile, fall back
+        // to the template's existing values for full back-compat.
+        var effectiveImage = profile?.BaseImageRef ?? template.BaseImage;
+        var effectiveGuiType = profile is null
+            ? template.GuiType
+            : (profile.Kind == EnvironmentKind.Desktop ? "vnc" : "none");
+
         // Enqueue the provisioning job for the background worker
         var job = new ContainerProvisionJob(
             ContainerId: container.Id,
             ProviderId: provider.Id,
             ProviderCode: provider.Code,
-            TemplateBaseImage: template.BaseImage,
+            TemplateBaseImage: effectiveImage,
             ContainerName: container.Name,
             OwnerId: container.OwnerId,
             Resources: request.Resources,
@@ -402,12 +430,14 @@ public class ContainerOrchestrationService : IContainerService
             PostCreateScripts: postCreateScripts,
             CodeAssistant: codeAssistant,
             EnvironmentVariables: envVars,
-            GuiType: template.GuiType,
+            GuiType: effectiveGuiType,
             ContainerUser: container.ContainerUser ?? "root",
             OwnerEmail: request.OwnerEmail,
             OwnerPreferredUsername: request.OwnerPreferredUsername,
             TemplateName: template.Name,
-            ProviderName: provider.Name);
+            ProviderName: provider.Name,
+            EnvironmentProfileId: profile?.Id,
+            EnvironmentKind: profile?.Kind.ToString());
 
         await _queue.EnqueueAsync(job, ct);
         _logger.LogInformation("Container {ContainerId} enqueued for provisioning on {Provider}",

--- a/src/Andy.Containers.Api/Services/ContainerProvisioningQueue.cs
+++ b/src/Andy.Containers.Api/Services/ContainerProvisioningQueue.cs
@@ -20,7 +20,14 @@ public record ContainerProvisionJob(
     string? OwnerEmail = null,
     string? OwnerPreferredUsername = null,
     string? TemplateName = null,
-    string? ProviderName = null);
+    string? ProviderName = null,
+    // X4 (rivoli-ai/andy-containers#93). EnvironmentProfile context for
+    // observability — TemplateBaseImage and GuiType are already resolved
+    // by the orchestration service when the request bound a profile, so
+    // the worker doesn't need to re-evaluate. These fields land in log
+    // lines and let downstream events carry the profile correlation.
+    Guid? EnvironmentProfileId = null,
+    string? EnvironmentKind = null);
 
 public class ContainerProvisioningQueue
 {

--- a/src/Andy.Containers/Abstractions/IContainerService.cs
+++ b/src/Andy.Containers/Abstractions/IContainerService.cs
@@ -51,6 +51,17 @@ public class CreateContainerRequest
     // run.* lifecycle events (finished/failed/cancelled) carry this id so
     // the caller (e.g. andy-issues) can tie the run back to a UserStory.
     public Guid? StoryId { get; set; }
+
+    /// <summary>
+    /// X4 (rivoli-ai/andy-containers#93). When set, the bound
+    /// <c>EnvironmentProfile</c> overrides the template's base image
+    /// (with <c>profile.BaseImageRef</c>) and the GUI sidecar
+    /// behaviour (Headless/Terminal → no VNC; Desktop → VNC). The
+    /// template still supplies resources, scripts, and dependencies.
+    /// X5 wires this from the workspace-create surface; here the
+    /// pipeline just propagates whatever the caller sets.
+    /// </summary>
+    public Guid? EnvironmentProfileId { get; set; }
 }
 
 public class GitRepositoryConfig

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTests.cs
@@ -1007,4 +1007,140 @@ public class ContainerOrchestrationServiceTests : IDisposable
         var container = await service.CreateContainerAsync(request, CancellationToken.None);
         container.Name.Should().Be("still-allowed");
     }
+
+    // X4 (rivoli-ai/andy-containers#93). EnvironmentProfile resolution.
+    // Pin the contract: when a profile is bound, its BaseImageRef wins
+    // over the template's image and Kind dictates GuiType. Without a
+    // profile, behaviour matches the template (back-compat).
+
+    [Fact]
+    public async Task CreateContainer_HeadlessProfile_OverridesImage_AndSkipsVnc()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+        // Template has a desktop GuiType so the profile override has
+        // something to flip — proves profile beats template, not just
+        // adds when the template is silent.
+        template.GuiType = "vnc";
+        var profile = await SeedProfile(
+            "headless-container",
+            EnvironmentKind.HeadlessContainer,
+            "ghcr.io/rivoli-ai/andy-headless:2026.04");
+
+        await _service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "h1",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            EnvironmentProfileId = profile.Id,
+        }, CancellationToken.None);
+
+        _queue.Reader.TryRead(out var job).Should().BeTrue();
+        job!.TemplateBaseImage.Should().Be("ghcr.io/rivoli-ai/andy-headless:2026.04");
+        job.GuiType.Should().Be("none",
+            "headless profile must drop the VNC sidecar even when the template asked for one");
+        job.EnvironmentProfileId.Should().Be(profile.Id);
+        job.EnvironmentKind.Should().Be("HeadlessContainer");
+    }
+
+    [Fact]
+    public async Task CreateContainer_TerminalProfile_KeepsNoVnc_UsesProfileImage()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+        template.GuiType = "vnc";
+        var profile = await SeedProfile(
+            "terminal", EnvironmentKind.Terminal, "ghcr.io/rivoli-ai/andy-terminal:latest");
+
+        await _service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "t1",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            EnvironmentProfileId = profile.Id,
+        }, CancellationToken.None);
+
+        _queue.Reader.TryRead(out var job).Should().BeTrue();
+        job!.TemplateBaseImage.Should().Be("ghcr.io/rivoli-ai/andy-terminal:latest");
+        job.GuiType.Should().Be("none");
+        job.EnvironmentKind.Should().Be("Terminal");
+    }
+
+    [Fact]
+    public async Task CreateContainer_DesktopProfile_SetsVncGuiType()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+        // Template has no GUI on its own; profile is what flips on VNC.
+        template.GuiType = "none";
+        var profile = await SeedProfile(
+            "desktop", EnvironmentKind.Desktop, "ghcr.io/rivoli-ai/andy-desktop:latest");
+
+        await _service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "d1",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            EnvironmentProfileId = profile.Id,
+        }, CancellationToken.None);
+
+        _queue.Reader.TryRead(out var job).Should().BeTrue();
+        job!.TemplateBaseImage.Should().Be("ghcr.io/rivoli-ai/andy-desktop:latest");
+        job.GuiType.Should().Be("vnc",
+            "desktop profile must enable the VNC sidecar even when the template was non-GUI");
+    }
+
+    [Fact]
+    public async Task CreateContainer_NoProfile_KeepsTemplateImageAndGui()
+    {
+        // Back-compat: callers that don't bind a profile see exactly
+        // the pre-X4 behaviour — template drives image + GUI.
+        var (template, provider) = await SeedTemplateAndProvider();
+        template.GuiType = "vnc";
+
+        await _service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "t1",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+        }, CancellationToken.None);
+
+        _queue.Reader.TryRead(out var job).Should().BeTrue();
+        job!.TemplateBaseImage.Should().Be(template.BaseImage);
+        job.GuiType.Should().Be("vnc");
+        job.EnvironmentProfileId.Should().BeNull();
+        job.EnvironmentKind.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateContainer_UnknownProfileId_Throws()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+
+        var act = () => _service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "x",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            EnvironmentProfileId = Guid.NewGuid(),
+        }, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .Where(e => e.Message.Contains("EnvironmentProfile"));
+        _queue.Reader.TryRead(out _).Should().BeFalse(
+            "a missing profile must short-circuit before any provisioning is enqueued");
+    }
+
+    private async Task<EnvironmentProfile> SeedProfile(
+        string code, EnvironmentKind kind, string baseImageRef)
+    {
+        var profile = new EnvironmentProfile
+        {
+            Id = Guid.NewGuid(),
+            Name = code,
+            DisplayName = code,
+            Kind = kind,
+            BaseImageRef = baseImageRef,
+        };
+        _db.EnvironmentProfiles.Add(profile);
+        await _db.SaveChangesAsync();
+        return profile;
+    }
 }


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#93

## Summary

Container creation now consumes \`EnvironmentProfileId\` (X1 entity, X2 seeds). When a profile is bound, its \`BaseImageRef\` wins over the template's \`BaseImage\` and its \`Kind\` drives the sidecar \`GuiType\`:

| Profile kind | Effective image | GuiType | Effect |
|---|---|---|---|
| \`HeadlessContainer\` | \`profile.BaseImageRef\` | \`"none"\` | No VNC, no code-server side-cars |
| \`Terminal\` | \`profile.BaseImageRef\` | \`"none"\` | TTY attach via the existing \`/exec\` path |
| \`Desktop\` | \`profile.BaseImageRef\` | \`"vnc"\` | VNC sidecar wired by the worker |
| _(no profile bound)_ | \`template.BaseImage\` | \`template.GuiType\` | Pre-X4 behaviour (back-compat) |

## Architecture

All the work lives in \`ContainerOrchestrationService.CreateContainerAsync\`:
1. Resolve the profile (unknown id → \`ArgumentException\`).
2. Compute \`effectiveImage\` / \`effectiveGuiType\`.
3. Stamp them onto \`ContainerProvisionJob\` along with \`EnvironmentProfileId\` / \`EnvironmentKind\` (observability).

\`ContainerProvisioningWorker\` and **all 9 providers** (Docker / Apple / AWS / Azure / GCP / Civo / DigitalOcean / Fly.io / Hetzner) get the headless behaviour for free — sidecars are already a worker concern (port 6080 mapping + \`/start.sh\` command), not a provider one, so flipping \`GuiType\` is the only lever needed.

## Notes

- X5 will wire \`EnvironmentProfileId\` from the workspace-create surface through to \`CreateContainerRequest\`. AP5's run-mode dispatcher could similarly forward \`Run.EnvironmentProfileId\` in a follow-up — out of scope here.
- The issue mentioned per-service-CLI auto-injection on \`PATH\` (Epic Y5) for headless agents. That's an image-build concern (the \`ghcr.io/rivoli-ai/andy-headless\` image must ship the CLIs); out of scope for X4 which is the orchestration pipeline.

## Test plan

- [x] \`ContainerOrchestrationServiceTests\` adds 5 X4 cases:
  - Headless profile overrides image AND drops VNC (template explicitly wanted it)
  - Terminal profile substitutes image with no VNC
  - Desktop profile flips on VNC even when template was non-GUI
  - No profile → template's image + GuiType (back-compat)
  - Unknown profile id → \`ArgumentException\` and never enqueues
- [x] All 36 pre-existing \`ContainerOrchestrationServiceTests\` still pass after \`ContainerProvisionJob\` gained two optional fields.
- [x] Full unit suite: 1142 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)