### PR TITLE
X5: workspace-create binds an EnvironmentProfile + container inherits it (#94)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/WorkspacesController.cs
+++ b/src/Andy.Containers.Api/Controllers/WorkspacesController.cs
@@ -79,6 +79,29 @@ public class WorkspacesController : ControllerBase
             if (!isMember) return Forbid();
         }
 
+        // X5 (rivoli-ai/andy-containers#94). Profile binding is required at
+        // create time — it's the governance anchor for every container the
+        // workspace later provisions (X4 substitutes image + GuiType from
+        // the bound profile). 400 on missing/unknown rather than letting
+        // the row land profile-less and surfacing the gap downstream.
+        if (string.IsNullOrWhiteSpace(dto.EnvironmentProfileCode))
+        {
+            return BadRequest(new
+            {
+                error = "environmentProfileCode is required (e.g. 'headless-container').",
+            });
+        }
+
+        var profile = await _db.EnvironmentProfiles
+            .FirstOrDefaultAsync(p => p.Name == dto.EnvironmentProfileCode, ct);
+        if (profile is null)
+        {
+            return BadRequest(new
+            {
+                error = $"EnvironmentProfile '{dto.EnvironmentProfileCode}' not found in catalog.",
+            });
+        }
+
         // Validate uniqueness of git repo URLs
         var repos = dto.GitRepositories ?? [];
         var duplicateUrl = repos.GroupBy(r => r.Url, StringComparer.OrdinalIgnoreCase)
@@ -95,7 +118,8 @@ public class WorkspacesController : ControllerBase
             TeamId = dto.TeamId,
             GitRepositoryUrl = dto.GitRepositoryUrl,
             GitBranch = dto.GitBranch,
-            GitRepositories = repos.Count > 0 ? JsonSerializer.Serialize(repos) : null
+            GitRepositories = repos.Count > 0 ? JsonSerializer.Serialize(repos) : null,
+            EnvironmentProfileId = profile.Id,
         };
         _db.Workspaces.Add(workspace);
         await _db.SaveChangesAsync(ct);
@@ -150,5 +174,9 @@ public class WorkspacesController : ControllerBase
 }
 
 public record WorkspaceGitRepoDto(string Url, string? Branch = null, string? CredentialRef = null, string? TargetPath = null);
-public record CreateWorkspaceDto(string Name, string? Description, Guid? OrganizationId, Guid? TeamId, string? GitRepositoryUrl, string? GitBranch, List<WorkspaceGitRepoDto>? GitRepositories = null);
+// X5 (rivoli-ai/andy-containers#94): EnvironmentProfileCode is the slug from
+// the X3 catalog (e.g. "headless-container"). Optional in the C# signature
+// so existing callers don't break at compile time, but the controller
+// validates it as required and returns 400 when omitted on Create.
+public record CreateWorkspaceDto(string Name, string? Description, Guid? OrganizationId, Guid? TeamId, string? GitRepositoryUrl, string? GitBranch, List<WorkspaceGitRepoDto>? GitRepositories = null, string? EnvironmentProfileCode = null);
 public record UpdateWorkspaceDto(string? Name, string? Description, string? GitBranch, List<WorkspaceGitRepoDto>? GitRepositories = null);

--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -109,15 +109,31 @@ public class ContainerOrchestrationService : IContainerService
         // Terminal kinds skip the VNC sidecar entirely; Desktop keeps
         // it. The template still drives resources, scripts, and
         // dependencies — only image + sidecar surface flip.
+        //
+        // X5 (rivoli-ai/andy-containers#94). When the request omits a
+        // profile but binds a workspace, inherit the workspace's bound
+        // profile — that's the workspace's governance anchor and every
+        // container the workspace provisions should match its envelope.
+        // Explicit request.EnvironmentProfileId still wins (one-off
+        // shells into a different env are intentional).
+        var effectiveProfileId = request.EnvironmentProfileId;
+        if (effectiveProfileId is null && request.WorkspaceId.HasValue)
+        {
+            effectiveProfileId = await _db.Workspaces
+                .Where(w => w.Id == request.WorkspaceId.Value)
+                .Select(w => w.EnvironmentProfileId)
+                .FirstOrDefaultAsync(ct);
+        }
+
         EnvironmentProfile? profile = null;
-        if (request.EnvironmentProfileId.HasValue)
+        if (effectiveProfileId.HasValue)
         {
             profile = await _db.EnvironmentProfiles
-                .FirstOrDefaultAsync(p => p.Id == request.EnvironmentProfileId.Value, ct);
+                .FirstOrDefaultAsync(p => p.Id == effectiveProfileId.Value, ct);
             if (profile is null)
             {
                 throw new ArgumentException(
-                    $"EnvironmentProfile '{request.EnvironmentProfileId.Value}' not found.");
+                    $"EnvironmentProfile '{effectiveProfileId.Value}' not found.");
             }
         }
 

--- a/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
+++ b/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
@@ -137,6 +137,16 @@ public class ContainersDbContext : DbContext
             }
             e.HasOne(w => w.DefaultContainer).WithMany().HasForeignKey(w => w.DefaultContainerId);
             e.HasMany(w => w.Containers).WithMany();
+            // X5 (rivoli-ai/andy-containers#94). Governance binding to the
+            // EnvironmentProfile catalog. SetNull on profile-delete so a
+            // profile retirement doesn't cascade-destroy workspaces; the
+            // workspace stays addressable but loses its image/sidecar
+            // derivation until an operator rebinds it.
+            e.HasOne(w => w.EnvironmentProfile)
+                .WithMany()
+                .HasForeignKey(w => w.EnvironmentProfileId)
+                .OnDelete(DeleteBehavior.SetNull);
+            e.HasIndex(w => w.EnvironmentProfileId);
         });
 
         // InfrastructureProvider

--- a/src/Andy.Containers.Infrastructure/Migrations/20260428000900_AddWorkspaceEnvironmentProfile.Designer.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260428000900_AddWorkspaceEnvironmentProfile.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Andy.Containers.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Containers.Infrastructure.Migrations
 {
     [DbContext(typeof(ContainersDbContext))]
-    partial class ContainersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428000900_AddWorkspaceEnvironmentProfile")]
+    partial class AddWorkspaceEnvironmentProfile
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Containers.Infrastructure/Migrations/20260428000900_AddWorkspaceEnvironmentProfile.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260428000900_AddWorkspaceEnvironmentProfile.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Containers.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorkspaceEnvironmentProfile : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "EnvironmentProfileId",
+                table: "Workspaces",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Workspaces_EnvironmentProfileId",
+                table: "Workspaces",
+                column: "EnvironmentProfileId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Workspaces_EnvironmentProfiles_EnvironmentProfileId",
+                table: "Workspaces",
+                column: "EnvironmentProfileId",
+                principalTable: "EnvironmentProfiles",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Workspaces_EnvironmentProfiles_EnvironmentProfileId",
+                table: "Workspaces");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Workspaces_EnvironmentProfileId",
+                table: "Workspaces");
+
+            migrationBuilder.DropColumn(
+                name: "EnvironmentProfileId",
+                table: "Workspaces");
+        }
+    }
+}

--- a/src/Andy.Containers/Models/Workspace.cs
+++ b/src/Andy.Containers/Models/Workspace.cs
@@ -21,6 +21,19 @@ public class Workspace
     public string? Metadata { get; set; }
 
     public ICollection<Container> Containers { get; set; } = new List<Container>();
+
+    /// <summary>
+    /// X5 (rivoli-ai/andy-containers#94). Governance anchor: every new
+    /// workspace binds an <see cref="EnvironmentProfile"/> at creation
+    /// time which dictates the runtime shape (headless / terminal /
+    /// desktop) and capability envelope for every container the
+    /// workspace provisions. Nullable for back-compat with rows
+    /// created before X5; new workspaces require it via the
+    /// <c>CreateWorkspaceDto</c> contract.
+    /// </summary>
+    public Guid? EnvironmentProfileId { get; set; }
+
+    public EnvironmentProfile? EnvironmentProfile { get; set; }
 }
 
 public enum WorkspaceStatus

--- a/tests/Andy.Containers.Api.Tests/Controllers/WorkspacesControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/WorkspacesControllerTests.cs
@@ -37,7 +37,12 @@ public class WorkspacesControllerTests : IDisposable
     [Fact]
     public async Task Create_ShouldReturnCreatedWorkspace()
     {
-        var dto = new CreateWorkspaceDto("My Workspace", "A test workspace", null, null, "https://github.com/test/repo", "main");
+        // X5 (#94): EnvironmentProfileCode is now required at create time.
+        var profile = await SeedHeadlessProfile();
+        var dto = new CreateWorkspaceDto(
+            "My Workspace", "A test workspace", null, null,
+            "https://github.com/test/repo", "main",
+            EnvironmentProfileCode: profile.Name);
 
         var result = await _controller.Create(dto, CancellationToken.None);
 
@@ -48,6 +53,87 @@ public class WorkspacesControllerTests : IDisposable
         ws.OwnerId.Should().Be("test-user");
         ws.GitRepositoryUrl.Should().Be("https://github.com/test/repo");
         ws.GitBranch.Should().Be("main");
+        ws.EnvironmentProfileId.Should().Be(profile.Id,
+            "the bound profile is the workspace's governance anchor");
+    }
+
+    // X5 (#94) -----------------------------------------------------------
+
+    [Fact]
+    public async Task Create_MissingEnvironmentProfileCode_ReturnsBadRequest()
+    {
+        var dto = new CreateWorkspaceDto(
+            "no-profile", null, null, null, null, null);
+
+        var result = await _controller.Create(dto, CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>(
+            "profile binding is the governance anchor; missing it can't fall through silently");
+    }
+
+    [Fact]
+    public async Task Create_BlankEnvironmentProfileCode_ReturnsBadRequest()
+    {
+        var dto = new CreateWorkspaceDto(
+            "blank", null, null, null, null, null,
+            EnvironmentProfileCode: "   ");
+
+        var result = await _controller.Create(dto, CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Create_UnknownEnvironmentProfileCode_ReturnsBadRequest()
+    {
+        var dto = new CreateWorkspaceDto(
+            "unknown-profile", null, null, null, null, null,
+            EnvironmentProfileCode: "totally-fake");
+
+        var result = await _controller.Create(dto, CancellationToken.None);
+
+        var bad = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        bad.Value!.ToString().Should().Contain("totally-fake");
+    }
+
+    [Fact]
+    public async Task Update_DoesNotExposeProfileChange()
+    {
+        // UpdateWorkspaceDto deliberately omits EnvironmentProfileCode —
+        // the FK is a governance anchor that should require workspace
+        // recreation to change. Pin that the field can't be sneaked
+        // through via Update by asserting the profile id is preserved.
+        var profile = await SeedHeadlessProfile();
+        var ws = new Workspace
+        {
+            Name = "ws", OwnerId = "test-user",
+            EnvironmentProfileId = profile.Id,
+        };
+        _db.Workspaces.Add(ws);
+        await _db.SaveChangesAsync();
+
+        var dto = new UpdateWorkspaceDto("renamed", null, null);
+        var result = await _controller.Update(ws.Id, dto, CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>();
+        var reloaded = await _db.Workspaces.FindAsync(ws.Id);
+        reloaded!.EnvironmentProfileId.Should().Be(profile.Id,
+            "Update has no profile field — re-binding requires workspace recreation");
+    }
+
+    private async Task<Andy.Containers.Models.EnvironmentProfile> SeedHeadlessProfile()
+    {
+        var profile = new Andy.Containers.Models.EnvironmentProfile
+        {
+            Id = Guid.NewGuid(),
+            Name = "headless-container",
+            DisplayName = "Headless container",
+            Kind = Andy.Containers.Models.EnvironmentKind.HeadlessContainer,
+            BaseImageRef = "ghcr.io/rivoli-ai/andy-headless:latest",
+        };
+        _db.EnvironmentProfiles.Add(profile);
+        await _db.SaveChangesAsync();
+        return profile;
     }
 
     [Fact]

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTests.cs
@@ -1128,6 +1128,90 @@ public class ContainerOrchestrationServiceTests : IDisposable
             "a missing profile must short-circuit before any provisioning is enqueued");
     }
 
+    // X5 (#94). When a request omits the profile but binds a workspace,
+    // inherit the workspace's profile — that's the governance anchor and
+    // every container the workspace provisions should match its envelope.
+
+    [Fact]
+    public async Task CreateContainer_InheritsWorkspaceProfile_WhenRequestOmitsProfile()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+        template.GuiType = "vnc"; // would normally drive VNC sidecar
+        var profile = await SeedProfile(
+            "headless-container",
+            EnvironmentKind.HeadlessContainer,
+            "ghcr.io/rivoli-ai/andy-headless:2026.04");
+        var workspace = await SeedWorkspaceWithProfile(profile.Id);
+
+        await _service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "from-workspace",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            WorkspaceId = workspace.Id,
+            // EnvironmentProfileId intentionally omitted — inheritance
+            // path is what we're pinning here.
+        }, CancellationToken.None);
+
+        _queue.Reader.TryRead(out var job).Should().BeTrue();
+        job!.TemplateBaseImage.Should().Be("ghcr.io/rivoli-ai/andy-headless:2026.04");
+        job.GuiType.Should().Be("none",
+            "inherited headless profile must drop the VNC sidecar");
+        job.EnvironmentProfileId.Should().Be(profile.Id);
+        job.EnvironmentKind.Should().Be("HeadlessContainer");
+    }
+
+    [Fact]
+    public async Task CreateContainer_ExplicitProfileWinsOverWorkspaceProfile()
+    {
+        // One-off shells into a different env are intentional: the
+        // explicit request value beats the workspace anchor.
+        var (template, provider) = await SeedTemplateAndProvider();
+        var workspaceProfile = await SeedProfile(
+            "headless-container", EnvironmentKind.HeadlessContainer, "image:headless");
+        var explicitProfile = await SeedProfile(
+            "desktop", EnvironmentKind.Desktop, "image:desktop");
+        var workspace = await SeedWorkspaceWithProfile(workspaceProfile.Id);
+
+        await _service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "explicit-wins",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            WorkspaceId = workspace.Id,
+            EnvironmentProfileId = explicitProfile.Id,
+        }, CancellationToken.None);
+
+        _queue.Reader.TryRead(out var job).Should().BeTrue();
+        job!.EnvironmentProfileId.Should().Be(explicitProfile.Id);
+        job.GuiType.Should().Be("vnc");
+    }
+
+    [Fact]
+    public async Task CreateContainer_WorkspaceWithoutProfile_FallsBackToTemplate()
+    {
+        // Pre-X5 workspaces (or workspaces somehow created without a
+        // profile binding) leave EnvironmentProfileId null. The
+        // container falls through to the template's image / GuiType
+        // exactly as it did before X4 — back-compat.
+        var (template, provider) = await SeedTemplateAndProvider();
+        template.GuiType = "vnc";
+        var workspace = await SeedWorkspaceWithProfile(null);
+
+        await _service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "no-profile-ws",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            WorkspaceId = workspace.Id,
+        }, CancellationToken.None);
+
+        _queue.Reader.TryRead(out var job).Should().BeTrue();
+        job!.TemplateBaseImage.Should().Be(template.BaseImage);
+        job.GuiType.Should().Be("vnc");
+        job.EnvironmentProfileId.Should().BeNull();
+    }
+
     private async Task<EnvironmentProfile> SeedProfile(
         string code, EnvironmentKind kind, string baseImageRef)
     {
@@ -1142,5 +1226,19 @@ public class ContainerOrchestrationServiceTests : IDisposable
         _db.EnvironmentProfiles.Add(profile);
         await _db.SaveChangesAsync();
         return profile;
+    }
+
+    private async Task<Workspace> SeedWorkspaceWithProfile(Guid? profileId)
+    {
+        var workspace = new Workspace
+        {
+            Id = Guid.NewGuid(),
+            Name = "ws",
+            OwnerId = "alice",
+            EnvironmentProfileId = profileId,
+        };
+        _db.Workspaces.Add(workspace);
+        await _db.SaveChangesAsync();
+        return workspace;
     }
 }


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#94 (workspace-binding portion; agent-capability cross-service check deferred — see Notes)

## Summary

Workspaces now bind an \`EnvironmentProfile\` at creation time — the governance anchor for every container the workspace later provisions. Containers created with a \`WorkspaceId\` automatically inherit the workspace's profile, and X4's image / sidecar substitution kicks in transparently.

- **\`Workspace.EnvironmentProfileId\`** — nullable \`Guid\` FK with \`SetNull\` cascade (a profile retirement doesn't cascade-destroy workspaces). Migration \`AddWorkspaceEnvironmentProfile\` adds the column + index + FK.
- **\`CreateWorkspaceDto.EnvironmentProfileCode\`** — slug from the X3 catalog. Optional in the C# signature so existing call-sites compile, but the controller validates as required and returns \`400\` on missing / blank / unknown codes.
- **\`UpdateWorkspaceDto\`** intentionally has no profile field — re-binding requires workspace recreation since the profile is the anchor for the entire capability envelope.
- **Container inheritance** — \`ContainerOrchestrationService\` reads \`Workspace.EnvironmentProfileId\` when the request omits its own. Explicit \`request.EnvironmentProfileId\` still wins (one-off shells into a different env stay intentional).

## What's deferred

The issue's **agent \`allowed_environments\` enforcement** is out of scope here. \`andy-agents\` (Epic W3) doesn't expose the lookup endpoint yet, so an \`IAgentCapabilityService\` would be stub-only today. When W3 lands the contract, the synchronous path described in the issue (Option A) drops in: resolve workspace's profile, fetch agent's allowlist, return 403 if the profile isn't in it. Until then, workspaces are agent-agnostic and the run-submit surface (Conductor / AP runs) is the natural enforcement point.

## Test plan

- [x] \`WorkspacesControllerTests\` adds 4 X5 cases:
  - happy path: profile binding lands as FK on the row;
  - missing code → 400;
  - blank code → 400;
  - unknown code → 400 with the slug echoed back;
  - \`Update\` can't sneak through a profile change (no field exposed).
- [x] \`ContainerOrchestrationServiceTests\` adds 3 X5 cases:
  - workspace's headless profile drops the VNC sidecar even when the template wanted it;
  - explicit \`request.EnvironmentProfileId\` wins over the workspace's;
  - profile-less workspace (pre-X5 row) falls through to template's image + GuiType.
- [x] All 36 pre-existing \`ContainerOrchestrationServiceTests\` + 7 \`WorkspacesControllerTests\` still pass.
- [x] Full unit suite: **1149 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)