### PR TITLE
X9: agent allowed_environments enforcement + production-YAML round-trip tests (#99)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/WorkspacesController.cs
+++ b/src/Andy.Containers.Api/Controllers/WorkspacesController.cs
@@ -18,12 +18,21 @@ public class WorkspacesController : ControllerBase
     private readonly ContainersDbContext _db;
     private readonly ICurrentUserService _currentUser;
     private readonly IOrganizationMembershipService _orgMembership;
+    private readonly IAgentCapabilityService _agentCapabilities;
+    private readonly ILogger<WorkspacesController> _logger;
 
-    public WorkspacesController(ContainersDbContext db, ICurrentUserService currentUser, IOrganizationMembershipService orgMembership)
+    public WorkspacesController(
+        ContainersDbContext db,
+        ICurrentUserService currentUser,
+        IOrganizationMembershipService orgMembership,
+        IAgentCapabilityService agentCapabilities,
+        ILogger<WorkspacesController> logger)
     {
         _db = db;
         _currentUser = currentUser;
         _orgMembership = orgMembership;
+        _agentCapabilities = agentCapabilities;
+        _logger = logger;
     }
 
     [RequirePermission("workspace:read")]
@@ -102,6 +111,40 @@ public class WorkspacesController : ControllerBase
             });
         }
 
+        // X9 (rivoli-ai/andy-containers#99). When the workspace targets a
+        // specific agent, enforce the agent's allowed_environments
+        // declaration. Agents without a policy stay open (null
+        // allowlist); agents with one are enforced strictly. Service
+        // outage fails closed — better to refuse provisioning than
+        // bind a workspace to an unverifiable policy.
+        if (!string.IsNullOrWhiteSpace(dto.AgentId))
+        {
+            IReadOnlyList<string>? allowed;
+            try
+            {
+                allowed = await _agentCapabilities.GetAllowedEnvironmentsAsync(dto.AgentId, ct);
+            }
+            catch (AgentCapabilityServiceUnavailableException ex)
+            {
+                _logger.LogError(ex,
+                    "Agent capability service unavailable while creating workspace for agent {AgentId}",
+                    dto.AgentId);
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+                {
+                    error = "Agent capability service unavailable; cannot validate allowed_environments.",
+                });
+            }
+
+            if (allowed is not null
+                && !allowed.Any(code => string.Equals(code, profile.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                return StatusCode(StatusCodes.Status403Forbidden, new
+                {
+                    error = $"Profile '{profile.Name}' is not in agent '{dto.AgentId}' allowed_environments.",
+                });
+            }
+        }
+
         // Validate uniqueness of git repo URLs
         var repos = dto.GitRepositories ?? [];
         var duplicateUrl = repos.GroupBy(r => r.Url, StringComparer.OrdinalIgnoreCase)
@@ -178,5 +221,11 @@ public record WorkspaceGitRepoDto(string Url, string? Branch = null, string? Cre
 // the X3 catalog (e.g. "headless-container"). Optional in the C# signature
 // so existing callers don't break at compile time, but the controller
 // validates it as required and returns 400 when omitted on Create.
-public record CreateWorkspaceDto(string Name, string? Description, Guid? OrganizationId, Guid? TeamId, string? GitRepositoryUrl, string? GitBranch, List<WorkspaceGitRepoDto>? GitRepositories = null, string? EnvironmentProfileCode = null);
+//
+// X9 (rivoli-ai/andy-containers#99): AgentId is optional — when set, the
+// controller calls IAgentCapabilityService and rejects the create with
+// 403 if the workspace's profile isn't in the agent's allowlist. Omit
+// to keep the workspace agent-agnostic (run-submit time becomes the
+// natural enforcement point in that case).
+public record CreateWorkspaceDto(string Name, string? Description, Guid? OrganizationId, Guid? TeamId, string? GitRepositoryUrl, string? GitBranch, List<WorkspaceGitRepoDto>? GitRepositories = null, string? EnvironmentProfileCode = null, string? AgentId = null);
 public record UpdateWorkspaceDto(string? Name, string? Description, string? GitBranch, List<WorkspaceGitRepoDto>? GitRepositories = null);

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -258,6 +258,13 @@ try
         builder.Configuration.GetSection(SecretsOptions.SectionName));
     builder.Services.AddSingleton<ITokenIssuer, StubTokenIssuer>();
 
+    // X9 (rivoli-ai/andy-containers#99). Stub allowlist resolver until
+    // andy-agents (Epic W3) ships GET /api/agents/{id}/allowed-environments.
+    // The stub returns null (= no policy) so workspace-create stays open
+    // for agents that haven't declared an allowlist; explicit policies
+    // get enforced by the controller once the real client lands here.
+    builder.Services.AddSingleton<IAgentCapabilityService, StubAgentCapabilityService>();
+
     // AP7 (rivoli-ai/andy-containers#109). In-process registry of active
     // runs so the cancel endpoint can signal the AP6 runner across
     // request scopes. Singleton — runner registrations span requests.

--- a/src/Andy.Containers.Api/Services/IAgentCapabilityService.cs
+++ b/src/Andy.Containers.Api/Services/IAgentCapabilityService.cs
@@ -1,0 +1,68 @@
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// X9 (rivoli-ai/andy-containers#99). Resolves an agent's
+/// <c>allowed_environments</c> declaration so the workspace-create
+/// surface can enforce that a workspace's bound EnvironmentProfile is
+/// permitted by the agent the workspace targets.
+/// </summary>
+/// <remarks>
+/// Today an in-process stub returns <c>null</c> ("no allowlist on
+/// record — allow all"); when andy-agents (Epic W3) ships
+/// <c>GET /api/agents/{id}/allowed-environments</c>, swap the
+/// implementation for the HTTP client without touching callers.
+///
+/// The contract is deliberately minimal: caller passes the agent id,
+/// gets the list of profile codes the agent permits, or null to
+/// signal "no policy on this agent". A 403 only fires when an
+/// agent has an explicit allowlist that doesn't include the
+/// workspace's profile — agents without a policy stay open.
+/// </remarks>
+public interface IAgentCapabilityService
+{
+    /// <summary>
+    /// Fetch the agent's allowed environment-profile codes.
+    /// </summary>
+    /// <returns>
+    /// Non-null = the explicit allowlist (case-insensitive match).
+    /// Null = no policy on record; treat as "all allowed".
+    /// </returns>
+    /// <exception cref="AgentCapabilityServiceUnavailableException">
+    /// Thrown when the upstream agents service is reachable-but-erroring
+    /// (5xx, transport failure). Callers fail-closed: the workspace-
+    /// create flow returns 503 rather than provisioning a workspace
+    /// against an unverifiable policy.
+    /// </exception>
+    Task<IReadOnlyList<string>?> GetAllowedEnvironmentsAsync(string agentId, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Raised when the agents service can't answer a capability query.
+/// Distinct from "agent has no allowlist" (null result) so the
+/// fail-closed branch is explicit at the caller.
+/// </summary>
+public sealed class AgentCapabilityServiceUnavailableException : Exception
+{
+    public AgentCapabilityServiceUnavailableException(string message)
+        : base(message)
+    {
+    }
+
+    public AgentCapabilityServiceUnavailableException(string message, Exception inner)
+        : base(message, inner)
+    {
+    }
+}
+
+/// <summary>
+/// X9 in-process stub. Always returns null (= no policy on record).
+/// Replace with the andy-agents HTTP client when W3 lands.
+/// </summary>
+public sealed class StubAgentCapabilityService : IAgentCapabilityService
+{
+    public Task<IReadOnlyList<string>?> GetAllowedEnvironmentsAsync(
+        string agentId, CancellationToken ct = default)
+    {
+        return Task.FromResult<IReadOnlyList<string>?>(null);
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Controllers/WorkspacesControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/WorkspacesControllerTests.cs
@@ -4,7 +4,10 @@ using Andy.Containers.Api.Tests.Helpers;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Models;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -14,6 +17,7 @@ public class WorkspacesControllerTests : IDisposable
 {
     private readonly ContainersDbContext _db;
     private readonly Mock<ICurrentUserService> _mockCurrentUser;
+    private readonly Mock<IAgentCapabilityService> _agentCapabilities;
     private readonly WorkspacesController _controller;
 
     public WorkspacesControllerTests()
@@ -26,7 +30,16 @@ public class WorkspacesControllerTests : IDisposable
         var mockOrgMembership = new Mock<IOrganizationMembershipService>();
         mockOrgMembership.Setup(o => o.IsMemberAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
         mockOrgMembership.Setup(o => o.HasPermissionAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
-        _controller = new WorkspacesController(_db, _mockCurrentUser.Object, mockOrgMembership.Object);
+        // X9 (#99): default to "no allowlist on record" so existing tests
+        // (which don't pass an AgentId) skip the enforcement branch.
+        _agentCapabilities = new Mock<IAgentCapabilityService>();
+        _agentCapabilities
+            .Setup(a => a.GetAllowedEnvironmentsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<string>?)null);
+        _controller = new WorkspacesController(
+            _db, _mockCurrentUser.Object, mockOrgMembership.Object,
+            _agentCapabilities.Object,
+            NullLogger<WorkspacesController>.Instance);
     }
 
     public void Dispose()
@@ -119,6 +132,136 @@ public class WorkspacesControllerTests : IDisposable
         var reloaded = await _db.Workspaces.FindAsync(ws.Id);
         reloaded!.EnvironmentProfileId.Should().Be(profile.Id,
             "Update has no profile field — re-binding requires workspace recreation");
+    }
+
+    // X9 (#99) -----------------------------------------------------------
+    // Agent allowed_environments enforcement. Workspaces that target a
+    // specific agent must respect that agent's policy; agents without a
+    // policy stay open. Service outage fails closed.
+
+    [Fact]
+    public async Task Create_AgentBound_ProfileInAllowlist_Returns201()
+    {
+        var profile = await SeedHeadlessProfile();
+        _agentCapabilities
+            .Setup(a => a.GetAllowedEnvironmentsAsync("triage", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { "headless-container", "terminal" });
+
+        var dto = new CreateWorkspaceDto(
+            "agent-allowed", null, null, null, null, null,
+            EnvironmentProfileCode: profile.Name,
+            AgentId: "triage");
+
+        var result = await _controller.Create(dto, CancellationToken.None);
+
+        result.Should().BeOfType<CreatedAtActionResult>();
+    }
+
+    [Fact]
+    public async Task Create_AgentBound_ProfileNotInAllowlist_Returns403()
+    {
+        var profile = await SeedHeadlessProfile();
+        _agentCapabilities
+            .Setup(a => a.GetAllowedEnvironmentsAsync("review-only", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { "terminal", "desktop" });
+
+        var dto = new CreateWorkspaceDto(
+            "agent-rejected", null, null, null, null, null,
+            EnvironmentProfileCode: profile.Name,
+            AgentId: "review-only");
+
+        var result = await _controller.Create(dto, CancellationToken.None);
+
+        var status = result.Should().BeOfType<ObjectResult>().Subject;
+        status.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        status.Value!.ToString().Should().Contain("headless-container")
+            .And.Contain("review-only",
+                "the 403 must name the profile and the agent so callers can self-correct");
+    }
+
+    [Fact]
+    public async Task Create_AgentBound_AllowlistMatchesCaseInsensitively()
+    {
+        // Agents may declare codes with different casing; the catalog
+        // is canonical lowercase, so the comparison must be tolerant.
+        var profile = await SeedHeadlessProfile();
+        _agentCapabilities
+            .Setup(a => a.GetAllowedEnvironmentsAsync("ci", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { "Headless-Container" });
+
+        var dto = new CreateWorkspaceDto(
+            "casey", null, null, null, null, null,
+            EnvironmentProfileCode: profile.Name,
+            AgentId: "ci");
+
+        var result = await _controller.Create(dto, CancellationToken.None);
+
+        result.Should().BeOfType<CreatedAtActionResult>();
+    }
+
+    [Fact]
+    public async Task Create_AgentBound_NullAllowlist_Returns201()
+    {
+        // Null = "no policy on record". Open by default until an
+        // agent declares an allowlist.
+        var profile = await SeedHeadlessProfile();
+        _agentCapabilities
+            .Setup(a => a.GetAllowedEnvironmentsAsync("freeform", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<string>?)null);
+
+        var dto = new CreateWorkspaceDto(
+            "freeform-ws", null, null, null, null, null,
+            EnvironmentProfileCode: profile.Name,
+            AgentId: "freeform");
+
+        var result = await _controller.Create(dto, CancellationToken.None);
+
+        result.Should().BeOfType<CreatedAtActionResult>();
+    }
+
+    [Fact]
+    public async Task Create_AgentBound_ServiceUnavailable_Returns503()
+    {
+        // Fail-closed: refuse to provision a workspace against an
+        // unverifiable policy rather than silently bypass enforcement.
+        var profile = await SeedHeadlessProfile();
+        _agentCapabilities
+            .Setup(a => a.GetAllowedEnvironmentsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new AgentCapabilityServiceUnavailableException(
+                "andy-agents 503"));
+
+        var dto = new CreateWorkspaceDto(
+            "outage", null, null, null, null, null,
+            EnvironmentProfileCode: profile.Name,
+            AgentId: "any");
+
+        var result = await _controller.Create(dto, CancellationToken.None);
+
+        var status = result.Should().BeOfType<ObjectResult>().Subject;
+        status.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        (await _db.Workspaces.AnyAsync()).Should().BeFalse(
+            "the service-down path must not produce a row that survived the failed check");
+    }
+
+    [Fact]
+    public async Task Create_NoAgentBound_SkipsEnforcementCallEntirely()
+    {
+        // The capability service never gets called when AgentId is null;
+        // pin that explicitly so a future refactor doesn't accidentally
+        // ask the agent service "does null have an allowlist?" on every
+        // workspace-create.
+        var profile = await SeedHeadlessProfile();
+
+        var dto = new CreateWorkspaceDto(
+            "no-agent", null, null, null, null, null,
+            EnvironmentProfileCode: profile.Name);
+
+        var result = await _controller.Create(dto, CancellationToken.None);
+
+        result.Should().BeOfType<CreatedAtActionResult>();
+        _agentCapabilities.Verify(
+            a => a.GetAllowedEnvironmentsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     private async Task<Andy.Containers.Models.EnvironmentProfile> SeedHeadlessProfile()

--- a/tests/Andy.Containers.Api.Tests/Data/EnvironmentProfileSeederProductionYamlTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Data/EnvironmentProfileSeederProductionYamlTests.cs
@@ -1,0 +1,105 @@
+using Andy.Containers.Api.Data;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Data;
+
+// X9 (rivoli-ai/andy-containers#99). Round-trip the actual production
+// YAML files (config/environments/global/*.yaml) through the real
+// seeder. The X2 tests use synthetic strings; nothing yet pins that
+// the files we ship parse cleanly. This class catches drift if
+// someone edits a profile file with an unparseable enum value or a
+// typo in the schema.
+public class EnvironmentProfileSeederProductionYamlTests : IDisposable
+{
+    private readonly ContainersDbContext _db;
+    private readonly Mock<IHostEnvironment> _env = new();
+
+    public EnvironmentProfileSeederProductionYamlTests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+        // Walk up from the test binary
+        // (tests/Andy.Containers.Api.Tests/bin/Debug/net8.0) until we
+        // find the worktree root that contains config/environments.
+        // The seeder's `ContentRootPath/config/environments/global`
+        // candidate hits when ContentRootPath is the worktree root.
+        // Bounded walk so a misconfigured CI checkout doesn't loop.
+        _env.Setup(e => e.ContentRootPath).Returns(FindWorktreeRoot());
+    }
+
+    private static string FindWorktreeRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            if (Directory.Exists(Path.Combine(dir, "config", "environments", "global")))
+            {
+                return dir;
+            }
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        throw new DirectoryNotFoundException(
+            $"Could not find config/environments/global walking up from {AppContext.BaseDirectory}");
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public void ProductionSeedDirectory_ResolvesFromTestBinary()
+    {
+        var dir = EnvironmentProfileSeeder.ResolveSeedDirectory(_env.Object);
+        dir.Should().NotBeNull(
+            "the seeder's path-walk must find config/environments/global from the test binary; " +
+            "if this fails, the search-paths logic drifted from the actual repo layout");
+        Directory.GetFiles(dir!, "*.yaml").Should().HaveCount(3,
+            "headless-container.yaml + terminal.yaml + desktop.yaml are the three seeded files");
+    }
+
+    [Fact]
+    public async Task SeedAsync_AgainstProductionFiles_LoadsThreeProfiles()
+    {
+        var changes = await EnvironmentProfileSeeder.SeedAsync(_db, _env.Object, NullLogger.Instance);
+
+        changes.Should().Be(3, "the three production YAML files must all parse cleanly");
+        var names = await _db.EnvironmentProfiles
+            .OrderBy(p => p.Name)
+            .Select(p => p.Name)
+            .ToListAsync();
+        names.Should().BeEquivalentTo(new[] { "desktop", "headless-container", "terminal" });
+    }
+
+    [Fact]
+    public async Task SeedAsync_AgainstProductionFiles_HeadlessHasStrictAuditAndRestrictedEgress()
+    {
+        await EnvironmentProfileSeeder.SeedAsync(_db, _env.Object, NullLogger.Instance);
+
+        var headless = await _db.EnvironmentProfiles.SingleAsync(p => p.Name == "headless-container");
+        headless.Kind.Should().Be(EnvironmentKind.HeadlessContainer);
+        headless.Capabilities.AuditMode.Should().Be(AuditMode.Strict,
+            "headless agents run unattended; full audit is the contract");
+        headless.Capabilities.HasGui.Should().BeFalse();
+        headless.Capabilities.SecretsScope.Should().Be(SecretsScope.WorkspaceScoped);
+        // The seeded file must restrict egress to platform services + canonical
+        // package mirrors. A wildcard would defeat the unattended-agent contract.
+        headless.Capabilities.NetworkAllowlist.Should().NotContain("*");
+        headless.Capabilities.NetworkAllowlist.Should().Contain("registry.rivoli.ai");
+    }
+
+    [Fact]
+    public async Task SeedAsync_AgainstProductionFiles_DesktopFlipsGuiOn()
+    {
+        await EnvironmentProfileSeeder.SeedAsync(_db, _env.Object, NullLogger.Instance);
+
+        var desktop = await _db.EnvironmentProfiles.SingleAsync(p => p.Name == "desktop");
+        desktop.Kind.Should().Be(EnvironmentKind.Desktop);
+        desktop.Capabilities.HasGui.Should().BeTrue(
+            "desktop is the only profile that ships a GUI; X4 keys VNC sidecar provisioning on this");
+    }
+}


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#99

## Summary

X9 is the umbrella testing story. X1-X8 already shipped 37 tests across seeder / controller / MCP / CLI surfaces; this PR fills the two genuine gaps:

### 1. Agent \`allowed_environments\` enforcement (deferred from X5)

- **\`IAgentCapabilityService\`** in \`Andy.Containers.Api.Services\`. Returns the allowlist or \`null\` (no policy on record).
- **\`StubAgentCapabilityService\`** is the in-process default — always returns null, so workspaces stay open until andy-agents (Epic W3) ships \`GET /api/agents/{id}/allowed-environments\`. Swap-in is one DI line.
- **\`AgentCapabilityServiceUnavailableException\`** distinguishes "service down" (fail-closed → 503) from "agent has no policy" (open → 201).
- **\`CreateWorkspaceDto.AgentId\`** is the new optional binding. \`WorkspacesController.Create\` resolves the allowlist when set:

| Allowlist state | Outcome |
|---|---|
| Profile in allowlist (case-insensitive) | **201** |
| Profile not in allowlist | **403** — message names both profile and agent |
| Service throws \`Unavailable\` | **503** — no row persisted |
| Allowlist is null (no policy) | **201** — open by default |
| \`AgentId\` omitted | Service never called; existing path |

### 2. Production-YAML round-trip tests

The X2 seeder tests use synthetic YAML; nothing pinned the actual three files in \`config/environments/global\`. The new \`EnvironmentProfileSeederProductionYamlTests\`:
- Path-walk resolves the prod dir from the test binary (catches drift if the search-paths logic regresses).
- All three files parse cleanly through the real seeder.
- Headless contract holds (\`AuditMode.Strict\`, \`HasGui = false\`, no wildcard egress).
- Desktop has \`HasGui = true\` (X4 keys VNC sidecar provisioning on this).

## What's deferred

The issue calls for a Pact / consumer-driven contract test for andy-agents. Out of scope: the upstream service doesn't exist, the tooling choice is undecided ("Clarifications needed" in the issue), and a stub interface gives the same deferred-implementation property without a Pact broker.

## Test plan

- [x] 6 new \`WorkspacesControllerTests\` agent-enforcement cases covering the table above.
- [x] 4 new \`EnvironmentProfileSeederProductionYamlTests\` cases.
- [x] All 12 pre-existing \`WorkspacesControllerTests\` still pass after the new \`IAgentCapabilityService\` constructor parameter.
- [x] Full unit suite: **1162 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)