### PR TITLE
[HIGH] Redact userinfo from base-URL log line (#131)

### DIFF
--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -379,7 +379,11 @@ public class ContainerOrchestrationService : IContainerService
                 {
                     var baseUrlEnv = codeAssistant.ApiBaseUrlEnvVar ?? "OPENAI_API_BASE";
                     envVars[baseUrlEnv] = baseUrl;
-                    _logger.LogInformation("Injecting base URL {Url} as {EnvVar}", baseUrl, baseUrlEnv);
+                    // rivoli-ai/andy-containers#131: redact userinfo before
+                    // emitting. Logs ship to OTLP / shared sinks; embedded
+                    // user:token in a proxy URL is exfiltration-by-default.
+                    _logger.LogInformation("Injecting base URL {Url} as {EnvVar}",
+                        UrlRedactor.Redact(baseUrl), baseUrlEnv);
                 }
 
                 // Inject model name from credential (code assistant config overrides credential)

--- a/src/Andy.Containers.Api/Services/UrlRedactor.cs
+++ b/src/Andy.Containers.Api/Services/UrlRedactor.cs
@@ -1,0 +1,70 @@
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// Sanitises URLs before they hit log sinks. The platform's
+/// observability stack ships logs to OTLP and shared infrastructure;
+/// any structured argument that ends up in the message body is at risk
+/// of cross-tenant leakage if it embeds credentials.
+/// </summary>
+/// <remarks>
+/// Code-assistant config routinely supplies OpenAI-compatible proxy
+/// URLs of the form <c>https://user:token@proxy.example.com/v1</c>;
+/// the userinfo portion is the credential. Redaction preserves the
+/// scheme, host, port, path, and query (so log readers can still
+/// identify the upstream service) and replaces only the userinfo with
+/// <c>user:***</c> or <c>***</c>. Malformed inputs round-trip a fixed
+/// <c>&lt;invalid-url&gt;</c> token rather than the raw string so a
+/// pasted credential without a scheme still doesn't reach the sink.
+/// </remarks>
+public static class UrlRedactor
+{
+    private const string MalformedToken = "<invalid-url>";
+    private const string RedactionPlaceholder = "***";
+
+    /// <summary>
+    /// Return <paramref name="url"/> with any userinfo component
+    /// redacted. Null / empty / whitespace inputs round-trip
+    /// unchanged so callers don't have to pre-check.
+    /// </summary>
+    public static string Redact(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return url ?? string.Empty;
+
+        // Use UriBuilder rather than parsing userinfo by hand: it
+        // handles ports, IPv6 hosts, and percent-encoded bytes that a
+        // regex would mishandle. Prefer absolute parse so a relative
+        // path doesn't masquerade as a URL with credentials.
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var parsed))
+        {
+            return MalformedToken;
+        }
+
+        if (string.IsNullOrEmpty(parsed.UserInfo))
+        {
+            // Nothing to redact — return the original string rather
+            // than the round-tripped one so the log line preserves the
+            // caller's exact spelling (trailing slashes, casing, etc).
+            return url;
+        }
+
+        var builder = new UriBuilder(parsed);
+
+        // Format depends on whether a password component was present:
+        // user:token@ → user:***@   (preserve the user identifier)
+        // bareuser@   → ***@        (the "user" alone may be a token)
+        if (string.IsNullOrEmpty(builder.Password))
+        {
+            builder.UserName = RedactionPlaceholder;
+        }
+        else
+        {
+            builder.Password = RedactionPlaceholder;
+        }
+
+        // UriBuilder.Uri.ToString() round-trips with default port
+        // elision and percent-encoding normalisation. Acceptable for a
+        // log line — the redacted URL is for human / scraper
+        // identification, not for re-fetching.
+        return builder.Uri.ToString();
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Services/UrlRedactorTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/UrlRedactorTests.cs
@@ -1,0 +1,91 @@
+using Andy.Containers.Api.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+// rivoli-ai/andy-containers#131. The redactor sits in the hot path for
+// every code-assistant injection log line; it must redact reliably,
+// preserve enough of the URL for log readers to identify the upstream,
+// and never crash on malformed input. These tests pin those three
+// contracts.
+public class UrlRedactorTests
+{
+    [Fact]
+    public void Redact_UserAndPassword_MasksPasswordOnly()
+    {
+        var redacted = UrlRedactor.Redact("https://alice:s3cret@proxy.example.com/v1");
+
+        redacted.Should().Contain("alice", "the user identifier is not the credential here");
+        redacted.Should().NotContain("s3cret");
+        redacted.Should().Contain("***");
+        redacted.Should().Contain("proxy.example.com/v1",
+            "log readers still need to identify the upstream service");
+    }
+
+    [Fact]
+    public void Redact_BareToken_MasksUser()
+    {
+        // Many OpenAI-compatible proxies pass the token alone in the
+        // user position (no colon, no password). The "user" string is
+        // the credential in that case.
+        var redacted = UrlRedactor.Redact("https://sk-proj-abc123@proxy.example.com/v1");
+
+        redacted.Should().NotContain("sk-proj-abc123");
+        redacted.Should().Contain("***@proxy.example.com");
+    }
+
+    [Fact]
+    public void Redact_NoUserInfo_ReturnsUnchanged()
+    {
+        const string clean = "https://api.openai.com/v1";
+
+        UrlRedactor.Redact(clean).Should().Be(clean);
+    }
+
+    [Fact]
+    public void Redact_PortAndPathPreserved()
+    {
+        var redacted = UrlRedactor.Redact("https://u:p@proxy.example.com:8443/v1/chat/completions?stream=true");
+
+        redacted.Should().Contain("proxy.example.com:8443");
+        redacted.Should().Contain("/v1/chat/completions");
+        redacted.Should().Contain("stream=true");
+        redacted.Should().NotContain(":p@");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Redact_NullOrEmptyOrBlank_RoundTrips(string? input)
+    {
+        UrlRedactor.Redact(input).Should().Be(input ?? string.Empty,
+            "callers expect to feed any code-assistant config straight through without pre-checks");
+    }
+
+    [Fact]
+    public void Redact_MalformedInput_ReturnsPlaceholder()
+    {
+        // A pasted credential that's not a URL at all — e.g. the
+        // operator misconfigured ApiBaseUrl. Better to log a
+        // placeholder than the raw bytes that may themselves be a
+        // secret.
+        var redacted = UrlRedactor.Redact("sk-proj-abc123");
+
+        redacted.Should().Be("<invalid-url>");
+        redacted.Should().NotContain("sk-proj-abc123");
+    }
+
+    [Fact]
+    public void Redact_Ipv6HostPreserved()
+    {
+        // IPv6 brackets are a common parser-trip in hand-rolled
+        // redactors. UriBuilder handles them correctly; pin that
+        // explicitly.
+        var redacted = UrlRedactor.Redact("https://u:p@[::1]:8080/v1");
+
+        redacted.Should().Contain("[::1]:8080");
+        redacted.Should().NotContain(":p@");
+    }
+}


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#131

## Finding

\`ContainerOrchestrationService.cs:382\` logged the resolved code-assistant base URL with userinfo intact:

\`\`\`csharp
_logger.LogInformation("Injecting base URL {Url} as {EnvVar}", baseUrl, baseUrlEnv);
\`\`\`

OpenAI-compatible proxies routinely use \`https://user:token@...\` or bare-token URLs, and the platform's logs ship to OTLP / shared sinks — embedding credentials in a structured log argument is exfiltration by default.

## Fix

New \`UrlRedactor\` helper — small, focused, defensive:

- Preserves scheme / host / port / path / query (log readers can still identify the upstream).
- Masks the password component when both user + password are present (the user is often a non-secret identifier — e.g. \`alice:s3cret\` becomes \`alice:***\`).
- Masks the user component when no password is present (the lone "user" string is often the credential — \`sk-proj-...@\` becomes \`***@\`).
- Round-trips null / empty / whitespace so callers don't pre-check.
- Returns a fixed \`<invalid-url>\` token for non-URL input rather than the raw bytes (a pasted secret without a scheme is still a secret).
- Handles IPv6 hosts (brackets) + ports correctly via \`UriBuilder\` rather than hand-rolled parsing.

The single log call wraps \`baseUrl\` in \`UrlRedactor.Redact()\` before emitting. \`envVars[baseUrlEnv]\` still receives the **raw** URL — the agent process needs to dial it; only the log line is sanitised.

## Test plan

- [x] 9 \`UrlRedactorTests\` cases: user+password, bare token, no userinfo, port + path + query preservation, null/empty/whitespace round-trip Theory, malformed input → placeholder, IPv6 host preservation.
- [x] Full Api.Tests suite: **827 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)