### PR TITLE
X7: andy-containers-cli environments {list,get} (#97)

### DIFF
--- a/src/Andy.Containers.Cli/Commands/EnvironmentCommands.cs
+++ b/src/Andy.Containers.Cli/Commands/EnvironmentCommands.cs
@@ -1,0 +1,111 @@
+using System.CommandLine;
+using System.Text.Json;
+using Andy.Containers.Cli.Formatting;
+using Andy.Containers.Models;
+using Spectre.Console;
+
+namespace Andy.Containers.Cli.Commands;
+
+/// <summary>
+/// X7 (rivoli-ai/andy-containers#97). <c>andy-containers-cli environments
+/// {list,get}</c> — read-only browse over the X3 catalog. Mirrors the
+/// vocabulary established by <c>andy-conductor-cli</c> (Epic AN); shared
+/// <c>--format</c> contract via <see cref="OutputFormatOption"/>.
+/// </summary>
+public static class EnvironmentCommands
+{
+    private static readonly JsonSerializerOptions JsonOut = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+
+    public static Command Create()
+    {
+        var cmd = new Command("environments", "Browse the EnvironmentProfile catalog (Epic X)");
+        cmd.AddCommand(CreateListCommand());
+        cmd.AddCommand(CreateGetCommand());
+        return cmd;
+    }
+
+    private static Command CreateListCommand()
+    {
+        var cmd = new Command("list", "List environment profiles");
+
+        var kindOpt = new Option<string?>(
+            "--kind",
+            "Filter by kind: HeadlessContainer, Terminal, or Desktop (case-insensitive).");
+        var formatOpt = OutputFormatOption.Create();
+
+        cmd.AddOption(kindOpt);
+        cmd.AddOption(formatOpt);
+
+        cmd.SetHandler(async (context) =>
+        {
+            var kind = context.ParseResult.GetValueForOption(kindOpt);
+            var format = context.ParseResult.GetValueForOption(formatOpt);
+            var ct = context.GetCancellationToken();
+
+            var client = ClientFactory.Create();
+            var page = await client.ListEnvironmentsAsync(kind, ct: ct);
+
+            if (format == OutputFormat.Json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(page.Items, JsonOut));
+                return;
+            }
+
+            TableFormatter.PrintEnvironmentTable(page.Items);
+            if (page.TotalCount > page.Items.Length)
+            {
+                AnsiConsole.MarkupLine(
+                    $"[dim]Showing {page.Items.Length} of {page.TotalCount} profile(s).[/]");
+            }
+        });
+
+        return cmd;
+    }
+
+    private static Command CreateGetCommand()
+    {
+        var cmd = new Command("get", "Show one environment profile by code");
+
+        var codeArg = new Argument<string>("code",
+            "Profile code (slug, e.g. 'headless-container').");
+        var formatOpt = OutputFormatOption.Create();
+
+        cmd.AddArgument(codeArg);
+        cmd.AddOption(formatOpt);
+
+        cmd.SetHandler(async (context) =>
+        {
+            var code = context.ParseResult.GetValueForArgument(codeArg);
+            var format = context.ParseResult.GetValueForOption(formatOpt);
+            var ct = context.GetCancellationToken();
+
+            var client = ClientFactory.Create();
+            EnvironmentProfileDto profile;
+            try
+            {
+                profile = await client.GetEnvironmentByCodeAsync(code, ct);
+            }
+            catch (Andy.Containers.Client.ContainersApiException ex)
+                when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                AnsiConsole.MarkupLine($"[red]Profile '{Markup.Escape(code)}' not found.[/]");
+                // Epic AN exit-code contract: 4 = not-found.
+                context.ExitCode = 4;
+                return;
+            }
+
+            if (format == OutputFormat.Json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(profile, JsonOut));
+                return;
+            }
+
+            TableFormatter.PrintEnvironmentDetail(profile);
+        });
+
+        return cmd;
+    }
+}

--- a/src/Andy.Containers.Cli/Formatting/OutputFormat.cs
+++ b/src/Andy.Containers.Cli/Formatting/OutputFormat.cs
@@ -1,0 +1,36 @@
+using System.CommandLine;
+
+namespace Andy.Containers.Cli.Formatting;
+
+/// <summary>
+/// X7 (rivoli-ai/andy-containers#97). Shared <c>--format</c> contract for
+/// per-service CLIs (Epic AN). Two values today; <c>yaml</c> follows
+/// once a consumer needs it. Centralised so future commands (and an
+/// AP9/X7 retrofit) reuse one parser instead of re-deriving it.
+/// </summary>
+public enum OutputFormat
+{
+    /// <summary>Spectre.Console table — the default human-readable view.</summary>
+    Table,
+    /// <summary>Newline-terminated JSON — script-friendly, one record per response.</summary>
+    Json,
+}
+
+public static class OutputFormatOption
+{
+    /// <summary>
+    /// Build a System.CommandLine option named <c>--format</c> with
+    /// <c>-o</c> alias (per Epic AN's shared-flag contract). Defaults
+    /// to <see cref="OutputFormat.Table"/>; explicitly enumerated values
+    /// so a typo gets caught by the parser, not by the formatter.
+    /// </summary>
+    public static Option<OutputFormat> Create()
+    {
+        var option = new Option<OutputFormat>(
+            aliases: new[] { "--format", "-o" },
+            description: "Output format: table (default) or json.",
+            getDefaultValue: () => OutputFormat.Table);
+        option.FromAmong("table", "Table", "json", "Json");
+        return option;
+    }
+}

--- a/src/Andy.Containers.Cli/Formatting/TableFormatter.cs
+++ b/src/Andy.Containers.Cli/Formatting/TableFormatter.cs
@@ -1,4 +1,5 @@
 using Andy.Containers.Client;
+using Andy.Containers.Models;
 using Spectre.Console;
 
 namespace Andy.Containers.Cli.Formatting;
@@ -169,4 +170,78 @@ public static class TableFormatter
         i = Math.Min(i, units.Length - 1);
         return $"{bytes / Math.Pow(1024, i):F1} {units[i]}";
     }
+
+    // X7 (rivoli-ai/andy-containers#97). Environment catalog views.
+
+    public static void PrintEnvironmentTable(IReadOnlyList<EnvironmentProfileDto> profiles)
+    {
+        if (profiles.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[dim]No environment profiles found.[/]");
+            return;
+        }
+
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .AddColumn("Code")
+            .AddColumn("Display name")
+            .AddColumn("Kind")
+            .AddColumn("GUI")
+            .AddColumn("Secrets")
+            .AddColumn("Audit")
+            .AddColumn("Base image");
+
+        foreach (var p in profiles)
+        {
+            var kindColor = p.Kind switch
+            {
+                "HeadlessContainer" => "cyan",
+                "Terminal" => "yellow",
+                "Desktop" => "magenta",
+                _ => "white",
+            };
+            table.AddRow(
+                Markup.Escape(p.Code),
+                Markup.Escape(p.DisplayName),
+                $"[{kindColor}]{p.Kind}[/]",
+                p.Capabilities.HasGui ? "[green]yes[/]" : "[dim]no[/]",
+                Markup.Escape(p.Capabilities.SecretsScope.ToString()),
+                AuditModeColor(p.Capabilities.AuditMode),
+                Markup.Escape(p.BaseImageRef));
+        }
+
+        AnsiConsole.Write(table);
+    }
+
+    public static void PrintEnvironmentDetail(EnvironmentProfileDto profile)
+    {
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .HideHeaders()
+            .AddColumn("")
+            .AddColumn("");
+
+        table.AddRow("Code", Markup.Escape(profile.Code));
+        table.AddRow("Display name", Markup.Escape(profile.DisplayName));
+        table.AddRow("Kind", profile.Kind);
+        table.AddRow("Base image", Markup.Escape(profile.BaseImageRef));
+        table.AddRow("Created", profile.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss"));
+        table.AddRow("GUI", profile.Capabilities.HasGui ? "[green]yes[/]" : "[dim]no[/]");
+        table.AddRow("Secrets scope", profile.Capabilities.SecretsScope.ToString());
+        table.AddRow("Audit mode", AuditModeColor(profile.Capabilities.AuditMode));
+        var allowlist = profile.Capabilities.NetworkAllowlist;
+        table.AddRow("Network allowlist",
+            allowlist.Count == 0 ? "[dim](none — egress denied)[/]"
+                : string.Join(", ", allowlist.Select(Markup.Escape)));
+
+        AnsiConsole.Write(table);
+    }
+
+    private static string AuditModeColor(AuditMode mode) => mode switch
+    {
+        AuditMode.Strict => "[red]Strict[/]",
+        AuditMode.Standard => "[yellow]Standard[/]",
+        AuditMode.None => "[dim]None[/]",
+        _ => mode.ToString(),
+    };
 }

--- a/src/Andy.Containers.Cli/Program.cs
+++ b/src/Andy.Containers.Cli/Program.cs
@@ -34,6 +34,9 @@ rootCommand.AddCommand(ConnectCommand.Create());
 // Run commands (AP9 — rivoli-ai/andy-containers#111).
 rootCommand.AddCommand(RunCommands.Create());
 
+// Environment-profile catalog (X7 — rivoli-ai/andy-containers#97).
+rootCommand.AddCommand(EnvironmentCommands.Create());
+
 // Workspace commands (stubs for future)
 var workspaceCommand = new Command("workspace", "Manage workspaces");
 workspaceCommand.AddCommand(new Command("create", "Create a workspace"));

--- a/src/Andy.Containers.Client/ContainersClient.cs
+++ b/src/Andy.Containers.Client/ContainersClient.cs
@@ -117,6 +117,33 @@ public sealed class ContainersClient
     // client lib already references Andy.Containers for Permissions
     // constants, so this is no extra dependency.
 
+    // Environments (X7 — rivoli-ai/andy-containers#97). Read-only catalog.
+    // The X3 server returns the standard { items, totalCount } envelope;
+    // PaginatedResult<EnvironmentProfileDto> deserialises it directly via
+    // the case-insensitive options the client already configures.
+
+    public async Task<PaginatedResult<EnvironmentProfileDto>> ListEnvironmentsAsync(
+        string? kind = null, int? skip = null, int? take = null, CancellationToken ct = default)
+    {
+        var query = new List<string>();
+        if (!string.IsNullOrWhiteSpace(kind)) query.Add($"kind={Uri.EscapeDataString(kind)}");
+        if (skip.HasValue) query.Add($"skip={skip.Value}");
+        if (take.HasValue) query.Add($"take={take.Value}");
+        var url = "api/environments" + (query.Count > 0 ? "?" + string.Join("&", query) : "");
+
+        var r = await _http.GetAsync(url, ct);
+        await EnsureSuccessAsync(r, ct);
+        return (await r.Content.ReadFromJsonAsync<PaginatedResult<EnvironmentProfileDto>>(_json, ct))!;
+    }
+
+    public async Task<EnvironmentProfileDto> GetEnvironmentByCodeAsync(
+        string code, CancellationToken ct = default)
+    {
+        var r = await _http.GetAsync($"api/environments/by-code/{Uri.EscapeDataString(code)}", ct);
+        await EnsureSuccessAsync(r, ct);
+        return (await r.Content.ReadFromJsonAsync<EnvironmentProfileDto>(_json, ct))!;
+    }
+
     public async Task<RunDto> CreateRunAsync(CreateRunRequest request, CancellationToken ct = default)
     {
         var r = await _http.PostAsJsonAsync("api/runs", request, _json, ct);

--- a/tests/Andy.Containers.Client.Tests/ContainersClientTests.cs
+++ b/tests/Andy.Containers.Client.Tests/ContainersClientTests.cs
@@ -159,6 +159,9 @@ public class ContainersClientTests
         private readonly string _contentType;
         private readonly HttpStatusCode _status;
 
+        public Uri? LastRequestUri { get; private set; }
+        public HttpMethod? LastMethod { get; private set; }
+
         public CannedHandler(string body, string contentType, HttpStatusCode status = HttpStatusCode.OK)
         {
             _body = Encoding.UTF8.GetBytes(body);
@@ -168,9 +171,137 @@ public class ContainersClientTests
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
         {
+            LastRequestUri = request.RequestUri;
+            LastMethod = request.Method;
             var content = new ByteArrayContent(_body);
             content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(_contentType);
             return Task.FromResult(new HttpResponseMessage(_status) { Content = content });
         }
+    }
+
+    // X7 (rivoli-ai/andy-containers#97). Environment catalog wrappers.
+    // Pin the URL shape so a typo in the route or a regression in
+    // pagination encoding becomes a test failure here, not a 404 in
+    // the CLI.
+
+    [Fact]
+    public async Task ListEnvironmentsAsync_NoFilters_HitsBareCollectionUrl()
+    {
+        var handler = new CannedHandler(
+            """{"items":[],"totalCount":0}""", "application/json");
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://example.local/") };
+        var client = new ContainersClient(http);
+
+        var page = await client.ListEnvironmentsAsync();
+
+        page.TotalCount.Should().Be(0);
+        page.Items.Should().BeEmpty();
+        handler.LastMethod.Should().Be(HttpMethod.Get);
+        handler.LastRequestUri!.AbsolutePath.Should().Be("/api/environments");
+        handler.LastRequestUri.Query.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListEnvironmentsAsync_AllFilters_AppendsQueryParams()
+    {
+        var handler = new CannedHandler(
+            """{"items":[],"totalCount":0}""", "application/json");
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://example.local/") };
+        var client = new ContainersClient(http);
+
+        await client.ListEnvironmentsAsync(kind: "Headless Container", skip: 0, take: 25);
+
+        var query = handler.LastRequestUri!.Query;
+        query.Should().Contain("kind=Headless%20Container",
+            "spaces in user-supplied kind values must be URL-encoded, not silently dropped");
+        query.Should().Contain("skip=0");
+        query.Should().Contain("take=25");
+    }
+
+    [Fact]
+    public async Task ListEnvironmentsAsync_DeserialisesItems_AndCapabilities()
+    {
+        var profileId = Guid.NewGuid();
+        var body = $$"""
+            {
+              "items": [{
+                "id": "{{profileId}}",
+                "code": "headless-container",
+                "displayName": "Headless container",
+                "kind": "HeadlessContainer",
+                "baseImageRef": "ghcr.io/rivoli-ai/andy-headless:latest",
+                "capabilities": {
+                  "networkAllowlist": ["registry.rivoli.ai"],
+                  "secretsScope": "WorkspaceScoped",
+                  "hasGui": false,
+                  "auditMode": "Strict"
+                },
+                "createdAt": "2026-04-27T00:00:00+00:00"
+              }],
+              "totalCount": 1
+            }
+            """;
+        var http = new HttpClient(new CannedHandler(body, "application/json"))
+        {
+            BaseAddress = new Uri("https://example.local/"),
+        };
+        var client = new ContainersClient(http);
+
+        var page = await client.ListEnvironmentsAsync();
+
+        page.Items.Should().HaveCount(1);
+        var dto = page.Items[0];
+        dto.Code.Should().Be("headless-container");
+        dto.Kind.Should().Be("HeadlessContainer");
+        dto.Capabilities.HasGui.Should().BeFalse();
+        dto.Capabilities.SecretsScope.Should()
+            .Be(Andy.Containers.Models.SecretsScope.WorkspaceScoped);
+        dto.Capabilities.AuditMode.Should()
+            .Be(Andy.Containers.Models.AuditMode.Strict);
+    }
+
+    [Fact]
+    public async Task GetEnvironmentByCodeAsync_HitsByCodeRoute_AndDeserialises()
+    {
+        var body = """
+            {
+              "id": "00000000-0000-0000-0000-000000000001",
+              "code": "desktop",
+              "displayName": "Desktop",
+              "kind": "Desktop",
+              "baseImageRef": "ghcr.io/rivoli-ai/andy-desktop:latest",
+              "capabilities": {
+                "networkAllowlist": ["*"],
+                "secretsScope": "OrganizationScoped",
+                "hasGui": true,
+                "auditMode": "Standard"
+              },
+              "createdAt": "2026-04-27T00:00:00+00:00"
+            }
+            """;
+        var handler = new CannedHandler(body, "application/json");
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://example.local/") };
+        var client = new ContainersClient(http);
+
+        var dto = await client.GetEnvironmentByCodeAsync("desktop");
+
+        handler.LastRequestUri!.AbsolutePath.Should().Be("/api/environments/by-code/desktop");
+        dto.Capabilities.HasGui.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetEnvironmentByCodeAsync_404_ThrowsContainersApiException()
+    {
+        var http = new HttpClient(
+            new CannedHandler("", "application/json", HttpStatusCode.NotFound))
+        {
+            BaseAddress = new Uri("https://example.local/"),
+        };
+        var client = new ContainersClient(http);
+
+        var act = async () => await client.GetEnvironmentByCodeAsync("nope");
+
+        await act.Should().ThrowAsync<ContainersApiException>()
+            .Where(e => e.StatusCode == HttpStatusCode.NotFound);
     }
 }


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#97

## Summary

Two new CLI subcommands mirroring the \`andy-conductor-cli\` vocabulary (Epic AN):

\`\`\`
andy-containers-cli environments list [--kind ...] [--format table|json]
andy-containers-cli environments get  <code>      [--format table|json]
\`\`\`

Architecture matches AP9 (CLI wrapping HTTP):

- **\`ContainersClient\`** gains \`ListEnvironmentsAsync\` (PaginatedResult envelope from X3, query-param encoding) and \`GetEnvironmentByCodeAsync\`.
- **\`EnvironmentCommands\`** wires both into the CLI; \`get\` honours the Epic AN not-found exit code (4) and renders a friendly red error message.
- **\`TableFormatter\`** gains \`PrintEnvironmentTable\` / \`PrintEnvironmentDetail\`. Kind is colour-coded (cyan / yellow / magenta), audit mode in red/yellow/dim, an empty network allowlist is rendered as "(none — egress denied)" instead of blank.
- **\`OutputFormatOption\`** — shared \`--format / -o\` parser for future commands (and an AP9 retrofit). \`Table\` (default) and \`Json\`. The issue's \`yaml\` is deferred until a consumer asks.

## Manual smoke

\`\`\`
$ andy-containers-cli environments --help
Commands:
  list        List environment profiles
  get <code>  Show one environment profile by code

$ andy-containers-cli environments list --help
Options:
  --kind <kind>                         Filter by kind: HeadlessContainer, Terminal, or Desktop (case-insensitive).
  -o, --format <Json|json|Table|table>  Output format: table (default) or json. [default: Table]
\`\`\`

## What's deferred

Per Epic AN: \`yaml\` format, \`--quiet\` / \`--no-color\`, \`--profile\`. The issue calls these out as "confirm once AN lands"; \`OutputFormat\` is structured to grow in place.

## Test plan

- [x] \`ContainersClientTests\` adds 5 cases via the existing \`CannedHandler\` (extended to capture the request URI):
  - bare collection URL with no query
  - kind + skip + take all encoded correctly (spaces URL-escaped)
  - list deserialises Capabilities enums (\`SecretsScope.WorkspaceScoped\`, \`AuditMode.Strict\`)
  - get-by-code path shape (\`/api/environments/by-code/desktop\`)
  - get-404 propagates as \`ContainersApiException\` with \`StatusCode == NotFound\`
- [x] CLI \`--help\` smoke for \`environments\` / \`environments list\` shows the expected tree.
- [x] Full unit suite: **1164 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)