### PR TITLE
[HIGH] SshDockerHelper: POSIX-quote every interpolated value (#128)

### DIFF
--- a/src/Andy.Containers.Infrastructure/Providers/Shared/SshDockerHelper.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Shared/SshDockerHelper.cs
@@ -1,5 +1,6 @@
 using Andy.Containers.Abstractions;
 using Andy.Containers.Models;
+using Andy.Containers.Validation;
 using Microsoft.Extensions.Logging;
 using Renci.SshNet;
 
@@ -46,40 +47,16 @@ public class SshDockerHelper : IDisposable
     public Task<string> RunContainerAsync(ContainerSpec spec, CancellationToken ct)
     {
         EnsureConnected();
+
+        // rivoli-ai/andy-containers#128. Validate the image reference at
+        // the boundary; defense-in-depth on top of the shell-quoting
+        // applied below. Catches obviously malformed BaseImage values
+        // before they hit a remote shell.
+        OciReferenceValidator.Validate(spec.ImageReference, paramName: nameof(spec.ImageReference));
+
         var containerName = $"andy-{Guid.NewGuid().ToString("N")[..12]}";
 
-        var envArgs = "";
-        if (spec.EnvironmentVariables is not null)
-        {
-            foreach (var (key, value) in spec.EnvironmentVariables)
-                envArgs += $" -e {key}={value}";
-        }
-
-        var portArgs = "";
-        if (spec.PortMappings is not null)
-        {
-            foreach (var (container, host) in spec.PortMappings)
-                portArgs += $" -p {host}:{container}";
-        }
-
-        var resources = spec.Resources ?? new ResourceSpec();
-        var cpuLimit = $"--cpus={resources.CpuCores}";
-        var memLimit = $"--memory={resources.MemoryMb}m";
-        // Mirror the local DockerInfrastructureProvider hardening: PID cap to
-        // resist fork bombs, no-new-privileges to block setuid escalation, and
-        // drop NET_RAW + MKNOD which dev workloads do not need.
-        const string hardening =
-            " --pids-limit 4096" +
-            " --security-opt no-new-privileges" +
-            " --cap-drop NET_RAW --cap-drop MKNOD";
-
-        var cmd = $"docker run -d --name {containerName} {cpuLimit} {memLimit}{hardening}{envArgs}{portArgs} {spec.ImageReference}";
-        if (!string.IsNullOrEmpty(spec.Command))
-        {
-            cmd += $" {spec.Command}";
-            if (spec.Arguments is not null)
-                cmd += " " + string.Join(" ", spec.Arguments);
-        }
+        var cmd = BuildRunCommand(spec, containerName);
 
         _logger.LogInformation("Running Docker container via SSH: {Cmd}", cmd);
         var result = RunCommand(cmd);
@@ -90,28 +67,113 @@ public class SshDockerHelper : IDisposable
         return Task.FromResult(containerName);
     }
 
+    /// <summary>
+    /// Build the <c>docker run -d ...</c> command we send over SSH for
+    /// <see cref="RunContainerAsync"/>. Pure function so the assembly
+    /// can be unit-tested without a live SSH connection
+    /// (rivoli-ai/andy-containers#128). Every interpolated value is
+    /// POSIX-quoted before insertion: a remote shell session
+    /// re-tokenises the command we send, so an unquoted env value or
+    /// image ref with whitespace would split into independent argv
+    /// tokens just like the local-process case.
+    /// </summary>
+    internal static string BuildRunCommand(ContainerSpec spec, string containerName)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+        ArgumentException.ThrowIfNullOrEmpty(containerName);
+
+        var envArgs = "";
+        if (spec.EnvironmentVariables is not null)
+        {
+            foreach (var (key, value) in spec.EnvironmentVariables)
+            {
+                // Quote both the KEY=VALUE token (because VALUE may
+                // contain shell metas) and treat the entire string as
+                // one argv slot. KEY itself is operator-controlled and
+                // a sane shell-safe identifier in practice; quoting
+                // the whole pair is the conservative move.
+                envArgs += $" -e {PosixShellQuote.Quote($"{key}={value ?? string.Empty}")}";
+            }
+        }
+
+        var portArgs = "";
+        if (spec.PortMappings is not null)
+        {
+            foreach (var (container, host) in spec.PortMappings)
+            {
+                // Ports are integers; quoting is unnecessary but
+                // costs nothing and keeps the rule "every interpolated
+                // value is quoted" easy to enforce by review.
+                portArgs += $" -p {PosixShellQuote.Quote($"{host}:{container}")}";
+            }
+        }
+
+        var resources = spec.Resources ?? new ResourceSpec();
+        var cpuLimit = $"--cpus={resources.CpuCores}";
+        var memLimit = $"--memory={resources.MemoryMb}m";
+
+        // Mirror the local DockerInfrastructureProvider hardening: PID cap to
+        // resist fork bombs, no-new-privileges to block setuid escalation, and
+        // drop NET_RAW + MKNOD which dev workloads do not need.
+        const string hardening =
+            " --pids-limit 4096" +
+            " --security-opt no-new-privileges" +
+            " --cap-drop NET_RAW --cap-drop MKNOD";
+
+        var cmd =
+            $"docker run -d --name {PosixShellQuote.Quote(containerName)}" +
+            $" {cpuLimit} {memLimit}{hardening}{envArgs}{portArgs}" +
+            $" {PosixShellQuote.Quote(spec.ImageReference)}";
+
+        if (!string.IsNullOrEmpty(spec.Command))
+        {
+            cmd += $" {PosixShellQuote.Quote(spec.Command)}";
+            if (spec.Arguments is not null)
+            {
+                foreach (var arg in spec.Arguments)
+                {
+                    cmd += $" {PosixShellQuote.Quote(arg)}";
+                }
+            }
+        }
+
+        return cmd;
+    }
+
     public ExecResult DockerExec(string containerName, string command)
     {
         EnsureConnected();
-        return RunCommand($"docker exec {containerName} sh -c '{command.Replace("'", "'\\''")}'");
+        // rivoli-ai/andy-containers#128. Quote both the container name
+        // and the inner command. The previous bespoke 's/'/'\\''/g'
+        // replacement was correct for the inner command but didn't
+        // protect the container name against an exotic externalId.
+        return RunCommand(
+            $"docker exec {PosixShellQuote.Quote(containerName)} sh -c {PosixShellQuote.Quote(command)}");
     }
 
     public void StopContainer(string containerName)
     {
         EnsureConnected();
-        RunCommand($"docker stop {containerName}");
+        // rivoli-ai/andy-containers#128. Container names are operator-
+        // generated alphanumerics today, but quoting is the consistent
+        // rule across the helper.
+        RunCommand($"docker stop {PosixShellQuote.Quote(containerName)}");
     }
 
     public void RemoveContainer(string containerName)
     {
         EnsureConnected();
-        RunCommand($"docker rm -f {containerName}");
+        RunCommand($"docker rm -f {PosixShellQuote.Quote(containerName)}");
     }
 
     public ContainerRuntimeInfo GetContainerInfo(string containerName)
     {
         EnsureConnected();
-        var result = RunCommand($"docker inspect --format '{{{{.State.Running}}}} {{{{.State.StartedAt}}}}' {containerName}");
+        // rivoli-ai/andy-containers#128. The --format pattern is a
+        // fixed literal authored by us — safe to interpolate without
+        // quoting. The container name is the untrusted value here.
+        var result = RunCommand(
+            $"docker inspect --format '{{{{.State.Running}}}} {{{{.State.StartedAt}}}}' {PosixShellQuote.Quote(containerName)}");
         var parts = result.StdOut?.Trim().Split(' ') ?? [];
         var running = parts.Length > 0 && parts[0] == "true";
 
@@ -139,12 +201,23 @@ public class SshDockerHelper : IDisposable
 
     public static string GetCloudInitScript(string dockerImage, string containerName, Dictionary<int, int>? portMappings)
     {
+        // rivoli-ai/andy-containers#128. The cloud-init script runs
+        // verbatim on the VM at first boot — every interpolated value
+        // sits inside a bash command that the kernel re-tokenises.
+        // Quote every variable; validate the image reference up-front
+        // for the same defense-in-depth reasoning as RunContainerAsync.
+        OciReferenceValidator.Validate(dockerImage, paramName: nameof(dockerImage));
+        ArgumentException.ThrowIfNullOrEmpty(containerName);
+
         var portArgs = "";
         if (portMappings is not null)
         {
             foreach (var (container, host) in portMappings)
-                portArgs += $" -p {host}:{container}";
+                portArgs += $" -p {PosixShellQuote.Quote($"{host}:{container}")}";
         }
+
+        var quotedImage = PosixShellQuote.Quote(dockerImage);
+        var quotedName = PosixShellQuote.Quote(containerName);
 
         return $"""
                 #!/bin/bash
@@ -153,8 +226,8 @@ public class SshDockerHelper : IDisposable
                 apt-get install -y -qq docker.io
                 systemctl enable docker
                 systemctl start docker
-                docker pull {dockerImage}
-                docker run -d --name {containerName} --restart unless-stopped --pids-limit 4096 --security-opt no-new-privileges --cap-drop NET_RAW --cap-drop MKNOD{portArgs} {dockerImage}
+                docker pull {quotedImage}
+                docker run -d --name {quotedName} --restart unless-stopped --pids-limit 4096 --security-opt no-new-privileges --cap-drop NET_RAW --cap-drop MKNOD{portArgs} {quotedImage}
                 """;
     }
 

--- a/src/Andy.Containers/Validation/PosixShellQuote.cs
+++ b/src/Andy.Containers/Validation/PosixShellQuote.cs
@@ -1,0 +1,35 @@
+namespace Andy.Containers.Validation;
+
+/// <summary>
+/// POSIX shell-quoting for values interpolated into commands run via
+/// <c>/bin/sh -c</c> (or any other shell). Wraps the value in single
+/// quotes and escapes any embedded single quote via <c>'\''</c> —
+/// the canonical safe pattern: nothing inside single quotes is
+/// interpreted by the shell, including <c>$</c>, <c>`</c>, and
+/// backslash escapes.
+/// </summary>
+/// <remarks>
+/// Used by the SSH provider helper (rivoli-ai/andy-containers#128)
+/// to assemble remote <c>docker run</c> commands without the
+/// remote shell tokenising on whitespace or expanding metacharacters.
+/// Same pattern AP6's <c>HeadlessRunner.ShellEscape</c> uses for the
+/// local <c>andy-cli</c> spawn — pulled into Andy.Containers/Validation
+/// so both layers share a single implementation.
+/// </remarks>
+public static class PosixShellQuote
+{
+    /// <summary>
+    /// Return <paramref name="value"/> wrapped in single quotes,
+    /// safe for interpolation into a POSIX shell command. Null is
+    /// rendered as the empty single-quoted string <c>''</c>.
+    /// </summary>
+    public static string Quote(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return "''";
+
+        // Single quotes can't appear inside single quotes; close the
+        // quoted segment, emit an escaped literal quote, reopen.
+        // Result: 'foo'\''bar' for input foo'bar.
+        return "'" + value.Replace("'", "'\\''") + "'";
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Providers/SshDockerHelperBuildRunTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Providers/SshDockerHelperBuildRunTests.cs
@@ -1,0 +1,162 @@
+using Andy.Containers.Abstractions;
+using Andy.Containers.Infrastructure.Providers.Shared;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Providers;
+
+// rivoli-ai/andy-containers#128. The pre-fix code interpolated env
+// values, image refs, command, and args into a single shell-line that
+// got executed on a remote sshd. Whitespace or shell metacharacters in
+// any value would split into independent argv tokens or trigger
+// metacharacter expansion. BuildRunCommand now POSIX-quotes every
+// interpolated value; these tests pin the shape of the assembled
+// command so a future regression breaks here, not in the field.
+public class SshDockerHelperBuildRunTests
+{
+    [Fact]
+    public void Build_BareMinimum_ProducesQuotedDockerRun()
+    {
+        var spec = new ContainerSpec { Name = "x", ImageReference = "ubuntu:24.04" };
+
+        var cmd = SshDockerHelper.BuildRunCommand(spec, "andy-abc123");
+
+        cmd.Should().StartWith("docker run -d --name 'andy-abc123'",
+            "container name lands quoted even though Guid-derived names are safe today");
+        cmd.Should().Contain(" 'ubuntu:24.04'",
+            "image reference is the primary untrusted value — always quoted");
+        cmd.Should().Contain("--pids-limit 4096",
+            "the hardening block carries through unchanged");
+        cmd.Should().Contain("--security-opt no-new-privileges");
+        cmd.Should().Contain("--cap-drop NET_RAW");
+    }
+
+    [Fact]
+    public void Build_EnvValueWithSpace_LandsInOneQuotedSlot()
+    {
+        // The threat model: a template-author-controlled env value
+        // with a space would have split into two argv tokens at the
+        // remote shell under the old code.
+        var spec = new ContainerSpec
+        {
+            Name = "x",
+            ImageReference = "ubuntu:24.04",
+            EnvironmentVariables = new() { ["GREETING"] = "hello world" },
+        };
+
+        var cmd = SshDockerHelper.BuildRunCommand(spec, "n");
+
+        cmd.Should().Contain(" -e 'GREETING=hello world'",
+            "the entire KEY=VALUE pair is one quoted slot — space stays inside the quotes");
+        cmd.Should().NotContain(" world ", "the value must not split into 'world' as an extra token");
+    }
+
+    [Fact]
+    public void Build_EnvValueWithDollarAndBackticks_DoesNotExpand()
+    {
+        var spec = new ContainerSpec
+        {
+            Name = "x",
+            ImageReference = "ubuntu:24.04",
+            EnvironmentVariables = new() { ["TOKEN"] = "$(whoami)`id`" },
+        };
+
+        var cmd = SshDockerHelper.BuildRunCommand(spec, "n");
+
+        cmd.Should().Contain(" -e 'TOKEN=$(whoami)`id`'",
+            "single quotes neuter $ and ` — the metacharacters reach the docker daemon as literal bytes");
+    }
+
+    [Fact]
+    public void Build_EnvValueWithSingleQuote_UsesEscapeSequence()
+    {
+        var spec = new ContainerSpec
+        {
+            Name = "x",
+            ImageReference = "ubuntu:24.04",
+            EnvironmentVariables = new() { ["NAME"] = "O'Malley" },
+        };
+
+        var cmd = SshDockerHelper.BuildRunCommand(spec, "n");
+
+        cmd.Should().Contain("'NAME=O'\\''Malley'",
+            "embedded single quote uses the canonical close-escape-reopen pattern");
+    }
+
+    [Fact]
+    public void Build_CommandWithArguments_QuotesEachIndependently()
+    {
+        var spec = new ContainerSpec
+        {
+            Name = "x",
+            ImageReference = "ubuntu:24.04",
+            Command = "/usr/bin/python3",
+            Arguments = new[] { "-c", "print('hi'); import os; os.system('id')" },
+        };
+
+        var cmd = SshDockerHelper.BuildRunCommand(spec, "n");
+
+        cmd.Should().Contain(" '/usr/bin/python3'");
+        cmd.Should().Contain(" '-c'");
+        cmd.Should().Contain(
+            "'print('\\''hi'\\''); import os; os.system('\\''id'\\'')'",
+            "embedded quotes round-trip via the close-escape-reopen pattern");
+    }
+
+    [Fact]
+    public void Build_ImageRefWithEmbeddedFlag_StaysOneQuotedSlot()
+    {
+        // OciReferenceValidator rejects this at the entry, but
+        // BuildRunCommand is also called by tests / future callers
+        // that may not validate. Pin that the quoting holds even when
+        // the validator hasn't run.
+        var spec = new ContainerSpec
+        {
+            Name = "x",
+            ImageReference = "evil:latest --rm --volume /:/host",
+        };
+
+        var cmd = SshDockerHelper.BuildRunCommand(spec, "n");
+
+        cmd.Should().Contain(" 'evil:latest --rm --volume /:/host'",
+            "even adversarial image refs must reach the daemon as one quoted argv slot");
+        // Verify there's no UNQUOTED occurrence of `--rm`. The string
+        // search would match inside the quoted blob, so split on the
+        // single quote that opens the image ref and assert nothing
+        // before that point carries `--rm`.
+        var openQuote = cmd.IndexOf(" 'evil:", StringComparison.Ordinal);
+        openQuote.Should().BeGreaterThan(0);
+        cmd[..openQuote].Should().NotContain("--rm",
+            "outside the quoted image ref, `--rm` must not appear as an independent flag");
+    }
+
+    [Fact]
+    public void Build_PortMappings_ProduceQuotedDashP()
+    {
+        var spec = new ContainerSpec
+        {
+            Name = "x",
+            ImageReference = "ubuntu:24.04",
+            PortMappings = new() { [8080] = 12345 },
+        };
+
+        var cmd = SshDockerHelper.BuildRunCommand(spec, "n");
+
+        cmd.Should().Contain(" -p '12345:8080'");
+    }
+
+    [Fact]
+    public void Build_NullSpec_Throws()
+    {
+        var act = () => SshDockerHelper.BuildRunCommand(null!, "n");
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Build_BlankContainerName_Throws()
+    {
+        var act = () => SshDockerHelper.BuildRunCommand(
+            new ContainerSpec { Name = "x", ImageReference = "ubuntu:24.04" }, "");
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/Andy.Containers.Tests/Validation/PosixShellQuoteTests.cs
+++ b/tests/Andy.Containers.Tests/Validation/PosixShellQuoteTests.cs
@@ -1,0 +1,70 @@
+using Andy.Containers.Validation;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Tests.Validation;
+
+// rivoli-ai/andy-containers#128. The SSH provider helper interpolates
+// untrusted values (env values, image refs, command args) into shell
+// commands sent to a remote sshd. PosixShellQuote is the safe-by-
+// default helper used at every interpolation site; these tests pin
+// the quoting contract.
+public class PosixShellQuoteTests
+{
+    [Theory]
+    [InlineData("plain", "'plain'")]
+    [InlineData("with spaces", "'with spaces'")]
+    [InlineData("with$dollar", "'with$dollar'")]
+    [InlineData("with`backticks`", "'with`backticks`'")]
+    [InlineData("semi;colon&pipe|", "'semi;colon&pipe|'")]
+    [InlineData("back\\slash", "'back\\slash'")]
+    public void Quote_WrapsInSingleQuotes(string input, string expected)
+    {
+        // Inside single quotes the shell does not interpret $, `, \,
+        // or any other metacharacter — pin that the helper exploits
+        // that property correctly.
+        PosixShellQuote.Quote(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Quote_EmbeddedSingleQuote_UsesEscapeSequence()
+    {
+        // Single quotes can't appear inside single-quoted strings, so
+        // the canonical pattern is: close, emit \', reopen.
+        // Input:   foo'bar
+        // Output:  'foo'\''bar'
+        PosixShellQuote.Quote("foo'bar").Should().Be("'foo'\\''bar'");
+    }
+
+    [Fact]
+    public void Quote_MultipleSingleQuotes_AllEscaped()
+    {
+        PosixShellQuote.Quote("a'b'c").Should().Be("'a'\\''b'\\''c'");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Quote_NullOrEmpty_ReturnsEmptyQuotedString(string? input)
+    {
+        // Empty single-quoted string is the canonical "empty argv slot"
+        // representation. Passing null / empty must round-trip cleanly
+        // so callers don't pre-check.
+        PosixShellQuote.Quote(input).Should().Be("''");
+    }
+
+    [Fact]
+    public void Quote_OutputIsRoundTripSafe()
+    {
+        // Re-feeding the helper through itself wraps the wrapped form
+        // — useful for layered commands (`sh -c '... sh -c '\''...'\'''`).
+        // Validate that the inner-quote logic doesn't break on its own
+        // output.
+        var inner = PosixShellQuote.Quote("hello world");
+        var outer = PosixShellQuote.Quote(inner);
+
+        outer.Should().StartWith("'").And.EndWith("'");
+        outer.Should().Contain("hello world",
+            "the literal payload must round-trip through the double-wrap unchanged");
+    }
+}


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#128

## Finding

\`SshDockerHelper\` assembled \`docker run -d --name {name} -e {key}={value} ... {ImageReference} {Command} {Arguments}\` as a single shell line and sent it over SSH to a remote sshd. The remote shell re-tokenised on whitespace and expanded shell metacharacters: an env value with a space split into independent argv tokens; \`\$()\` and backticks triggered command substitution on the **remote host**. Same threat model as #127 but on the SSH path.

## Fix

- **\`Andy.Containers/Validation/PosixShellQuote\`** — wraps values in single quotes and escapes embedded single quotes via the canonical close-escape-reopen pattern (\`foo'bar\` → \`'foo'\\''bar'\`). Single-quoted strings are POSIX-immune to expansion of \`\$\`, \`\` ` \`\`, \`\\\`, and every other metacharacter. AP6's \`HeadlessRunner\` already uses this pattern; pulled into shared validation so the SSH path doesn't reinvent it.
- **\`BuildRunCommand\`** extracted from \`RunContainerAsync\` as a pure static helper so the assembly is unit-testable without a live SSH connection. Every interpolated value (env \`KEY=VALUE\` pair, port mapping, image ref, container name, command, each argument) goes through \`PosixShellQuote.Quote\`. Hardening flags (\`--pids-limit\`, \`--security-opt no-new-privileges\`, \`--cap-drop\`) are author-controlled literals and stay unquoted.
- **\`DockerExec\` / \`StopContainer\` / \`RemoveContainer\` / \`GetContainerInfo\` / \`GetCloudInitScript\`** — every interpolated \`containerName\` / image / command argument flows through \`PosixShellQuote\`. The previous bespoke \`s/'/'\\\\''/g\` replacement in \`DockerExec\` was correct for the inner command but left the container name unquoted; the new path covers both.
- **\`OciReferenceValidator\`** (#126) gates both \`RunContainerAsync\` and \`GetCloudInitScript\` at their entry points so malformed image refs fail with a clear operator-facing error before reaching a remote shell.

## Test plan

- [x] 11 \`PosixShellQuoteTests\` cases: wrap in single quotes, embedded single quote round-trips, \`\$\` / backtick / semicolon / pipe / backslash all literal, multiple embedded quotes, null/empty → \`''\`, double-wrap round-trips cleanly.
- [x] 9 \`SshDockerHelperBuildRunTests\` cases: bare-minimum shape, env value with spaces stays one slot, \`\$()\` and backticks don't expand, embedded single quote uses the escape sequence, command + arguments quoted independently, adversarial image ref stays inside the quoted slot (no \`--rm\` smuggled outside), port mappings quoted, null/blank guards.
- [x] Full unit suite: **1215 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)