### PR TITLE
[HIGH] Remove default Postgres password from compose + appsettings (#129)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Andy Containers — environment variables
+#
+# Copy this file to `.env` (which is gitignored) and fill in real
+# values before running `docker compose up`.
+#
+# rivoli-ai/andy-containers#129: there is no default Postgres
+# password — compose fails fast when POSTGRES_PASSWORD is unset.
+
+# Postgres credentials. Used by both the postgres service (for
+# initdb) and the api service's connection string. Must be a strong
+# value in any non-throwaway deployment; generate with:
+#   openssl rand -base64 32
+POSTGRES_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -51,8 +51,17 @@ Development container management platform for the Andy ecosystem.
 ```bash
 git clone https://github.com/rivoli-ai/andy-containers.git
 cd andy-containers
+cp .env.example .env
+# Edit .env: set POSTGRES_PASSWORD to a strong value
+# (e.g. `openssl rand -base64 32`).
 docker compose up --build
 ```
+
+> **POSTGRES_PASSWORD has no default.** Compose fails fast if the variable
+> isn't set in the environment or `.env` — see [`.env.example`](.env.example).
+> This is intentional ([rivoli-ai/andy-containers#129](https://github.com/rivoli-ai/andy-containers/issues/129)) — shipping a known
+> default is exactly the kind of credential that gets missed during deploy
+> rotation.
 
 This starts all services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,14 @@ services:
   postgres:
     image: postgres:16-alpine
     container_name: andy-containers-db
+    # rivoli-ai/andy-containers#129. POSTGRES_PASSWORD must be supplied
+    # via the operator's environment (or .env file alongside this
+    # compose file) — there is no default. Compose fails fast with
+    # the error message below when unset, which beats inheriting a
+    # known password into a deployment.
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the environment or a .env file (see .env.example).}
       POSTGRES_DB: andy_containers
     ports:
       - "7434:5432"
@@ -44,7 +49,7 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=https://+:8443;http://+:8080
-      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=andy_containers;Username=postgres;Password=postgres
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=andy_containers;Username=postgres;Password=${POSTGRES_PASSWORD}
       - AndyAuth__Authority=https://host.docker.internal:5001
       - AndyAuth__Audience=urn:andy-containers-api
       - AndyAuth__RequireHttpsMetadata=false

--- a/src/Andy.Containers.Api/appsettings.json
+++ b/src/Andy.Containers.Api/appsettings.json
@@ -1,6 +1,7 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5434;Database=andy_containers;Username=postgres;Password=postgres"
+    "_comment": "rivoli-ai/andy-containers#129. Password is intentionally blank — the previous shipped default ('postgres') is exactly the kind of low-friction credential that gets missed during deploy rotation. Override via ConnectionStrings__DefaultConnection (env var) for hosted/Docker, or via appsettings.Development.json for local `dotnet run`. See .env.example.",
+    "DefaultConnection": "Host=localhost;Port=5434;Database=andy_containers;Username=postgres;Password="
   },
   "Database": {
     "_comment": "PostgreSQL is the hosted/Docker default. Conductor's embedded launcher overrides this with Database__Provider=Sqlite via environment variables.",


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#129

## Finding

\`docker-compose.yml\` and \`src/Andy.Containers.Api/appsettings.json\` ship \`Password=postgres\` as the default — exactly the kind of low-friction credential that gets missed during deploy rotation. Identified in the 2026-04-21 platform security audit (Conductor #800).

## Fix

- **\`docker-compose.yml\`** — \`POSTGRES_PASSWORD\` now uses \`\${POSTGRES_PASSWORD:?...}\` with a descriptive error message. Compose fails fast when the variable isn't set. The api service's \`ConnectionStrings__DefaultConnection\` passes the same value through. **No literal password remains.**
- **\`appsettings.json\`** — Password component blanked. Operators override via \`ConnectionStrings__DefaultConnection\` env var (hosted / Docker) or via \`appsettings.Development.json\` for local \`dotnet run\`. A blank password fails the connection rather than silently inheriting an insecure default.
- **\`.env.example\`** — new file documenting the required vars with a strong-value hint (\`openssl rand -base64 32\`). \`.gitignore\` already excludes \`.env*\` with \`.env.example\` as the explicit exception.
- **\`README.md\`** — Docker Compose quickstart starts with \`cp .env.example .env\` and an admonition explaining the no-default policy.

\`appsettings.Development.json\` keeps its dev convenience password — it only loads under \`ASPNETCORE_ENVIRONMENT=Development\`, conventionally local-only, and the compose deployment overrides it via env vars anyway.

## Local verification

\`\`\`
$ unset POSTGRES_PASSWORD && docker compose config
error while interpolating services.postgres.environment.POSTGRES_PASSWORD:
  required variable POSTGRES_PASSWORD is missing a value:
  POSTGRES_PASSWORD must be set in the environment or a .env file
  (see .env.example).

$ POSTGRES_PASSWORD=test123 docker compose config | grep Password
ConnectionStrings__DefaultConnection: ...Password=test123
POSTGRES_PASSWORD: test123
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)