### PR TITLE
[HIGH] Image build: argv-list + OCI reference validation (#126)

### DIFF
--- a/src/Andy.Containers.Api/Services/ImageBuildService.cs
+++ b/src/Andy.Containers.Api/Services/ImageBuildService.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Text.Json;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Models;
+using Andy.Containers.Validation;
 using Microsoft.EntityFrameworkCore;
 
 namespace Andy.Containers.Api.Services;
@@ -96,23 +97,37 @@ public class TemplateBuildService : ITemplateBuildService
 
             _logger.LogInformation("Building image {Image} from {Dir}", imageReference, buildDir);
 
-            var args = $"buildx build -t {imageReference}";
-            if (scriptsDir is not null && Directory.Exists(scriptsDir))
-                args += $" --build-context scripts={scriptsDir}";
-            args += $" {buildDir}";
+            // rivoli-ai/andy-containers#126. Validate before invoking
+            // docker so a malformed reference fails with a clear
+            // operator-facing error rather than a daemon parse warning.
+            // The argv-list path below is the primary defense; this is
+            // belt + braces.
+            OciReferenceValidator.Validate(imageReference);
 
-            var process = new Process
+            // rivoli-ai/andy-containers#126. ProcessStartInfo.ArgumentList
+            // bypasses .NET's Win32-style tokeniser so a template's
+            // BaseImage with embedded whitespace can't smuggle extra CLI
+            // flags (`-t evil --file /etc/passwd`).
+            var psi = new ProcessStartInfo
             {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "docker",
-                    Arguments = args,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                }
+                FileName = "docker",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
             };
+            psi.ArgumentList.Add("buildx");
+            psi.ArgumentList.Add("build");
+            psi.ArgumentList.Add("-t");
+            psi.ArgumentList.Add(imageReference);
+            if (scriptsDir is not null && Directory.Exists(scriptsDir))
+            {
+                psi.ArgumentList.Add("--build-context");
+                psi.ArgumentList.Add($"scripts={scriptsDir}");
+            }
+            psi.ArgumentList.Add(buildDir);
+
+            var process = new Process { StartInfo = psi };
 
             process.Start();
             var stdout = await process.StandardOutput.ReadToEndAsync();
@@ -291,18 +306,24 @@ public class TemplateBuildService : ITemplateBuildService
     {
         try
         {
-            var process = new Process
+            // rivoli-ai/andy-containers#126. ArgumentList prevents the
+            // template-supplied imageReference from tokenising into
+            // extra docker flags.
+            var psi = new ProcessStartInfo
             {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "docker",
-                    Arguments = $"image inspect {imageReference} --format json",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                }
+                FileName = "docker",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
             };
+            psi.ArgumentList.Add("image");
+            psi.ArgumentList.Add("inspect");
+            psi.ArgumentList.Add(imageReference);
+            psi.ArgumentList.Add("--format");
+            psi.ArgumentList.Add("json");
+
+            var process = new Process { StartInfo = psi };
             process.Start();
             var output = await process.StandardOutput.ReadToEndAsync();
             await process.WaitForExitAsync();
@@ -343,18 +364,21 @@ public class TemplateBuildService : ITemplateBuildService
     {
         try
         {
-            var process = new Process
+            // rivoli-ai/andy-containers#126. ArgumentList for the same
+            // reason as InspectImageAsync above.
+            var psi = new ProcessStartInfo
             {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "docker",
-                    Arguments = $"image inspect {imageReference}",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                }
+                FileName = "docker",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
             };
+            psi.ArgumentList.Add("image");
+            psi.ArgumentList.Add("inspect");
+            psi.ArgumentList.Add(imageReference);
+
+            var process = new Process { StartInfo = psi };
             process.Start();
             await process.WaitForExitAsync();
             return process.ExitCode == 0;

--- a/src/Andy.Containers.Infrastructure/Providers/Local/DockerInfrastructureProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Local/DockerInfrastructureProvider.cs
@@ -687,22 +687,35 @@ public class DockerInfrastructureProvider : IInfrastructureProvider
 
         _logger.LogInformation("Building desktop image {Image} from {Dir}", imageReference, buildDir);
 
-        var args = $"buildx build -t {imageReference}";
-        if (Directory.Exists(scriptsDir))
-            args += $" --build-context scripts={Path.GetFullPath(scriptsDir)}";
-        args += $" {buildDir}";
+        // rivoli-ai/andy-containers#126. Validate the image reference up-
+        // front so a malformed value fails with a clear operator-facing
+        // error rather than a daemon parse warning. The argv-list path
+        // below is the primary defense; this is belt + braces.
+        Andy.Containers.Validation.OciReferenceValidator.Validate(imageReference);
 
-        var process = new System.Diagnostics.Process
+        // rivoli-ai/andy-containers#126. ProcessStartInfo.ArgumentList
+        // bypasses .NET's Win32-style tokeniser so any whitespace or
+        // shell metacharacter that snuck into a template's BaseImage
+        // can't smuggle extra docker flags.
+        var psi = new System.Diagnostics.ProcessStartInfo
         {
-            StartInfo = new System.Diagnostics.ProcessStartInfo
-            {
-                FileName = "docker",
-                Arguments = args,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-            }
+            FileName = "docker",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
         };
+        psi.ArgumentList.Add("buildx");
+        psi.ArgumentList.Add("build");
+        psi.ArgumentList.Add("-t");
+        psi.ArgumentList.Add(imageReference);
+        if (Directory.Exists(scriptsDir))
+        {
+            psi.ArgumentList.Add("--build-context");
+            psi.ArgumentList.Add($"scripts={Path.GetFullPath(scriptsDir)}");
+        }
+        psi.ArgumentList.Add(buildDir);
+
+        var process = new System.Diagnostics.Process { StartInfo = psi };
 
         process.Start();
         _ = await process.StandardOutput.ReadToEndAsync(ct);

--- a/src/Andy.Containers/Validation/OciReferenceValidator.cs
+++ b/src/Andy.Containers/Validation/OciReferenceValidator.cs
@@ -1,0 +1,70 @@
+using System.Text.RegularExpressions;
+
+namespace Andy.Containers.Validation;
+
+/// <summary>
+/// Validates OCI image references against a conservative subset of the
+/// distribution-spec grammar. Used as defense-in-depth alongside the
+/// argv-list path in image-build call sites
+/// (rivoli-ai/andy-containers#126): even when the value lands in a
+/// single argv slot, refusing visibly malformed references at the API
+/// boundary surfaces operator typos with a clear error before the
+/// docker daemon emits a less-actionable one.
+/// </summary>
+/// <remarks>
+/// The full OCI grammar (digest algorithms, host:port + path, tags,
+/// digest discriminators) is intricate. We accept what the
+/// distribution-spec calls out as valid and reject anything containing
+/// characters that have no business in an image reference: whitespace,
+/// control characters, shell metacharacters. The intent is "obviously
+/// wrong" detection, not protocol-perfect parsing — the daemon owns
+/// the canonical decision.
+/// </remarks>
+public static partial class OciReferenceValidator
+{
+    // Rough regex that covers the common shape:
+    //   [registry[:port]/]name[:tag][@digest]
+    // - registry: hostname or hostname:port
+    // - name: lowercase alphanumeric + a small set of separators (`._-`),
+    //         optionally with `/`-separated path components
+    // - tag: alphanumeric + `_.-`, max 128 chars (distribution-spec)
+    // - digest: algo:hex, e.g. sha256:abcd...
+    [GeneratedRegex(
+        @"^(?:(?<registry>[a-zA-Z0-9][a-zA-Z0-9.\-]*(?::[0-9]+)?)/)?" +
+        @"(?<name>[a-z0-9]+(?:[._\-/][a-z0-9]+)*)" +
+        @"(?::(?<tag>[a-zA-Z0-9_][a-zA-Z0-9._\-]{0,127}))?" +
+        @"(?:@(?<digest>[a-zA-Z][a-zA-Z0-9]*:[a-fA-F0-9]+))?$",
+        RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture)]
+    private static partial Regex OciReferencePattern();
+
+    /// <summary>True when <paramref name="reference"/> matches the conservative grammar.</summary>
+    public static bool IsValid(string? reference)
+    {
+        if (string.IsNullOrWhiteSpace(reference)) return false;
+        // Whitespace / control / quote / shell metachars never belong in
+        // a reference. Reject up-front so a more pointed error message
+        // beats a regex miss.
+        foreach (var c in reference)
+        {
+            if (char.IsWhiteSpace(c) || char.IsControl(c)) return false;
+            if (c is '"' or '\'' or '`' or '$' or '\\' or ';' or '|' or '&') return false;
+        }
+        return OciReferencePattern().IsMatch(reference);
+    }
+
+    /// <summary>
+    /// Throw <see cref="ArgumentException"/> with a clear message when
+    /// the reference is invalid. Use at API boundaries before launching
+    /// build/inspect subprocesses.
+    /// </summary>
+    public static void Validate(string? reference, string paramName = "imageReference")
+    {
+        if (!IsValid(reference))
+        {
+            throw new ArgumentException(
+                $"'{reference}' is not a valid OCI image reference. " +
+                $"Expected [registry[:port]/]name[:tag][@digest] with no whitespace or shell metacharacters.",
+                paramName);
+        }
+    }
+}

--- a/tests/Andy.Containers.Tests/Validation/OciReferenceValidatorTests.cs
+++ b/tests/Andy.Containers.Tests/Validation/OciReferenceValidatorTests.cs
@@ -1,0 +1,88 @@
+using Andy.Containers.Validation;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Tests.Validation;
+
+// rivoli-ai/andy-containers#126. The validator is defense-in-depth on
+// the buildx + image-inspect call sites. Argv-list construction is the
+// primary fix — these tests pin the secondary check so a future caller
+// landing the validator on a new entry point gets the same behaviour.
+public class OciReferenceValidatorTests
+{
+    [Theory]
+    // Plain images
+    [InlineData("ubuntu", true)]
+    [InlineData("ubuntu:24.04", true)]
+    [InlineData("ubuntu:24.04-lts", true)]
+    // Registry-prefixed
+    [InlineData("ghcr.io/rivoli-ai/andy-headless:latest", true)]
+    [InlineData("registry.rivoli.ai:5000/team/repo:v1.2.3", true)]
+    // Digest-pinned
+    [InlineData("ubuntu@sha256:1a2b3c4d5e6f7890aabbccddeeff00112233445566778899aabbccddeeff0011", true)]
+    [InlineData("ghcr.io/rivoli-ai/andy:1.0@sha256:abcdef0123456789", true)]
+    public void IsValid_AcceptsCanonicalRefs(string reference, bool expected)
+    {
+        OciReferenceValidator.IsValid(reference).Should().Be(expected);
+    }
+
+    [Theory]
+    // Whitespace — the original threat model.
+    [InlineData("evil:latest --rm")]
+    [InlineData("evil:latest\n--rm")]
+    [InlineData("evil:latest\t-t something")]
+    // Shell metacharacters.
+    [InlineData("evil:latest;rm -rf /")]
+    [InlineData("evil$(whoami):latest")]
+    [InlineData("evil`whoami`:latest")]
+    [InlineData("evil:latest|cat /etc/passwd")]
+    [InlineData("evil:latest&background")]
+    [InlineData("evil:latest\\backslash")]
+    // Quotes (would never tokenise correctly).
+    [InlineData("\"quoted\":latest")]
+    [InlineData("'quoted':latest")]
+    // Empty / whitespace-only.
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsValid_RejectsMalformed(string reference)
+    {
+        OciReferenceValidator.IsValid(reference).Should().BeFalse(
+            $"'{reference}' must be rejected as a defense-in-depth check");
+    }
+
+    [Fact]
+    public void IsValid_NullReturnsFalse()
+    {
+        OciReferenceValidator.IsValid(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_ValidRef_DoesNotThrow()
+    {
+        var act = () => OciReferenceValidator.Validate("ubuntu:24.04");
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Validate_Malformed_ThrowsArgumentException_WithDescriptiveMessage()
+    {
+        var act = () => OciReferenceValidator.Validate("evil:latest --rm");
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*not a valid OCI image reference*")
+            .Which.Message.Should().Contain("--rm",
+                "the error must echo the offending input so operators can self-correct");
+    }
+
+    [Fact]
+    public void Validate_RespectsParamName()
+    {
+        // Different call sites use different parameter names; pin that
+        // the helper threads the name through so error reporting points
+        // at the right binding.
+        var act = () => OciReferenceValidator.Validate("evil ;", paramName: "templateBaseImage");
+
+        act.Should().Throw<ArgumentException>()
+            .Which.ParamName.Should().Be("templateBaseImage");
+    }
+}


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#126

## Finding

Four \`docker\` invocations built their entire command as a single \`Arguments\` string and let .NET's Win32-style parser tokenise:

| File:line | Command |
|---|---|
| \`ImageBuildService.cs:99\` | \`buildx build -t {imageReference}\` |
| \`ImageBuildService.cs:299\` | \`image inspect {imageReference} --format json\` |
| \`ImageBuildService.cs:351\` | \`image inspect {imageReference}\` |
| \`DockerInfrastructureProvider.cs:690\` | \`buildx build -t {imageReference} ...\` |

A template's \`BaseImage\` with embedded whitespace tokenises into extra docker tokens. \`BaseImage = "evil --file /etc/passwd"\` becomes \`-t evil --file /etc/passwd\`, escalating \`template:write\` into CLI-flag smuggling.

## Two-layer fix

1. **\`Andy.Containers/Validation/OciReferenceValidator\`** — conservative regex over the distribution-spec grammar (\`[registry[:port]/]name[:tag][@digest]\`) plus an upfront character check that rejects whitespace, control chars, and shell metas (\`;|&$\\\`'"\\\\\`). \`IsValid\` for branching, \`Validate(throw)\` for API-boundary use. The threat model is "obviously wrong" detection, not protocol-perfect parsing — the daemon owns the canonical decision.
2. **\`ProcessStartInfo.ArgumentList\`** in all four call sites. Every interpolated value lands in its own argv slot regardless of content; the OS never sees a shell or a tokeniser for these strings. **Primary defense**; the validator is belt + braces that surfaces typos earlier with a clearer error.

Validator gates the two \`buildx\` entry points. The two \`image inspect\` helpers don't re-validate — they're internal callers downstream of already-validated paths.

## Test plan

- [x] 24 \`OciReferenceValidatorTests\` cases:
  - Accepts canonical refs (plain, registry-prefixed, digest-pinned).
  - Rejects whitespace, shell metacharacters (\`;|&$\\\`'"\\\\\`), quotes, null, empty, blank.
  - Descriptive error message echoes the input so operators can self-correct.
  - \`paramName\` threads through the throw helper.
- [x] Full unit suite: **1195 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)