### PR TITLE
[HIGH] AppleContainerProvider: argv-list everywhere (#127)

### DIFF
--- a/src/Andy.Containers.Infrastructure/Providers/Apple/AppleContainerProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Apple/AppleContainerProvider.cs
@@ -74,15 +74,18 @@ public class AppleContainerProvider : IInfrastructureProvider
 
         var name = spec.Name.ToLowerInvariant().Replace(' ', '-');
 
-        // Remove any existing container with the same name (may be left over from a previous run)
+        // Remove any existing container with the same name (may be left over
+        // from a previous run). #127: pass the name as an argv element so a
+        // template-supplied container name with spaces can't tokenise into
+        // extra CLI flags.
         try
         {
-            var inspect = await RunCliAsync($"inspect {name}", ct, TimeSpan.FromSeconds(5));
+            var inspect = await RunCliWithArgsAsync(["inspect", name], ct, TimeSpan.FromSeconds(5));
             if (inspect.ExitCode == 0)
             {
                 _logger.LogInformation("Removing existing Apple Container {Name} before re-creation", name);
-                await RunCliAsync($"stop {name}", ct, TimeSpan.FromSeconds(15));
-                await RunCliAsync($"delete {name}", ct, TimeSpan.FromSeconds(15));
+                await RunCliWithArgsAsync(["stop", name], ct, TimeSpan.FromSeconds(15));
+                await RunCliWithArgsAsync(["delete", name], ct, TimeSpan.FromSeconds(15));
             }
         }
         catch (Exception ex)
@@ -90,55 +93,18 @@ public class AppleContainerProvider : IInfrastructureProvider
             _logger.LogWarning(ex, "Failed to check/remove existing Apple Container {Name}", name);
         }
 
-        // Use `container run -d` which creates AND starts in one step.
-        var args = $"run --name {name}";
+        // rivoli-ai/andy-containers#127. The previous implementation built the
+        // entire `container run ...` line as a single arguments string. A
+        // template's BaseImage with a space (`my-image --rm`), an env value
+        // with whitespace, or a Command with embedded flags split into extra
+        // CLI tokens at .NET's Win32-style parser, escalating template:write
+        // into CLI-flag smuggling. BuildCreateContainerArgs returns a
+        // string[] passed straight to ProcessStartInfo.ArgumentList — the OS
+        // never sees a shell or a tokeniser for these values.
+        var runArgs = BuildCreateContainerArgs(spec, name);
 
-        if (spec.Resources is not null)
-        {
-            if (spec.Resources.CpuCores > 0)
-                args += $" -c {spec.Resources.CpuCores}";
-            if (spec.Resources.MemoryMb > 0)
-                args += $" -m {spec.Resources.MemoryMb}M";
-        }
-
-        // Pass env vars at creation time so secrets reach `container exec` without
-        // being persisted to world-readable files inside the container.
-        // ProcessStartInfo.Arguments is parsed by .NET (Win32-style: pairs of double
-        // quotes, no shell interpretation). API key values in practice contain no
-        // whitespace or quotes; reject anything that would tokenize incorrectly so
-        // we never silently truncate a secret. Tighter quoting arrives with #127.
-        if (spec.EnvironmentVariables is { Count: > 0 })
-        {
-            foreach (var (key, value) in spec.EnvironmentVariables)
-            {
-                var v = value ?? string.Empty;
-                if (v.Any(c => char.IsWhiteSpace(c) || c == '"' || c == '\''))
-                {
-                    _logger.LogWarning(
-                        "Skipping env var {Key} for Apple Container {Name}: value contains whitespace or quote",
-                        key, name);
-                    continue;
-                }
-                args += $" -e {key}={v}";
-            }
-        }
-
-        args += $" -d {spec.ImageReference}";
-
-        // Add command if specified, otherwise default to sleep infinity to keep the container alive
-        if (!string.IsNullOrEmpty(spec.Command))
-        {
-            args += $" {spec.Command}";
-            if (spec.Arguments is not null)
-                args += " " + string.Join(" ", spec.Arguments);
-        }
-        else
-        {
-            args += " sleep infinity";
-        }
-
-        _logger.LogInformation("Running: {CliPath} {Args}", _cliPath, args);
-        var result = await RunCliAsync(args, ct, TimeSpan.FromMinutes(5));
+        _logger.LogInformation("Running: {CliPath} {ArgCount} args", _cliPath, runArgs.Length);
+        var result = await RunCliWithArgsAsync(runArgs, ct, TimeSpan.FromMinutes(5));
         if (result.ExitCode != 0)
             throw new InvalidOperationException($"Failed to run Apple Container: {result.StdErr}");
 
@@ -157,14 +123,14 @@ public class AppleContainerProvider : IInfrastructureProvider
 
     public async Task StartContainerAsync(string externalId, CancellationToken ct)
     {
-        var result = await RunCliAsync($"start {externalId}", ct, TimeSpan.FromSeconds(30));
+        var result = await RunCliWithArgsAsync(["start", externalId], ct, TimeSpan.FromSeconds(30));
         if (result.ExitCode != 0)
             throw new InvalidOperationException($"Failed to start: {result.StdErr}");
     }
 
     public async Task StopContainerAsync(string externalId, CancellationToken ct)
     {
-        var result = await RunCliAsync($"stop {externalId}", ct, TimeSpan.FromSeconds(15));
+        var result = await RunCliWithArgsAsync(["stop", externalId], ct, TimeSpan.FromSeconds(15));
         if (result.ExitCode != 0)
             throw new InvalidOperationException($"Failed to stop: {result.StdErr}");
     }
@@ -172,9 +138,9 @@ public class AppleContainerProvider : IInfrastructureProvider
     public async Task DestroyContainerAsync(string externalId, CancellationToken ct)
     {
         // Stop first (ignore errors — may already be stopped)
-        await RunCliAsync($"stop {externalId}", ct, TimeSpan.FromSeconds(15));
+        await RunCliWithArgsAsync(["stop", externalId], ct, TimeSpan.FromSeconds(15));
 
-        var result = await RunCliAsync($"delete {externalId}", ct, TimeSpan.FromSeconds(15));
+        var result = await RunCliWithArgsAsync(["delete", externalId], ct, TimeSpan.FromSeconds(15));
         if (result.ExitCode != 0)
             throw new InvalidOperationException($"Failed to delete: {result.StdErr}");
     }
@@ -296,7 +262,7 @@ public class AppleContainerProvider : IInfrastructureProvider
 
     private async Task<InspectInfo> InspectAsync(string externalId, CancellationToken ct)
     {
-        var result = await RunCliAsync($"inspect {externalId}", ct, TimeSpan.FromSeconds(10));
+        var result = await RunCliWithArgsAsync(["inspect", externalId], ct, TimeSpan.FromSeconds(10));
         if (result.ExitCode != 0 || string.IsNullOrWhiteSpace(result.StdOut))
             return new InspectInfo { Status = "unknown" };
 
@@ -333,6 +299,79 @@ public class AppleContainerProvider : IInfrastructureProvider
             _logger.LogWarning(ex, "Failed to parse inspect output for {Id}", externalId);
             return new InspectInfo { Status = "unknown" };
         }
+    }
+
+    /// <summary>
+    /// Build the argv list for <c>container run -d ...</c>. Pure function
+    /// (static + no I/O) so the construction can be unit-tested without
+    /// the Apple CLI being installed on the test runner. The returned
+    /// array is fed straight to <see cref="ProcessStartInfo.ArgumentList"/>;
+    /// each element becomes one argv slot, never tokenised by a shell or
+    /// .NET's Win32 parser.
+    /// </summary>
+    /// <remarks>
+    /// rivoli-ai/andy-containers#127. Order matters here: positional
+    /// values (image ref, command, command args) must appear in the
+    /// run-time positions Apple's CLI expects, but every interpolated
+    /// value goes through unescaped. A template with
+    /// <c>BaseImage = "evil --rm"</c> would have split into two argv
+    /// elements under the previous string-based path; here it stays
+    /// as a single (unrecognised, error-out-cleanly) argv slot.
+    /// </remarks>
+    internal static string[] BuildCreateContainerArgs(ContainerSpec spec, string name)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        var args = new List<string> { "run", "--name", name };
+
+        if (spec.Resources is not null)
+        {
+            if (spec.Resources.CpuCores > 0)
+            {
+                args.Add("-c");
+                args.Add(spec.Resources.CpuCores.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+            if (spec.Resources.MemoryMb > 0)
+            {
+                args.Add("-m");
+                args.Add($"{spec.Resources.MemoryMb}M");
+            }
+        }
+
+        // Env vars pass as separate `-e KEY=VALUE` argv slots. Whitespace
+        // and quote characters in the value are now safe — the previous
+        // skip-with-warning workaround is gone with the string-build path.
+        if (spec.EnvironmentVariables is { Count: > 0 })
+        {
+            foreach (var (key, value) in spec.EnvironmentVariables)
+            {
+                args.Add("-e");
+                args.Add($"{key}={value ?? string.Empty}");
+            }
+        }
+
+        args.Add("-d");
+        args.Add(spec.ImageReference);
+
+        if (!string.IsNullOrEmpty(spec.Command))
+        {
+            args.Add(spec.Command);
+            if (spec.Arguments is not null)
+            {
+                args.AddRange(spec.Arguments);
+            }
+        }
+        else
+        {
+            // Default keep-alive command. Two argv elements (`sleep` then
+            // `infinity`) so even this default doesn't accidentally
+            // tokenise differently from caller-supplied commands.
+            args.Add("sleep");
+            args.Add("infinity");
+        }
+
+        return args.ToArray();
     }
 
     private async Task<CliResult> RunCliAsync(string arguments, CancellationToken ct, TimeSpan? timeout = null)

--- a/tests/Andy.Containers.Api.Tests/Providers/AppleContainerProviderArgsTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Providers/AppleContainerProviderArgsTests.cs
@@ -1,0 +1,172 @@
+using Andy.Containers.Abstractions;
+using Andy.Containers.Infrastructure.Providers.Apple;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Providers;
+
+// rivoli-ai/andy-containers#127. The pre-fix code built the entire
+// `container run ...` line as a string and let .NET's Win32 parser
+// tokenise it. A template's BaseImage with a space, an env value with
+// whitespace, or a Command with embedded flags would split into extra
+// CLI tokens and let a caller with template:write smuggle in flags
+// (`--rm`, `--volume`, etc.). These tests pin the contract that every
+// untrusted value lands in exactly one argv slot regardless of its
+// content.
+public class AppleContainerProviderArgsTests
+{
+    [Fact]
+    public void Build_BareMinimum_StartsWithRunNameAndAddsDefaults()
+    {
+        var args = AppleContainerProvider.BuildCreateContainerArgs(
+            new ContainerSpec { Name = "x", ImageReference = "ubuntu:24.04" },
+            "x");
+
+        args.Should().StartWith(new[] { "run", "--name", "x" });
+        args.Should().EndWith(new[] { "-d", "ubuntu:24.04", "sleep", "infinity" });
+    }
+
+    [Fact]
+    public void Build_EnvValueWithSpaces_LandsInSingleArgvSlot()
+    {
+        // The previous string-build path skipped this with a warning;
+        // here it must pass through cleanly because each env var becomes
+        // its own argv element. Use a value that would have tokenised
+        // into three pieces under the old parser.
+        var spec = new ContainerSpec
+        {
+            Name = "x",
+            ImageReference = "ubuntu:24.04",
+            EnvironmentVariables = new() { ["GREETING"] = "hello world from apple" },
+        };
+
+        var args = AppleContainerProvider.BuildCreateContainerArgs(spec, "x");
+
+        args.Should().Contain("-e");
+        args.Should().Contain("GREETING=hello world from apple",
+            "spaces in env values are now safe — the value is one argv slot");
+    }
+
+    [Fact]
+    public void Build_EnvValueWithQuoteAndDollar_PassesThroughVerbatim()
+    {
+        // The argv path also handles characters a shell would expand.
+        var spec = new ContainerSpec
+        {
+            Name = "x",
+            ImageReference = "ubuntu:24.04",
+            EnvironmentVariables = new() { ["KEY"] = "p\"a$ssword" },
+        };
+
+        var args = AppleContainerProvider.BuildCreateContainerArgs(spec, "x");
+
+        args.Should().Contain("KEY=p\"a$ssword");
+    }
+
+    [Fact]
+    public void Build_ImageReferenceWithEmbeddedFlag_StaysOneArgvElement()
+    {
+        // Threat model: a template author sets BaseImage to something
+        // that would have tokenised into two args under the old path.
+        // The Apple CLI will reject this as an unknown image — that's
+        // fine; the point is that "--rm" never reaches argv as its own
+        // slot.
+        var spec = new ContainerSpec
+        {
+            Name = "x",
+            ImageReference = "evil:latest --rm --volume /:/host",
+        };
+
+        var args = AppleContainerProvider.BuildCreateContainerArgs(spec, "x");
+
+        // Find the `-d` token; the very next slot must be the entire
+        // (malicious) image string, with no extra slots in between.
+        var dashD = Array.IndexOf(args, "-d");
+        dashD.Should().BeGreaterThanOrEqualTo(0);
+        args[dashD + 1].Should().Be("evil:latest --rm --volume /:/host",
+            "the whole image-reference string is one argv slot; --rm and --volume " +
+            "do not become independent CLI flags");
+        args.Should().NotContain("--rm");
+        args.Should().NotContain("--volume");
+    }
+
+    [Fact]
+    public void Build_CommandWithArguments_AppendsInOrder_AfterImage()
+    {
+        var spec = new ContainerSpec
+        {
+            Name = "x",
+            ImageReference = "ubuntu:24.04",
+            Command = "/usr/bin/python3",
+            Arguments = new[] { "-c", "print('hi from $USER')" },
+        };
+
+        var args = AppleContainerProvider.BuildCreateContainerArgs(spec, "x");
+
+        var dashD = Array.IndexOf(args, "-d");
+        args[dashD + 1].Should().Be("ubuntu:24.04");
+        args[dashD + 2].Should().Be("/usr/bin/python3");
+        args[dashD + 3].Should().Be("-c");
+        args[dashD + 4].Should().Be("print('hi from $USER')",
+            "argument with single quotes + dollar passes through as one slot");
+        args.Should().NotContain("sleep",
+            "the default keep-alive command is replaced when an explicit Command is set");
+    }
+
+    [Fact]
+    public void Build_Resources_ProducesSeparateArgvSlots()
+    {
+        var spec = new ContainerSpec
+        {
+            Name = "x",
+            ImageReference = "ubuntu:24.04",
+            Resources = new ResourceSpec { CpuCores = 4, MemoryMb = 2048, DiskGb = 0 },
+        };
+
+        var args = AppleContainerProvider.BuildCreateContainerArgs(spec, "x");
+
+        // -c must be followed by the count as an int (invariant culture
+        // — a fr-FR runtime would render it with a comma otherwise).
+        var dashC = Array.IndexOf(args, "-c");
+        args[dashC + 1].Should().Be("4");
+        var dashM = Array.IndexOf(args, "-m");
+        args[dashM + 1].Should().Be("2048M");
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    public void Build_OmitsResourceFlagsWhenZeroOrUnset(int cpu, bool expectFlag)
+    {
+        var spec = new ContainerSpec
+        {
+            Name = "x",
+            ImageReference = "ubuntu:24.04",
+            Resources = new ResourceSpec { CpuCores = cpu, MemoryMb = 0, DiskGb = 0 },
+        };
+
+        var args = AppleContainerProvider.BuildCreateContainerArgs(spec, "x");
+
+        args.Contains("-c").Should().Be(expectFlag);
+        args.Contains("-m").Should().BeFalse("MemoryMb=0 means use the runtime default");
+    }
+
+    [Fact]
+    public void Build_NullSpec_Throws()
+    {
+        var act = () => AppleContainerProvider.BuildCreateContainerArgs(null!, "x");
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Build_BlankName_Throws()
+    {
+        // Container name is the one value the operator owns; refuse to
+        // build args for an empty one rather than producing nonsense the
+        // CLI would reject seconds later.
+        var act = () => AppleContainerProvider.BuildCreateContainerArgs(
+            new ContainerSpec { Name = "x", ImageReference = "ubuntu:24.04" },
+            "");
+        act.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#127

## Finding

\`AppleContainerProvider.CreateContainerAsync\` built \`container run --name {name} ... {ImageReference} {Command} {Arguments}\` as a single string and passed it to \`ProcessStartInfo.Arguments\`. .NET's Win32-style parser then re-tokenised on whitespace, so a template's \`BaseImage\` with an embedded space, an env value with whitespace, or a \`Command\` carrying extra flags would split into independent argv slots — escalating \`template:write\` into CLI-flag smuggling (\`--rm\`, \`--volume /:/host\`, additional \`-t\`).

The provider already had \`RunCliWithArgsAsync\`. \`exec\` used it; \`run\` didn't.

## Fix

- **\`BuildCreateContainerArgs(spec, name)\`** — pure static helper returning \`string[]\`. \`CreateContainerAsync\` passes the result to \`RunCliWithArgsAsync\`; \`ProcessStartInfo.ArgumentList\` preserves argv slots verbatim.
- **Dropped the env-var whitespace/quote skip workaround** — values now land in their own argv slot, so spaces / quotes / dollars no longer split or get interpreted.
- **Converted other interpolating call sites** (\`inspect\`, \`stop\`, \`delete\`, \`start\`) to the args-list path. Apple-generated names are reasonably safe today but consistency means a future change can't accidentally regress one of them.

## Test plan

- [x] **10 \`AppleContainerProviderArgsTests\`** unit cases on the static helper. Threat-model coverage:
  - env value with spaces → one argv slot (was a security warning before)
  - env value with quote + dollar → passes through verbatim
  - \`ImageReference = "evil:latest --rm --volume /:/host"\` → stays as one argv slot; \`--rm\` and \`--volume\` don't become independent flags
  - Command + Arguments containing single quotes and \`$USER\` → no shell expansion
  - Resources, default keep-alive (\`sleep infinity\`), null/blank guards
- [x] Full Api.Tests suite: **837 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)