### PR TITLE
AP13: docs — Agent runs concept + run configurator + ADR + nav (#116)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Development container management platform for the Andy ecosystem.
 ## Features
 
 - **Container Lifecycle** - Create from templates, start/stop/destroy, live resize CPU/RAM
+- **Agent runs** - First-class `Run` entity with state-machine, NDJSON event stream, run-scoped tokens revoked on terminal events, and matching HTTP / MCP / CLI surfaces (`POST /api/runs`, `run.create`, `andy-containers-cli runs`). See [docs/runs.md](docs/runs.md)
 - **Environment profiles** - Governance descriptors (`headless-container` / `terminal` / `desktop`) bound at workspace-create time. Drives base-image selection, VNC sidecar wiring, network allowlist, secrets scope, and audit mode (see [docs/environment-profiles.md](docs/environment-profiles.md))
 - **12 Templates** - Including 4 VNC desktop variants (dotnet-8-desktop, dotnet-8-alpine-desktop, dotnet-10-alpine-desktop, python-3.12-desktop)
 - **10 Code Assistants** - Claude Code, Aider, OpenCode, Codex CLI, Continue, Qwen Coder, Gemini Code, GitHub Copilot, Amazon Q, Cline with model/base URL configuration

--- a/docs/adr/0003-agent-run-execution.md
+++ b/docs/adr/0003-agent-run-execution.md
@@ -1,0 +1,105 @@
+# ADR 0003 — Agent run execution
+
+**Status.** Accepted. Implemented across stories AP1-AP12 (Epic AP, andy-containers#101).
+
+## Context
+
+Before Epic AP, andy-containers handled containers as opaque runtime hosts: the API created them, exposed exec / terminal / VNC, and emitted lifecycle events (`run.{containerId}.finished` and friends), but had no opinion on what executed inside them. Agents were a Conductor concern; the andy-containers controller didn't know whether a container was running a triage prompt, a test suite, or nothing at all.
+
+The simulator-parity wave (Epics AP / X / Y) makes the agent run a **first-class entity** the platform tracks end-to-end:
+
+- Conductor asks andy-containers to start a run via `POST /api/runs`.
+- The run is observable (`GET /api/runs/{id}`), cancellable (`POST /api/runs/{id}/cancel`), and its lifecycle streams to subscribers via NATS subjects keyed on `Run.Id`.
+- Subjects, payloads, and state-machine transitions are stable enough for downstream services (andy-issues, andy-tasks, audit) to subscribe without negotiating semantics out-of-band.
+
+That requires answering three questions:
+
+1. **What runs inside the container?** A specific binary with a specific config contract — not "whatever the agent author wrote".
+2. **Who decides what gets run, where, and how?** A central piece in andy-containers that maps `RunMode` to the right execution surface.
+3. **How do we observe and cancel cleanly?** Without a registry of in-flight processes, the cancel endpoint can only flip a database flag and hope.
+
+## Decision
+
+**`andy-cli` is the in-container agent runtime.** Every `Headless` run spawns
+
+```
+andy-cli run --headless --config <path-to-headless-run-config.json>
+```
+
+inside the run's container. `andy-cli` reads the config, executes the agent, emits structured events on stdout, and exits with a defined code (the AQ2 contract). andy-containers parses the exit code to derive the terminal `RunStatus` + `RunEventKind`, writes both to the DB and the outbox in the same transaction, and revokes the run-scoped token (AP10).
+
+**`IRunModeDispatcher` is the routing seam.** `RunsController.Create` doesn't know about runner internals. It hands off to a single `IRunModeDispatcher` that:
+
+- selects or provisions a container,
+- transitions `Pending` → `Provisioning`,
+- routes to the right execution surface based on `Run.Mode`:
+  - `Headless` → `IHeadlessRunner` (spawn andy-cli, await exit, terminate).
+  - `Terminal` → return `Attachable` (caller binds a TTY via `/api/containers/{id}/terminal`).
+  - `Desktop` → not yet implemented; explicit `NotImplemented` outcome rather than a dead branch.
+
+**`IRunCancellationRegistry` is the cancel seam.** Each active runner registers a linked CTS at spawn and disposes the registration on terminal write. The cancel endpoint signals via the registry and awaits the runner's terminal write up to a 30 s grace before forcing the row to `Cancelled`. No registry entry → flip the row directly (Pending row, no in-flight process).
+
+## Alternatives considered
+
+### Run agents directly via `docker exec` from the controller thread
+
+Rejected. Conflates "what to run" (agent prompt + tools) with "how to run it" (exec syntax, stdout parsing, exit-code mapping). Every agent author would re-derive the contract; every regression in andy-containers would require touching agent code and vice versa. `andy-cli` decouples them: the contract between andy-containers and the agent is a JSON config schema (AQ1) plus an exit-code table (AQ2), not a shell command.
+
+### Push agents into background workers; synchronous controller is just persistence
+
+Tempting but premature. AP1-AP9 land the synchronous path because:
+- It keeps the wire shape stable for early consumers.
+- It surfaces every state-machine transition in one stack trace, which made AP6/AP7 wiring much easier to test.
+- The 201 response carrying the terminal state turned out to be a useful UX signal for the CLI / MCP clients.
+
+The follow-up to move dispatch off the request thread is intentional, but doing it on day one would have made the AP1-AP9 sequence much harder to bisect.
+
+### A single `IRunService` instead of separate runner / dispatcher / registry
+
+Rejected. The three concerns have different lifetimes and DI scopes:
+
+- `IHeadlessRunner` is **scoped** — one per request — because it consumes a `DbContext`.
+- `IRunCancellationRegistry` is **singleton** — runner registrations span request scopes (the runner is alive in request A, the cancel POST arrives on request B).
+- `IRunModeDispatcher` is **scoped** — same reason as the runner.
+
+Collapsing them would force one of the three into the wrong scope and silently break the cancel signalling.
+
+### Use the existing `andy.containers.events.run.{containerId}.*` subjects for AP runs
+
+Rejected — the subject must key on `Run.Id`, not `Container.Id`. A container can host multiple runs (sequential or — once per-container concurrency lands — parallel); subscribers need to correlate to the specific run. AP6 introduced `AppendAgentRunEvent` keyed on `Run.Id` while leaving the container-lifecycle helper (`AppendRunEvent`) keyed on `Container.Id`. Same outbox table, different correlation.
+
+## Consequences
+
+### Positive
+
+- **Stable contract surface.** `CreateRunRequest`, `Run` (response), and the four NATS subjects are pinned by AP11's OpenAPI spec. AQ1 (config schema) + AQ2 (exit codes) pin the andy-cli boundary. Any of these breaking is a contract change with a coordinated cross-repo PR, not a surprise.
+- **Provider-agnostic execution.** `IHeadlessRunner` only needs `IContainerService.ExecAsync` and `IContainerService.GetContainerAsync`; all 9 infrastructure providers (Docker / Apple / AWS / Azure / GCP / Civo / DigitalOcean / Fly.io / Hetzner) inherit the AP runtime for free.
+- **Cancellation works across request scopes.** `IRunCancellationRegistry` is the in-process replacement for what would otherwise need a NATS control channel; we can swap it for distributed signalling (e.g. cancel commands published to a per-runner subject) without touching callers.
+- **Run-scoped credentials revoke automatically.** AP10's `ITokenIssuer.RevokeAsync` runs in `HeadlessRunner.TerminateAsync`'s `finally`-equivalent so every terminal observation (Succeeded / Failed / Cancelled / Timeout) frees the token. The `SecretsScope.RunScoped` enum on the bound `EnvironmentProfile` (Epic X) drives this lifecycle.
+
+### Negative
+
+- **andy-cli is a hard dependency.** A container that ships without `andy-cli` on `$PATH` cannot host a Headless run; provisioning succeeds but the runner exits non-zero. Mitigated by the `EnvironmentProfile.BaseImageRef` contract (X4): the image bound to a `HeadlessContainer` profile is expected to ship andy-cli. Future work: pre-flight check before spawn.
+- **Synchronous dispatch limits throughput.** A long-running headless agent ties up the request thread until exit. The 201 with terminal state is the most visible symptom. Moving dispatch off the request thread is a follow-up; the seam is `IRunModeDispatcher.DispatchAsync`'s return shape, which already supports an async `Started` outcome.
+- **In-process cancel registry doesn't survive a restart.** A run that's mid-flight when andy-containers restarts has no registry entry on the new process; cancelling falls through to "flip the row". Acceptable today (single-node deployments); an HA story would need to persist active-runner state.
+
+## Cross-references
+
+- **AP1 — Run entity + state machine:** `src/Andy.Containers/Models/Run.cs`.
+- **AP2 — `/api/runs` controller:** `src/Andy.Containers.Api/Controllers/RunsController.cs`.
+- **AP3 — configurator:** `src/Andy.Containers/Configurator/RunConfigurator.cs`. Spec → config mapping in `docs/run-configurator.md`.
+- **AP4 — config builder:** `src/Andy.Containers/Configurator/HeadlessConfigBuilder.cs` (golden-file tests in AP12).
+- **AP5 — mode dispatcher:** `src/Andy.Containers.Api/Services/RunModeDispatcher.cs`.
+- **AP6 — headless runner:** `src/Andy.Containers.Api/Services/HeadlessRunner.cs`.
+- **AP7 — cancel registry:** `src/Andy.Containers.Api/Services/IRunCancellationRegistry.cs`.
+- **AP8 — MCP tools:** `src/Andy.Containers.Api/Mcp/RunsMcpTools.cs`.
+- **AP9 — CLI + NDJSON event stream:** `src/Andy.Containers.Cli/Commands/RunCommands.cs`, `src/Andy.Containers.Api/Services/RunEventStream.cs`.
+- **AP10 — secrets scope:** `src/Andy.Containers/Configurator/ITokenIssuer.cs`.
+- **AP11 — OpenAPI:** `openapi/containers-api.yaml` (`/api/runs*` paths and schemas).
+- **AP12 — golden-file conformance:** `tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigBuilderGoldenFileTests.cs`.
+- **AQ1 (andy-cli) — headless config schema:** see the `andy-cli` repo for the JSON schema andy-containers writes against.
+- **AQ2 (andy-cli) — exit-code contract:** see the `andy-cli` repo for the canonical `HeadlessExitCode` enum.
+
+## Footnote
+
+The mode names (`Headless` / `Terminal` / `Desktop`) align with the `EnvironmentProfile.Kind` enum from Epic X. A `HeadlessContainer` profile only backs `RunMode.Headless` runs; the pairing is enforced by the AP5 dispatcher and validated at workspace-create time via the X5 binding.

--- a/docs/run-configurator.md
+++ b/docs/run-configurator.md
@@ -1,0 +1,151 @@
+# Run configurator: spec → config mapping
+
+The **run configurator** turns an `AgentSpec` (resolved from andy-agents Epic W) plus a `Run` (the AP1 entity) into a `HeadlessRunConfig` written to disk for `andy-cli` to consume. It's the join point between the platform's idea of a run (state machine, lifecycle events, governance) and the agent runtime's idea of a run (instructions, model, tools, limits, output sink).
+
+This page documents the field-by-field mapping. The contract is locked: the JSON shape must match AQ1 (the schema in the `andy-cli` repo) byte-for-byte; AP12's golden-file tests catch drift the moment a property is renamed, retyped, or added.
+
+## Pipeline
+
+```
+RunsController.Create
+   │
+   │  CreateRunRequest → Run row (Pending)
+   ▼
+IRunConfigurator.ConfigureAsync(run, ct)
+   │
+   ├── IAndyAgentsClient.GetAgentAsync(run.AgentId, run.AgentRevision)   →  AgentSpec
+   │
+   ├── ITokenIssuer.MintAsync(run.Id)                                    →  RunToken
+   │   (idempotent — configurator may retry without orphan tokens)
+   │
+   ├── MergeRunSecrets(spec.EnvVars, token, secrets)                     →  AgentSpec'
+   │   (ANDY_TOKEN / ANDY_PROXY_URL / ANDY_MCP_URL injected here;
+   │    agent's own EnvVars win on collision)
+   │
+   ├── IHeadlessConfigBuilder.Build(run, spec')                          →  HeadlessRunConfig
+   │   (validates AQ1 closures: provider enum, transport oneOf,
+   │    required-string non-empty, run id non-empty)
+   │
+   └── IHeadlessConfigWriter.WriteAsync(config)                          →  on-disk path
+       (atomic write, returns the path AP6 spawns andy-cli against)
+```
+
+A failure at any stage returns a structured `RunConfiguratorResult.Fail(reason)` rather than throwing — the controller logs the reason and leaves the row Pending so a future retry can succeed. AP6 inspects `Run.ContainerId` at spawn time; a row with no container short-circuits to `Failed`.
+
+## Field mapping
+
+The builder lives in `src/Andy.Containers/Configurator/HeadlessConfigBuilder.cs`. The mapping below is exhaustive; AP12 fixtures exercise every combination of optional fields.
+
+### Run-level fields (`HeadlessRunConfig`)
+
+| Output field | Source | Notes |
+|---|---|---|
+| `schema_version` | constant `1` | Bump in lockstep with AQ1's schema. |
+| `run_id` | `Run.Id` | Must be non-empty (`ArgumentException` otherwise). |
+| `policy_id` | `Run.PolicyId` | Optional. Null when no policy bound. |
+
+### Agent block (`HeadlessAgent`)
+
+| Output field | Source | Notes |
+|---|---|---|
+| `agent.slug` | `AgentSpec.Slug` | Required. |
+| `agent.revision` | `AgentSpec.Revision` | Optional pin; null = head. |
+| `agent.instructions` | `AgentSpec.Instructions` | Required, min length 1 — empty throws. |
+| `agent.output_format` | `AgentSpec.OutputFormat` | Optional. Hint to the agent for structured output (e.g. `json-triage-output-v1`). |
+
+### Model block (`HeadlessModel`)
+
+| Output field | Source | Notes |
+|---|---|---|
+| `model.provider` | `AgentSpec.Model.Provider` | Required, must be in `{anthropic, openai, google, cerebras, local}`. Unknown throws. |
+| `model.id` | `AgentSpec.Model.Id` | Required, non-empty. |
+| `model.api_key_ref` | `AgentSpec.Model.ApiKeyRef` | Optional. Format: `env:NAME` or `secret:provider/path`. Elided when null (per AQ1 schema). |
+
+### Tools (`HeadlessTool[]`)
+
+Each `AgentSpecTool` maps to one entry, discriminated by `Transport`:
+
+- **MCP** — `transport: "mcp"`, `endpoint: <url>`. Endpoint required; missing throws.
+- **CLI** — `transport: "cli"`, `binary: <path>`, `command: <string[] | null>`. Binary required; missing throws. Command elided when empty.
+
+Unknown transports (anything other than `"mcp"` or `"cli"`) throw at the builder layer — the schema enforces the same `oneOf` shape.
+
+### Workspace (`HeadlessWorkspace`)
+
+| Output field | Source | Notes |
+|---|---|---|
+| `workspace.root` | constant `"/workspace"` | Container-side mount point. |
+| `workspace.branch` | `Run.WorkspaceRef.Branch` | Optional; flows from the workspace ref the caller specified at submit time. |
+
+### Output (`HeadlessOutput`)
+
+| Output field | Source | Notes |
+|---|---|---|
+| `output.file` | constant `"/workspace/.andy-run/output.json"` | Path andy-cli atomically writes the agent's structured response to. Read by Conductor / consumers. |
+| `output.stream` | constant `"stdout"` | Where structured events are emitted (parsed by AP6). |
+
+### Event sink (`HeadlessEventSink`)
+
+| Output field | Source | Notes |
+|---|---|---|
+| `event_sink.nats_subject` | `andy.containers.events.run.{Run.Id}.progress` | Where AQ3 (the andy-cli runtime) pushes structured progress events. AP6's terminal subjects (`finished` / `failed` / `cancelled` / `timeout`) sit on the same prefix. |
+
+### Boundaries (`string[] | null`)
+
+`AgentSpec.Boundaries` round-trips when present, elided when empty/null. Format is policy-engine-defined (`branch:feature/*`, `fs:/workspace/**`, `read-only`, etc.); the configurator does not interpret values.
+
+### EnvVars (`Dictionary<string,string> | null`)
+
+Three layers compose the final dictionary in `RunConfigurator.MergeRunSecrets`:
+
+1. **Platform-injected (AP10):**
+    - `ANDY_TOKEN` from `ITokenIssuer.MintAsync(run.Id)`.
+    - `ANDY_PROXY_URL` from `Secrets:ProxyUrl` in appsettings (skipped when null/empty).
+    - `ANDY_MCP_URL` from `Secrets:McpUrl` (skipped when null/empty).
+2. **Agent-supplied (`AgentSpec.EnvVars`):** merged on top.
+3. **Collision rule:** the agent's value wins. An agent author who pins `ANDY_TOKEN` for a test fixture is not silently overridden by the platform — the collision is intentional, not the platform's call to break.
+
+The merged dictionary becomes `HeadlessRunConfig.EnvVars`. Empty maps elide to null per AQ1's "absent vs. null" handling.
+
+### Limits (`HeadlessLimits`)
+
+| Output field | Source | Default |
+|---|---|---|
+| `limits.max_iterations` | `AgentSpec.Limits.MaxIterations` | 100 |
+| `limits.timeout_seconds` | `AgentSpec.Limits.TimeoutSeconds` | 900 |
+
+`timeout_seconds` couples to AP6's outer watchdog: `ExecAsync` is given `timeout_seconds + 30 s` as its ceiling, so the AQ3 internal timeout (exit code 4) fires first and we observe a `Timeout` outcome rather than a watchdog-killed `Failed`.
+
+## Validation closures
+
+The builder enforces these up-front so AP6 never has to load-and-reject a config it just wrote:
+
+| Closure | Throws when |
+|---|---|
+| `Run.Id` non-empty | `Run.Id == Guid.Empty` |
+| `agent.instructions` non-empty | null / whitespace |
+| `model.provider` in allowlist | unknown provider |
+| `model.id` non-empty | null / whitespace |
+| MCP tool has `endpoint` | null / whitespace |
+| CLI tool has `binary` | null / whitespace |
+| Tool transport in `{"mcp", "cli"}` | unknown transport |
+
+All throw `ArgumentException` with a message naming the offending field. `RunConfigurator.ConfigureAsync` catches and converts to `RunConfiguratorResult.Fail`.
+
+## Snapshot conformance
+
+`tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigBuilderGoldenFileTests.cs` (AP12) builds the config for three representative agent types — `triage`, `plan`, `execute` — and compares the serialised JSON byte-for-byte against fixtures under `tests/.../Configurator/__snapshots__/`. Each fixture exercises a different combination of optional fields:
+
+- **triage** — full suite (api_key_ref, boundaries, mcp + cli tools).
+- **plan** — null api_key_ref + null boundaries (elision path).
+- **execute** — env_vars + multiple mcp tools + cli tool with binary.
+
+When a snapshot diff fails, treat it as a contract change: inspect the diff, decide whether the change is intentional, and update both the fixture and the AQ1 schema in lockstep.
+
+## Cross-references
+
+- **AP3** — `IRunConfigurator` / `RunConfigurator`.
+- **AP4** — `IHeadlessConfigBuilder` / `HeadlessConfigBuilder` (validation closures).
+- **AP10** — `ITokenIssuer` / `SecretsOptions` / `EnvVarNames` (platform env-var injection).
+- **AP12** — `HeadlessConfigBuilderGoldenFileTests` (golden-file snapshots).
+- **AQ1 (andy-cli)** — JSON schema source of truth in the andy-cli repo.

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -1,0 +1,167 @@
+# Agent runs
+
+A **run** is the execution of an agent against a delegation contract inside a provisioned container. Conductor (or an MCP/CLI client) submits a run; andy-containers persists it, configures andy-cli, dispatches it to the right execution surface, observes its lifecycle, and emits NATS events so downstream services (andy-issues, andy-tasks, audit) can react.
+
+The architectural decision is recorded in [ADR 0003](adr/0003-agent-run-execution.md). The configurator's spec → config mapping lives in [run-configurator.md](run-configurator.md). This page is the operator + integrator concept reference: the lifecycle, the surfaces, the event contract, and how to drive the system from each entry point.
+
+## Lifecycle
+
+```
+        Pending ──┐
+                  ├──> Provisioning ──> Running ──> Succeeded
+                  │                                  ─> Failed
+                  │                                  ─> Cancelled
+                  │                                  ─> Timeout
+                  └─────────────────> Cancelled / Failed (pre-spawn)
+```
+
+| Status | Meaning |
+|---|---|
+| `Pending` | Row persisted; AP5 dispatcher hasn't picked it up yet. |
+| `Provisioning` | AP5 has selected/created a container; AP6 is about to spawn andy-cli. |
+| `Running` | andy-cli is in flight. |
+| `Succeeded` | Exit code 0. |
+| `Failed` | Exit code 1, 2, 5, or unmapped non-zero. |
+| `Cancelled` | Exit code 3, OR an external cancel signal observed before exit. |
+| `Timeout` | Exit code 4 (AQ3 self-timeout) OR ExecAsync's outer watchdog fired. |
+
+The four terminal states are mutually exclusive and one-way: `Run.TransitionTo` rejects backward edges and disallowed sideways moves at the entity layer.
+
+## Submitting a run
+
+Three transports, identical wire shape:
+
+### HTTP (Conductor + everything else)
+
+```
+POST /api/runs
+Content-Type: application/json
+
+{
+  "agentId": "triage-agent",
+  "agentRevision": 3,
+  "mode": "Headless",
+  "environmentProfileId": "1f0e2d3c-4b5a-4c6d-9e8f-7a6b5c4d3e2f",
+  "workspaceRef": { "workspaceId": "...", "branch": "main" },
+  "policyId": null,
+  "correlationId": null
+}
+```
+
+Returns 201 with the [`Run`](https://github.com/rivoli-ai/andy-containers/blob/main/openapi/containers-api.yaml) response body. Today the response can already carry a terminal status because AP5's dispatcher is synchronous (a follow-up moves it off the request thread).
+
+### MCP
+
+```
+run.create  ({ agentId, mode, environmentProfileId, workspaceId?, branch?, policyId?, correlationId? })
+```
+
+Discoverable via `WithToolsFromAssembly()` in `Program.cs`. Permission-gated on `run:write`.
+
+### CLI
+
+```
+andy-containers-cli runs create triage-agent \
+  --mode Headless \
+  --environment-profile 1f0e2d3c-4b5a-4c6d-9e8f-7a6b5c4d3e2f \
+  --workspace ... --branch main
+```
+
+`runs get`, `runs cancel`, and `runs events` are the matching observers / mutators.
+
+## Modes
+
+| Mode | Surface | What runs in the container |
+|---|---|---|
+| `Headless` | `IHeadlessRunner` spawns `andy-cli run --headless --config <path>`. | `andy-cli` reads the AQ1 config, executes the agent, exits with an AQ2 code. andy-containers maps the code to a `RunStatus` + writes a terminal event. |
+| `Terminal` | Caller binds a TTY via `/api/containers/{id}/terminal`. AP5 returns `Attachable`. | Operator-driven; andy-containers exposes the exec surface but doesn't drive the agent. |
+| `Desktop` | Not implemented. AP5 returns `NotImplemented`. | Routing reserved for VNC-attached agents (Epic AF). |
+
+Modes pair with `EnvironmentProfile.Kind` via Epic X. A `HeadlessContainer` profile only backs `RunMode.Headless` runs; the pairing is enforced at workspace-create time (X5).
+
+## Cancellation
+
+```
+POST /api/runs/{id}/cancel
+```
+
+Behaviour depends on whether a runner is in flight:
+
+- **Active runner** — controller signals via `IRunCancellationRegistry`. The runner's `ExecAsync` aborts (linked CTS), its catch-OCE branch transitions the run to `Cancelled`, appends `andy.containers.events.run.{id}.cancelled` to the outbox, saves, and disposes its registration. The cancel endpoint awaits that disposal up to **30 s** before returning.
+- **No active runner** (Pending row, server restart, runner already exited) — controller flips the row directly and emits the cancelled event.
+
+Either way, exactly one terminal subject lands in the outbox. The 30 s grace is for hung Docker exec streams that don't honour the linked CTS; the runner's catch-OCE path normally resolves in <100 ms.
+
+`POST /api/runs/{id}/cancel` returns:
+- **200** with the run DTO (state reflects committed terminal write).
+- **404** if the run is unknown.
+- **409** if the run is already terminal.
+
+## Event stream
+
+Every terminal observation appends a row to the `OutboxEntries` table in the same EF transaction as the state-machine transition. The `OutboxDispatcher` background service drains pending rows to NATS at-least-once (per ADR 0001). Subjects:
+
+```
+andy.containers.events.run.{runId}.finished
+andy.containers.events.run.{runId}.failed
+andy.containers.events.run.{runId}.cancelled
+andy.containers.events.run.{runId}.timeout
+```
+
+Payload (`RunEventPayload`):
+
+```json
+{
+  "run_id":           "<uuid>",
+  "story_id":         "<uuid|null>",
+  "status":           "Succeeded|Failed|Cancelled|Timeout",
+  "exit_code":        12,
+  "duration_seconds": 2.5
+}
+```
+
+For HTTP / MCP / CLI consumers that want a per-run filtered view of the same stream:
+
+- **HTTP**: `GET /api/runs/{id}/events` returns NDJSON (one `RunEvent` per line, flushed). Closes when the run hits terminal (with a final drain pass).
+- **MCP**: `run.events` tool — `IAsyncEnumerable<RunEventDto>`, identical semantics.
+- **CLI**: `andy-containers-cli runs events <id>` colour-codes each line.
+
+The shared implementation lives in `RunEventStream.AsyncEnumerate` so all three surfaces have one polling loop and one terminal-stop policy.
+
+## Permissions
+
+| Scope | Granted to | Used by |
+|---|---|---|
+| `run:write` | Admin, Editor | `POST /api/runs`, `run.create`, `runs create` |
+| `run:read` | Admin, Editor, Viewer | `GET /api/runs/{id}`, `GET /api/runs/{id}/events`, `run.get`, `run.events`, `runs get`, `runs events` |
+| `run:execute` | Admin, Editor | `POST /api/runs/{id}/cancel`, `run.cancel`, `runs cancel` |
+
+Catalog source of truth: `src/Andy.Containers/Models/Permissions.cs` (AP8 added the run scopes).
+
+## Run-scoped credentials
+
+When the bound profile carries `SecretsScope.RunScoped`, AP10's `ITokenIssuer` mints a token at config time and injects three env vars into the agent's environment via the AQ1 config:
+
+- `ANDY_TOKEN` — bearer token, run-scoped.
+- `ANDY_PROXY_URL` — egress mediator (`Secrets:ProxyUrl` in appsettings).
+- `ANDY_MCP_URL` — platform MCP server (`Secrets:McpUrl`).
+
+The token is revoked on every terminal observation (Succeeded / Failed / Cancelled / Timeout) — the post-condition "no live run-scoped token after a run is terminal" holds regardless of exit path.
+
+## Failure modes
+
+| Symptom | Likely cause | Where to look |
+|---|---|---|
+| 201 with `Status: Pending` and never advances | Configurator failed; row persisted but AP5 didn't dispatch. | Application logs at `RunConfigurator: ...`. |
+| 201 with `Status: Failed` and `error: "Run {id} has no ContainerId"` | AP5 dispatcher couldn't select/provision a container. | Workspace's `DefaultContainer` exists? Profile compatible with workspace? |
+| Cancel returns 200 but the row stays `Running` | Runner ignored the linked CTS for >30 s; controller forced the transition. | `RunsController` log: "cancel grace expired before runner terminal write". |
+| Stream closes immediately with no events | Run was already terminal when the stream opened. The `RunEventStream` final-drain pass yielded everything in one tick then closed. | This is correct behaviour, not a bug. |
+| Stream returns 404 | Run id is unknown. | `GET /api/runs/{id}` — does the row exist? |
+
+## Cross-references
+
+- **ADR 0003** — [Agent run execution](adr/0003-agent-run-execution.md).
+- **Configurator** — [Spec → config mapping](run-configurator.md).
+- **EnvironmentProfile catalog** — [environment-profiles.md](environment-profiles.md).
+- **OpenAPI** — `openapi/containers-api.yaml` (`/api/runs*` paths and schemas).
+- **Cross-service flow** — Epic AO (rivoli-ai/conductor#669) covers the conductor → andy-containers → andy-issues round-trip.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,9 +45,12 @@ nav:
     - REST Endpoints: api-reference.md
   - Concepts:
     - Environment profiles: environment-profiles.md
+    - Agent runs: runs.md
+    - Run configurator: run-configurator.md
   - ADRs:
     - ADR 0001 — Messaging: adr/0001-messaging.md
     - ADR 0002 — Environment profiles: adr/0002-environment-profiles.md
+    - ADR 0003 — Agent run execution: adr/0003-agent-run-execution.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#116

Wraps **Epic AP** with three docs deliverables. No code changes.

## Summary

### \`docs/adr/0003-agent-run-execution.md\`

The architectural record. Captures:

- **Context** — containers were opaque runtime hosts; agents were a Conductor concern. Simulator-parity needs runs as first-class entities the platform tracks end-to-end.
- **Decision** — \`andy-cli\` as the in-container runtime, \`IRunModeDispatcher\` as the routing seam, \`IRunCancellationRegistry\` as the cancel seam.
- **Alternatives considered** — direct \`docker exec\`, background-only dispatch, single \`IRunService\`, container-keyed subjects. Each rejected with reasoning.
- **Consequences** — stable contract surface (AQ1 + AQ2 + AP11), provider-agnostic execution (all 9 providers free), automatic run-scoped token revocation. Offset by hard andy-cli dep, synchronous-dispatch throughput limit, in-process registry not HA-safe.

Cross-references every AP1-AP12 file by path.

### \`docs/runs.md\`

The operator + integrator concept reference. Lifecycle ASCII diagram + status table, three submission transports (HTTP / MCP / CLI), mode table coupled to \`EnvironmentProfile.Kind\`, cancel semantics with the 30 s grace explained, event-stream subjects + payload + per-run filtered views, permissions matrix, run-scoped credentials wiring (AP10), failure-mode triage table.

### \`docs/run-configurator.md\`

The spec → config mapping reference. Pipeline diagram (configurator → builder → writer), **exhaustive per-field mapping** for \`HeadlessRunConfig\` (run-level, agent block, model block, tools, workspace, output, event sink, boundaries, env vars layered-injection, limits coupled to AP6 watchdog grace), validation-closures table, snapshot-conformance pointer to AP12 fixtures.

### \`README.md\` + \`mkdocs.yml\`

- Features bullet for "Agent runs" linking the concept doc.
- Two new "Concepts" entries (runs + configurator) and one "ADRs" entry (0003).

## Verification

\`\`\`
$ mkdocs build --strict
INFO -  Documentation built in 1.04 seconds
$ echo \$?
0
\`\`\`

## Epic status

With AP13 merged, **Epic AP (rivoli-ai/andy-containers#101) is fully closed**:

- AP1 entity (#159 / earlier)
- AP2 controller
- AP3 configurator
- AP4 config builder
- AP5 mode dispatcher (#165)
- AP6 headless runner (#161)
- AP7 cancel path (#167)
- AP8 MCP tools (#168)
- AP9 CLI runs (#169)
- AP10 secrets scope (#170)
- AP11 OpenAPI (#180)
- AP12 golden-file tests (#181)
- AP13 docs ← this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)