### PR TITLE
X10: docs — Environment profiles design + ADR + README/nav (#100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Development container management platform for the Andy ecosystem.
 ## Features
 
 - **Container Lifecycle** - Create from templates, start/stop/destroy, live resize CPU/RAM
+- **Environment profiles** - Governance descriptors (`headless-container` / `terminal` / `desktop`) bound at workspace-create time. Drives base-image selection, VNC sidecar wiring, network allowlist, secrets scope, and audit mode (see [docs/environment-profiles.md](docs/environment-profiles.md))
 - **12 Templates** - Including 4 VNC desktop variants (dotnet-8-desktop, dotnet-8-alpine-desktop, dotnet-10-alpine-desktop, python-3.12-desktop)
 - **10 Code Assistants** - Claude Code, Aider, OpenCode, Codex CLI, Continue, Qwen Coder, Gemini Code, GitHub Copilot, Amazon Q, Cline with model/base URL configuration
 - **Web Terminal** - xterm.js + tmux session persistence, 18 themes with per-container persistence, WebGL rendering

--- a/docs/adr/0002-environment-profiles.md
+++ b/docs/adr/0002-environment-profiles.md
@@ -1,0 +1,76 @@
+# ADR 0002 — Environment profiles
+
+**Status.** Accepted. Implemented across stories X1–X9 (Epic X, andy-containers#88).
+
+## Context
+
+Until X1, the platform only had two governance handles per container:
+
+1. The `ContainerTemplate` — a provisioning recipe (base image, dependencies, GUI mode, post-create scripts).
+2. Ad-hoc per-environment env vars / network policies, configured at the provider layer.
+
+This conflated **what to provision** with **what the environment is permitted to do**. A "headless triage container" and a "developer terminal session" that happened to share the same base image had no way to differ in:
+
+- network egress allowlist,
+- secrets scope (run-scoped tokens vs. workspace-wide),
+- audit-trail intensity,
+- whether a GUI sidecar was attached.
+
+The simulator's `app.js` already enumerated three runtime shapes — `headless-container`, `terminal`, `desktop` — that downstream services (Conductor, andy-issues, andy-tasks) needed to reason about. Encoding those shapes only as templates left the governance contract implicit.
+
+## Decision
+
+Introduce **`EnvironmentProfile`** as a first-class entity sitting **above** `ContainerTemplate` in the resolution order:
+
+- A profile carries the runtime shape (`HeadlessContainer | Terminal | Desktop`), the base image, and a structured capability envelope (`NetworkAllowlist`, `SecretsScope`, `HasGui`, `AuditMode`).
+- Workspaces bind a profile at create time; containers created in the workspace inherit it.
+- When a profile is bound, its `BaseImageRef` and `Kind` override the template's image and GUI fields. The template still drives resources, scripts, and dependencies — only the image and sidecar surface flip.
+- Three baseline profiles ship as YAML seeds in `config/environments/global/*.yaml`, loaded idempotently at startup. Operator hand-edits via the catalog API survive restarts.
+- Agent capability declarations (`allowed_environments`, owned by andy-agents Epic W3) gate workspace-create: a workspace bound to a profile not in the agent's allowlist is rejected with 403.
+
+## Alternatives considered
+
+### Extend `ContainerTemplate` with capability fields
+
+Rejected. Templates are recipes — version-pinned, dependency-aware, often forked. Mixing governance fields would mean every template revision becomes a governance change, every governance update needs a template rev, and operators editing audit policy would be reaching into a "how to build the image" file. Profiles let the two evolve independently.
+
+### Per-workspace capability ACLs
+
+Rejected. Workspaces would each need a hand-curated capability set, with no sharing across workspaces of the same shape. Doesn't compose with the agent catalog (agents declare which *kinds* they allow, not which *workspaces*). Also can't be governed centrally — every workspace owner becomes a security policy author.
+
+### A single boolean flag (`isHeadless`) on `Workspace`
+
+Rejected. Couldn't express the desktop / terminal distinction or the audit and secrets dimensions. Would have leaked into 9 provider implementations as branching logic instead of one orchestration-layer decision.
+
+## Consequences
+
+### Positive
+
+- **Provider-agnostic.** All 9 infrastructure providers inherit headless / desktop / terminal behaviour for free — sidecar wiring lives in `ContainerOrchestrationService` + the `ContainerProvisioningWorker`, not the providers (X4).
+- **Governance is explicit.** The capability envelope on the wire (X3 DTO, X8 OpenAPI) lets MCP clients / CLIs / Conductor reason about what an environment is permitted to do without parsing template internals.
+- **Run-scoped tokens couple cleanly.** AP10's `ITokenIssuer` revokes on terminal events when `SecretsScope == RunScoped`; broader scopes don't get auto-revoked. The enum on the profile drives the lifecycle.
+- **Idempotent seeds.** The YAML pipeline catches drift at startup (round-trip tested in X9) without requiring per-environment migrations.
+
+### Negative
+
+- **Cross-service dependency.** Workspace-create now queries andy-agents (Epic W3) for `allowed_environments`. The current implementation is a stub returning null (open by default); a real allowlist requires W3 to ship. A capability-service outage fails closed (503) rather than provisioning against an unverifiable policy.
+- **Double-resolution at create time.** Both the template and the profile must exist before provisioning. Misconfiguration surfaces as a 400 (unknown profile code) rather than a 500.
+- **Conductor governance UI (Epic AF) depends on the catalog endpoint.** The shape of `EnvironmentProfile` and `EnvironmentCapabilities` is a public contract that AF will pin; field drift requires a coordinated change across the two repos.
+
+## Cross-references
+
+- **X1 — entity + EF migration:** `src/Andy.Containers/Models/EnvironmentProfile.cs`, `Migrations/AddEnvironmentProfiles`.
+- **X2 — YAML seeder:** `src/Andy.Containers.Api/Data/EnvironmentProfileSeeder.cs`, `config/environments/global/*.yaml`.
+- **X3 — catalog endpoint:** `src/Andy.Containers.Api/Controllers/EnvironmentsController.cs`.
+- **X4 — provisioning override:** `src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs` (profile-driven image + GuiType).
+- **X5 — workspace binding:** `src/Andy.Containers.Api/Controllers/WorkspacesController.cs` (`EnvironmentProfileCode` required at create time).
+- **X6 — MCP tool:** `src/Andy.Containers.Api/Mcp/EnvironmentsMcpTools.cs`.
+- **X7 — CLI:** `src/Andy.Containers.Cli/Commands/EnvironmentCommands.cs`.
+- **X8 — OpenAPI + lint:** `openapi/containers-api.yaml`, `.github/workflows/openapi.yml`.
+- **X9 — agent enforcement + production-YAML round-trip tests:** `IAgentCapabilityService`, `EnvironmentProfileSeederProductionYamlTests`.
+- **AP10 — secrets scope wiring:** `src/Andy.Containers/Configurator/ITokenIssuer.cs` (couples to `SecretsScope.RunScoped`).
+- **W3 (andy-agents) — allowed_environments:** awaits cross-service contract; `IAgentCapabilityService` is the swap-in seam.
+
+## Footnote
+
+The three profile codes (`headless-container`, `terminal`, `desktop`) come from the simulator's `app.js`, the canonical reference for naming during the simulator-parity wave (Epic AP, Epic X, Epic Y).

--- a/docs/environment-profiles.md
+++ b/docs/environment-profiles.md
@@ -1,0 +1,126 @@
+# Environment profiles
+
+`EnvironmentProfile` is the governance descriptor that sits **above** `ContainerTemplate` in the resolution order. A template says **what to provision**; a profile says **what the environment is permitted to do**.
+
+The architectural decision is recorded in [ADR 0002](adr/0002-environment-profiles.md). This page is the operator + developer reference: the entity shape, the capability matrix for the seeded profiles, the provisioning flow, and how to extend the catalog.
+
+## Entity shape
+
+| Field | Type | Notes |
+|---|---|---|
+| `Id` | `Guid` | Primary key. |
+| `Name` (a.k.a. `code`) | `string`, unique | Stable slug across renames (e.g. `headless-container`). |
+| `DisplayName` | `string` | Human-readable label. |
+| `Kind` | `enum` | `HeadlessContainer | Terminal | Desktop`. Drives the GUI sidecar at provision time. |
+| `BaseImageRef` | `string` | OCI reference; overrides `template.BaseImage` when bound. |
+| `Capabilities` | `EnvironmentCapabilities` | Structured envelope, owned-as-JSON in EF (one column on Postgres `jsonb`, TEXT on SQLite). |
+| `CreatedAt` | `DateTimeOffset` | Audit. |
+
+`EnvironmentCapabilities` carries:
+
+| Field | Type | Notes |
+|---|---|---|
+| `NetworkAllowlist` | `List<string>` | Hostnames or wildcards (`*.github.com`); empty list = no egress. |
+| `SecretsScope` | `enum` | `None | RunScoped | WorkspaceScoped | OrganizationScoped`. Couples to AP10's token lifecycle. |
+| `HasGui` | `bool` | True only for `Desktop`. Drives VNC sidecar wiring (port 6080, `/start.sh` entrypoint). |
+| `AuditMode` | `enum` | `None | Standard | Strict`. `Strict` captures every tool call pre-redaction. |
+
+## Capability matrix (seeded profiles)
+
+The three baseline profiles live in `config/environments/global/*.yaml` and are loaded idempotently at API startup:
+
+| Code | Kind | GUI | Secrets scope | Audit | Network |
+|---|---|---|---|---|---|
+| `headless-container` | `HeadlessContainer` | no | `WorkspaceScoped` | `Strict` | restricted (registry, GitHub API, pypi, nuget) |
+| `terminal` | `Terminal` | no | `WorkspaceScoped` | `Standard` | wildcard (`*`) |
+| `desktop` | `Desktop` | yes | `OrganizationScoped` | `Standard` | wildcard (`*`) |
+
+Rationale per profile:
+
+- **`headless-container`** — unattended agents (triage, planning, execution). Strict audit because no human is in the loop. Restricted egress because anything beyond platform services + canonical package mirrors is suspicious for an unattended run.
+- **`terminal`** — TTY attach where a human drives the agent. Wildcard egress because interactive sessions routinely reach docs, registries, third-party APIs. Standard audit since the human is the primary control.
+- **`desktop`** — full GUI session via VNC. Long-lived, often spans multiple runs, so `OrganizationScoped` (≈ SSO-scoped) credentials beat run-scoped ones.
+
+## Provisioning flow
+
+```
+workspace-create  →  resolve EnvironmentProfile.Code (X5)
+                   ↳ optional agent-allowed-environments check (X9)
+                   ↳ persist Workspace.EnvironmentProfileId
+
+container-create  →  EnvironmentProfileId from request
+                   ↳ fall back to Workspace.EnvironmentProfileId (X5 inheritance)
+                   ↳ profile.BaseImageRef wins over template.BaseImage    (X4)
+                   ↳ profile.Kind drives GuiType (Desktop → "vnc"; else "none")  (X4)
+                   ↳ ContainerProvisionJob carries the resolved values
+                   ↳ provider creates the container; worker maps ports / cmd
+                                                          (sidecars are the worker's
+                                                           concern, not the provider's)
+
+run-time          →  AP10 mints a run-scoped token when the agent's profile
+                   has SecretsScope = RunScoped. Token is revoked on every
+                   terminal event (Succeeded / Failed / Cancelled / Timeout).
+```
+
+Two key invariants:
+
+1. **Profile-as-source-of-truth.** When a profile is bound, `template.BaseImage` and `template.GuiType` are ignored. The template still drives resources / scripts / dependencies.
+2. **Workspace inheritance, not pin.** Containers in a workspace inherit the workspace's profile. An explicit `request.EnvironmentProfileId` still wins — one-off shells into a different env are intentional.
+
+## Extending the catalog
+
+Add a YAML file under `config/environments/global/` and restart the API.
+
+```yaml
+code: my-profile
+display_name: My profile
+kind: HeadlessContainer
+base_image_ref: ghcr.io/example/my-headless:latest
+
+capabilities:
+  network_allowlist:
+    - api.example.com
+  secrets_scope: WorkspaceScoped
+  has_gui: false
+  audit_mode: Strict
+```
+
+**Rules.**
+
+- Field names use `snake_case` in YAML; the seeder maps to `PascalCase` properties via `UnderscoredNamingConvention`.
+- `kind` / `secrets_scope` / `audit_mode` must match the enum names exactly (case-insensitive).
+- The seeder is idempotent on `code`. Existing rows are never overwritten — operator hand-edits via the catalog API survive restarts. To force a refresh, delete the row in the catalog and restart.
+- Malformed files are logged and skipped; the host never aborts startup on a bad seed entry.
+
+`config/environments/README.md` carries the colocated schema reference for operators editing seeds.
+
+## Surfaces
+
+The catalog is exposed via three transports, all gated on the `environment:read` permission (granted to Admin / Editor / Viewer in `Andy.Containers.Models.OrgRoles`):
+
+- **HTTP** — `GET /api/environments`, `GET /api/environments/{id}`, `GET /api/environments/by-code/{code}`. Pagination envelope `{items, totalCount}`. See [API reference](api-reference.md) and the OpenAPI spec at `openapi/containers-api.yaml`.
+- **MCP** — `environment.list` tool exposed by `EnvironmentsMcpTools`. Auto-discovered via `WithToolsFromAssembly()`; consumers (Conductor, Claude Code, agent runtimes) can introspect the catalog without an HTTP round-trip.
+- **CLI** — `andy-containers-cli environments list [--kind <Kind>] [--format table|json]` and `andy-containers-cli environments get <code>`. Shared `--format` flag is part of the Epic AN per-service CLI contract.
+
+## Relationship to `ContainerTemplate`
+
+Both exist; both are required to provision. They answer different questions:
+
+| Concern | ContainerTemplate | EnvironmentProfile |
+|---|---|---|
+| Base image | yes (default) | yes (overrides template when bound) |
+| Resources (CPU/RAM/disk) | yes | no |
+| Post-create scripts / dependencies | yes | no |
+| GUI sidecar (VNC) | yes (legacy) | yes (drives flip when bound) |
+| Network allowlist | no | yes |
+| Secrets scope | no | yes |
+| Audit mode | no | yes |
+| Mutable by operators via API | yes (CRUD) | read-only today (X3); CRUD lands when an operator UI requires it |
+
+Templates evolve with toolchain versions; profiles evolve with governance policy. Decoupling them means a template revision isn't a security review and an audit-policy change isn't a rebuild.
+
+## Cross-service contract
+
+When an agent declares `allowed_environments` (Epic W3 in `andy-agents`), `WorkspacesController.Create` enforces it: a workspace bound to a profile not in the agent's allowlist is rejected with 403. Today the resolver is a stub (`StubAgentCapabilityService` returns null = no policy on record). Once the W3 endpoint ships, swap the DI registration in `Program.cs` for an HTTP client; `IAgentCapabilityService` is the seam.
+
+A capability-service outage fails closed (503) rather than provisioning against an unverifiable policy. See ADR 0002 for the rationale.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,11 @@ nav:
     - CLI Reference: cli-reference.md
   - API:
     - REST Endpoints: api-reference.md
+  - Concepts:
+    - Environment profiles: environment-profiles.md
+  - ADRs:
+    - ADR 0001 — Messaging: adr/0001-messaging.md
+    - ADR 0002 — Environment profiles: adr/0002-environment-profiles.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#100

Wraps **Epic X** with three docs deliverables. No code changes.

## Summary

### \`docs/adr/0002-environment-profiles.md\`

The architectural record. Captures:
- **Context**: governance gap above \`ContainerTemplate\` — runtime shape, network allowlist, secrets scope, audit mode, GUI all conflated into provisioning recipes before X1.
- **Decision**: first-class \`EnvironmentProfile\` entity above templates; profile-as-source-of-truth at provision time; YAML-seeded; agent-allowlist-gated.
- **Alternatives considered**: extending \`ContainerTemplate\`, per-workspace ACLs, single \`isHeadless\` bool — each rejected with reasoning.
- **Consequences**: provider-agnostic win (all 9 providers free), W3 cross-service dependency, Conductor-AF coupling. Cross-references every X1-X9 file by path.

### \`docs/environment-profiles.md\`

The developer + operator reference. Entity shape table, capability matrix for the three seeded profiles with per-row rationale, ASCII provisioning-flow diagram (workspace-create → profile resolution → agent allowlist → X4 override → AP10 token lifecycle), how-to for adding a YAML seed, surface inventory (HTTP / MCP / CLI), template-vs-profile responsibility split table.

### \`README.md\` + \`mkdocs.yml\`

- Features bullet for environment profiles linking the design doc.
- Two new nav sections: **Concepts** (design doc) and **ADRs** (both 0001 and 0002).

## Verification

\`\`\`
$ mkdocs build --strict
INFO -  Documentation built in 0.82 seconds
$ echo \$?
0
\`\`\`

The only nav-orphan warning is pre-existing \`presentation.md\`, unrelated to X10.

## Epic status

With X10 merged, **Epic X (rivoli-ai/andy-containers#88) is fully closed**:

- X1 entity + EF migration (#163)
- X2 YAML seed pipeline (#171)
- X3 catalog endpoint (#172)
- X4 provisioning override (#173)
- X5 workspace binding + container inheritance (#174)
- X6 MCP \`environment.list\` tool (#175)
- X7 CLI \`environments {list,get}\` (#176)
- X8 OpenAPI schema + Spectral lint CI (#177)
- X9 agent allowed_environments enforcement + production-YAML round-trip tests (#178)
- X10 docs ← this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)