### PR TITLE
X6: MCP tool environment.list (#96)

### DIFF
--- a/src/Andy.Containers.Api/Mcp/EnvironmentsMcpTools.cs
+++ b/src/Andy.Containers.Api/Mcp/EnvironmentsMcpTools.cs
@@ -1,0 +1,97 @@
+using System.ComponentModel;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace Andy.Containers.Api.Mcp;
+
+/// <summary>
+/// X6 (rivoli-ai/andy-containers#96). MCP surface for the EnvironmentProfile
+/// catalog. Mirrors the X3 HTTP endpoint at <c>GET /api/environments</c>:
+/// MCP-aware clients (Conductor, Claude Code, agent runtimes) can discover
+/// the available runtime shapes (headless / terminal / desktop) and their
+/// capability envelopes without a separate HTTP round-trip.
+/// </summary>
+/// <remarks>
+/// Discovered automatically by <c>WithToolsFromAssembly()</c> in
+/// <c>Program.cs</c> — no explicit DI registration needed beyond the
+/// services this class consumes.
+/// </remarks>
+[McpServerToolType]
+public class EnvironmentsMcpTools
+{
+    private readonly ContainersDbContext _db;
+    private readonly ICurrentUserService _currentUser;
+    private readonly IOrganizationMembershipService _orgMembership;
+    private readonly ILogger<EnvironmentsMcpTools> _logger;
+
+    public EnvironmentsMcpTools(
+        ContainersDbContext db,
+        ICurrentUserService currentUser,
+        IOrganizationMembershipService orgMembership,
+        ILogger<EnvironmentsMcpTools> logger)
+    {
+        _db = db;
+        _currentUser = currentUser;
+        _orgMembership = orgMembership;
+        _logger = logger;
+    }
+
+    [McpServerTool(Name = "environment.list"), Description(
+        "List EnvironmentProfile rows from the catalog. Each profile declares the runtime shape " +
+        "(headless / terminal / desktop), the base image used for provisioning, and the capability " +
+        "envelope (network allowlist, secrets scope, GUI, audit mode). Optional kind filter narrows " +
+        "to a single runtime shape. Requires environment:read.")]
+    public async Task<IReadOnlyList<EnvironmentProfileDto>> ListEnvironments(
+        [Description("Optional kind filter: 'HeadlessContainer', 'Terminal', or 'Desktop' (case-insensitive). Unknown values yield an empty result.")]
+        string? kind = null,
+        CancellationToken ct = default)
+    {
+        if (!await EnsurePermission(Permissions.EnvironmentRead, ct))
+        {
+            return Array.Empty<EnvironmentProfileDto>();
+        }
+
+        EnvironmentKind? kindFilter = null;
+        if (!string.IsNullOrWhiteSpace(kind))
+        {
+            if (!Enum.TryParse<EnvironmentKind>(kind, ignoreCase: true, out var parsed))
+            {
+                // MCP clients get an empty list for unknown kinds rather
+                // than an error envelope — the HTTP layer surfaces 400
+                // for the same case (typo vs. empty), but the MCP
+                // contract here is "list", and an empty list is the
+                // right answer for "no profiles match this filter".
+                _logger.LogDebug(
+                    "environment.list: unknown kind filter '{Kind}'; returning empty.", kind);
+                return Array.Empty<EnvironmentProfileDto>();
+            }
+            kindFilter = parsed;
+        }
+
+        var query = _db.EnvironmentProfiles.AsNoTracking().AsQueryable();
+        if (kindFilter.HasValue)
+        {
+            query = query.Where(p => p.Kind == kindFilter.Value);
+        }
+
+        var rows = await query.OrderBy(p => p.Name).ToListAsync(ct);
+        return rows.Select(EnvironmentProfileDto.FromEntity).ToList();
+    }
+
+    private async Task<bool> EnsurePermission(string permission, CancellationToken ct)
+    {
+        if (_currentUser.IsAdmin()) return true;
+
+        var userId = _currentUser.GetUserId();
+        if (string.IsNullOrEmpty(userId)) return false;
+
+        var orgId = _currentUser.GetOrganizationId();
+        if (orgId is null) return false;
+
+        return await _orgMembership.HasPermissionAsync(userId, orgId.Value, permission, ct);
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Mcp/EnvironmentsMcpToolsTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Mcp/EnvironmentsMcpToolsTests.cs
@@ -1,0 +1,198 @@
+using Andy.Containers.Api.Mcp;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Mcp;
+
+// X6 (rivoli-ai/andy-containers#96). The MCP environment.list tool is
+// the discovery surface for the EnvironmentProfile catalog. Tests pin
+// the contract that matters: permission gating, kind filtering, and
+// the structured Capabilities block reaching MCP consumers without an
+// extra HTTP round-trip.
+public class EnvironmentsMcpToolsTests : IDisposable
+{
+    private readonly ContainersDbContext _db;
+    private readonly Mock<ICurrentUserService> _currentUser;
+    private readonly Mock<IOrganizationMembershipService> _orgMembership;
+    private readonly EnvironmentsMcpTools _tools;
+    private readonly Guid _orgId = Guid.NewGuid();
+
+    public EnvironmentsMcpToolsTests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+
+        _currentUser = new Mock<ICurrentUserService>();
+        _currentUser.Setup(u => u.GetUserId()).Returns("test-user");
+        _currentUser.Setup(u => u.IsAdmin()).Returns(false);
+        _currentUser.Setup(u => u.GetOrganizationId()).Returns(_orgId);
+
+        _orgMembership = new Mock<IOrganizationMembershipService>();
+        _orgMembership
+            .Setup(o => o.HasPermissionAsync(
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _tools = new EnvironmentsMcpTools(
+            _db, _currentUser.Object, _orgMembership.Object,
+            NullLogger<EnvironmentsMcpTools>.Instance);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task ListEnvironments_NoFilter_ReturnsAllProfiles_OrderedByCode()
+    {
+        SeedThreeProfiles();
+
+        var result = await _tools.ListEnvironments();
+
+        result.Should().HaveCount(3);
+        result.Select(p => p.Code).Should().ContainInOrder(
+            "desktop", "headless-container", "terminal");
+    }
+
+    [Fact]
+    public async Task ListEnvironments_ReturnsStructuredCapabilityBlock()
+    {
+        SeedThreeProfiles();
+
+        var result = await _tools.ListEnvironments();
+
+        var headless = result.Single(p => p.Code == "headless-container");
+        headless.Kind.Should().Be("HeadlessContainer");
+        headless.BaseImageRef.Should().Be("ghcr.io/rivoli-ai/andy-headless:latest");
+        headless.Capabilities.HasGui.Should().BeFalse();
+        headless.Capabilities.SecretsScope.Should().Be(SecretsScope.WorkspaceScoped);
+        headless.Capabilities.AuditMode.Should().Be(AuditMode.Strict);
+        headless.Capabilities.NetworkAllowlist.Should().Contain("registry.rivoli.ai");
+    }
+
+    [Theory]
+    [InlineData("HeadlessContainer", "headless-container")]
+    [InlineData("headlesscontainer", "headless-container")] // case-insensitive
+    [InlineData("Terminal", "terminal")]
+    [InlineData("Desktop", "desktop")]
+    public async Task ListEnvironments_KindFilter_NarrowsToMatchingProfile(string kind, string expected)
+    {
+        SeedThreeProfiles();
+
+        var result = await _tools.ListEnvironments(kind);
+
+        result.Should().ContainSingle().Which.Code.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task ListEnvironments_UnknownKind_ReturnsEmpty()
+    {
+        SeedThreeProfiles();
+
+        var result = await _tools.ListEnvironments(kind: "AlienShape");
+
+        result.Should().BeEmpty(
+            "MCP contract is 'list': an unknown kind narrows the result, the HTTP layer surfaces the typo");
+    }
+
+    [Fact]
+    public async Task ListEnvironments_NonAdminWithoutEnvironmentRead_ReturnsEmpty()
+    {
+        SeedThreeProfiles();
+        _orgMembership
+            .Setup(o => o.HasPermissionAsync(
+                It.IsAny<string>(), _orgId, Permissions.EnvironmentRead, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _tools.ListEnvironments();
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListEnvironments_AdminBypassesOrgPermissionLookup()
+    {
+        SeedThreeProfiles();
+        _currentUser.Setup(u => u.IsAdmin()).Returns(true);
+        _orgMembership
+            .Setup(o => o.HasPermissionAsync(
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _tools.ListEnvironments();
+
+        result.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task ListEnvironments_NoPrimaryOrg_ReturnsEmpty()
+    {
+        // Edge: a user with no primary org can't have org-scoped
+        // permissions evaluated. Match the convention RunsMcpTools
+        // uses (return empty rather than throw) so the MCP transport
+        // surfaces "no results visible" instead of a noisy error.
+        SeedThreeProfiles();
+        _currentUser.Setup(u => u.GetOrganizationId()).Returns((Guid?)null);
+
+        var result = await _tools.ListEnvironments();
+
+        result.Should().BeEmpty();
+    }
+
+    private void SeedThreeProfiles()
+    {
+        _db.EnvironmentProfiles.AddRange(
+            new EnvironmentProfile
+            {
+                Id = Guid.NewGuid(),
+                Name = "headless-container",
+                DisplayName = "Headless container",
+                Kind = EnvironmentKind.HeadlessContainer,
+                BaseImageRef = "ghcr.io/rivoli-ai/andy-headless:latest",
+                Capabilities = new EnvironmentCapabilities
+                {
+                    NetworkAllowlist = new List<string>
+                    {
+                        "registry.rivoli.ai", "api.github.com", "pypi.org", "nuget.org",
+                    },
+                    SecretsScope = SecretsScope.WorkspaceScoped,
+                    HasGui = false,
+                    AuditMode = AuditMode.Strict,
+                },
+            },
+            new EnvironmentProfile
+            {
+                Id = Guid.NewGuid(),
+                Name = "terminal",
+                DisplayName = "Terminal session",
+                Kind = EnvironmentKind.Terminal,
+                BaseImageRef = "ghcr.io/rivoli-ai/andy-terminal:latest",
+                Capabilities = new EnvironmentCapabilities
+                {
+                    NetworkAllowlist = new List<string> { "*" },
+                    SecretsScope = SecretsScope.WorkspaceScoped,
+                    HasGui = false,
+                    AuditMode = AuditMode.Standard,
+                },
+            },
+            new EnvironmentProfile
+            {
+                Id = Guid.NewGuid(),
+                Name = "desktop",
+                DisplayName = "Desktop session",
+                Kind = EnvironmentKind.Desktop,
+                BaseImageRef = "ghcr.io/rivoli-ai/andy-desktop:latest",
+                Capabilities = new EnvironmentCapabilities
+                {
+                    NetworkAllowlist = new List<string> { "*" },
+                    SecretsScope = SecretsScope.OrganizationScoped,
+                    HasGui = true,
+                    AuditMode = AuditMode.Standard,
+                },
+            });
+        _db.SaveChanges();
+    }
+}


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#96

## Summary

New \`EnvironmentsMcpTools\` class exposes the X3 catalog to MCP-aware clients (Conductor, Claude Code, agent runtimes). One method, \`[McpServerTool(Name = "environment.list")]\`, with optional \`kind\` filter and the structured \`EnvironmentProfileDto\` on the wire — agents can reason about capabilities (network allowlist, secrets scope, GUI, audit mode) without parsing raw JSON.

Discovered automatically by \`WithToolsFromAssembly()\` in \`Program.cs\` — no DI registration needed beyond the services the class consumes.

## Permission convention

Mirrors \`RunsMcpTools\` (AP8): admin bypasses the org check, non-admin without \`environment:read\` gets an empty list. Unknown kind filter values yield empty rather than an error envelope — the HTTP layer surfaces the typo (X3 returns 400), the MCP contract is "list" and an empty list is the right answer for "no profiles match this filter".

## What's deferred

\`environment.get\` is deferred per the issue's "Optional follow-up". HTTP \`/api/environments/by-code/{code}\` (X3) covers that case today; adding it to MCP is a 10-line follow-up if an MCP consumer needs single-row lookups.

## Test plan

- [x] \`EnvironmentsMcpToolsTests\` (10 cases): list-no-filter ordered by code, structured Capabilities round-trip, kind filter Theory (4: HeadlessContainer / case-insensitive / Terminal / Desktop), unknown kind empty, permission denial empty, admin bypass, missing-primary-org empty.
- [x] Full unit suite: **1159 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)