### PR TITLE
[HIGH] Image pinning: opt-in RequireDigestPin + post-pull digest audit log (#125)

### DIFF
--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -436,6 +436,25 @@ public class ContainerOrchestrationService : IContainerService
             ? template.GuiType
             : (profile.Kind == EnvironmentKind.Desktop ? "vnc" : "none");
 
+        // rivoli-ai/andy-containers#125. Strict mode: refuse to
+        // provision against a mutable tag. The flag is opt-in
+        // (default false) so dev workflows that rely on `:latest`
+        // still work; production deploys flip it on and pin every
+        // template to `@sha256:...`. Locally-built `andy-desktop-*`
+        // images are exempt — they're built from the repo's own
+        // Dockerfiles and never pulled from a registry, so a
+        // substitution attacker can't reach them.
+        var requireDigestPin = _configuration.GetValue<bool?>("Containers:Image:RequireDigestPin") ?? false;
+        if (requireDigestPin
+            && !effectiveImage.StartsWith("andy-desktop-", StringComparison.Ordinal)
+            && !Andy.Containers.Validation.OciReferenceValidator.IsDigestPinned(effectiveImage))
+        {
+            throw new ArgumentException(
+                $"Containers:Image:RequireDigestPin is enabled and image '{effectiveImage}' is not digest-pinned. " +
+                $"Use a reference of the form 'name@sha256:<hex>' to pin against mutable-tag substitution.",
+                nameof(request));
+        }
+
         // Enqueue the provisioning job for the background worker
         var job = new ContainerProvisionJob(
             ContainerId: container.Id,

--- a/src/Andy.Containers.Infrastructure/Providers/Local/DockerInfrastructureProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Local/DockerInfrastructureProvider.cs
@@ -172,6 +172,30 @@ public class DockerInfrastructureProvider : IInfrastructureProvider
                         null,
                         new Progress<JSONMessage>(m => _logger.LogDebug("Pull: {Status}", m.Status)),
                         ct);
+
+                    // rivoli-ai/andy-containers#125. Audit-log the resolved
+                    // RepoDigests after a successful pull so operators see
+                    // exactly which content-addressed blob the daemon
+                    // accepted. Lets a deploy detect tag-mutation
+                    // (different digest for the same tag across pulls)
+                    // even when RequireDigestPin isn't set.
+                    try
+                    {
+                        var inspect = await _client.Images.InspectImageAsync(spec.ImageReference, ct);
+                        var resolvedDigest = inspect.RepoDigests is { Count: > 0 }
+                            ? inspect.RepoDigests[0]
+                            : "(no repo digest reported)";
+                        _logger.LogInformation(
+                            "Pulled image {Image}; resolved digest: {Digest}",
+                            spec.ImageReference, resolvedDigest);
+                    }
+                    catch (Exception inspectEx)
+                    {
+                        // Best-effort; never fail provisioning because the
+                        // audit lookup didn't pan out.
+                        _logger.LogDebug(inspectEx,
+                            "Could not inspect resolved digest for {Image}", spec.ImageReference);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/Andy.Containers/Validation/OciReferenceValidator.cs
+++ b/src/Andy.Containers/Validation/OciReferenceValidator.cs
@@ -67,4 +67,38 @@ public static partial class OciReferenceValidator
                 paramName);
         }
     }
+
+    /// <summary>
+    /// True when <paramref name="reference"/> includes a content-addressed
+    /// digest (e.g. <c>name@sha256:abc...</c>). A digest-pinned reference
+    /// is immune to mutable-tag substitution: the daemon refuses to pull
+    /// any blob whose hash doesn't match.
+    /// </summary>
+    /// <remarks>
+    /// rivoli-ai/andy-containers#125. Used by
+    /// <c>Containers:Image:RequireDigestPin</c> in
+    /// <c>ContainerOrchestrationService</c> to reject unpinned refs in
+    /// strict-mode deployments. Doesn't re-validate the overall reference
+    /// structure (<see cref="IsValid"/> covers that) — only checks that
+    /// the canonical <c>@algorithm:hex</c> discriminator is present and
+    /// well-formed.
+    /// </remarks>
+    public static bool IsDigestPinned(string? reference)
+    {
+        if (string.IsNullOrWhiteSpace(reference)) return false;
+        var atIdx = reference.LastIndexOf('@');
+        if (atIdx < 0 || atIdx == reference.Length - 1) return false;
+
+        var digestPart = reference.AsSpan(atIdx + 1);
+        var colonIdx = digestPart.IndexOf(':');
+        if (colonIdx <= 0 || colonIdx == digestPart.Length - 1) return false;
+
+        // Hex part must be at least one char and contain only hex.
+        var hex = digestPart[(colonIdx + 1)..];
+        foreach (var c in hex)
+        {
+            if (!Uri.IsHexDigit(c)) return false;
+        }
+        return true;
+    }
 }

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTests.cs
@@ -816,6 +816,25 @@ public class ContainerOrchestrationServiceTests : IDisposable
             config, new Mock<ILogger<ContainerOrchestrationService>>().Object);
     }
 
+    /// <summary>
+    /// rivoli-ai/andy-containers#125. Builds a service with strict
+    /// digest pinning enabled. Strict-mode operators flip this on
+    /// in production deployments to refuse mutable-tag images.
+    /// </summary>
+    private ContainerOrchestrationService BuildServiceWithDigestPinRequired()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Containers:Image:RequireDigestPin"] = "true"
+            })
+            .Build();
+        return new ContainerOrchestrationService(
+            _db, _mockRouting.Object, _mockFactory.Object, _queue,
+            _mockProbeService.Object, new Mock<IApiKeyService>().Object,
+            config, new Mock<ILogger<ContainerOrchestrationService>>().Object);
+    }
+
     private async Task SeedContainersFor(string ownerId, int count, ContainerStatus status, ContainerTemplate template, InfrastructureProvider provider)
     {
         for (var i = 0; i < count; i++)
@@ -1240,5 +1259,123 @@ public class ContainerOrchestrationServiceTests : IDisposable
         _db.Workspaces.Add(workspace);
         await _db.SaveChangesAsync();
         return workspace;
+    }
+
+    // rivoli-ai/andy-containers#125 — RequireDigestPin enforcement -------
+
+    [Fact]
+    public async Task CreateContainer_RequireDigestPin_RejectsTaggedImage()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+        // Default template seed uses `ubuntu:24.04` — a mutable tag.
+        var service = BuildServiceWithDigestPinRequired();
+
+        var act = () => service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "tagged",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+        }, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ArgumentException>();
+        ex.Which.Message.Should().Contain("RequireDigestPin",
+            "the error must name the flag so operators know which knob to flip or which template to fix");
+        ex.Which.Message.Should().Contain("ubuntu:24.04",
+            "the error must echo the offending image so operators can self-correct");
+
+        _queue.Reader.TryRead(out _).Should().BeFalse(
+            "strict-mode rejection must short-circuit before any provisioning is enqueued");
+    }
+
+    [Fact]
+    public async Task CreateContainer_RequireDigestPin_AcceptsDigestPinnedImage()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+        // Pin the template to a digest. Strict mode must not reject this.
+        template.BaseImage = "ubuntu@sha256:1a2b3c4d5e6f7890abcdef0123456789abcdef0123456789abcdef0123456789";
+        await _db.SaveChangesAsync();
+
+        var service = BuildServiceWithDigestPinRequired();
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "pinned",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+        }, CancellationToken.None);
+
+        _queue.Reader.TryRead(out var job).Should().BeTrue();
+        job!.TemplateBaseImage.Should().StartWith("ubuntu@sha256:");
+    }
+
+    [Fact]
+    public async Task CreateContainer_RequireDigestPin_ExemptsLocallyBuiltAndyDesktopImages()
+    {
+        // andy-desktop-* images are built from the repo's own Dockerfiles
+        // and never pulled from a registry, so a substitution attacker
+        // can't reach them. Strict mode must not refuse them.
+        var (template, provider) = await SeedTemplateAndProvider();
+        template.BaseImage = "andy-desktop-dotnet:latest";
+        await _db.SaveChangesAsync();
+
+        var service = BuildServiceWithDigestPinRequired();
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "local-build",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+        }, CancellationToken.None);
+
+        _queue.Reader.TryRead(out var job).Should().BeTrue();
+        job!.TemplateBaseImage.Should().Be("andy-desktop-dotnet:latest");
+    }
+
+    [Fact]
+    public async Task CreateContainer_RequireDigestPinDisabled_AcceptsTaggedImages()
+    {
+        // Default config (flag absent or false) must accept mutable tags
+        // — every dev workflow + the seeded templates depend on this.
+        var (template, provider) = await SeedTemplateAndProvider();
+
+        await _service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "default",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+        }, CancellationToken.None);
+
+        _queue.Reader.TryRead(out var job).Should().BeTrue(
+            "default config must accept tagged images — strict mode is opt-in");
+        job!.TemplateBaseImage.Should().Be(template.BaseImage);
+    }
+
+    [Fact]
+    public async Task CreateContainer_RequireDigestPin_AppliesAfterProfileResolution()
+    {
+        // X4: a bound profile's BaseImageRef wins over the template's
+        // BaseImage. Strict mode must check the *resolved* image — a
+        // tagged profile must be rejected even when the underlying
+        // template happens to be digest-pinned.
+        var (template, provider) = await SeedTemplateAndProvider();
+        template.BaseImage = "ubuntu@sha256:1a2b3c4d5e6f7890abcdef0123456789abcdef0123456789abcdef0123456789";
+        var profile = await SeedProfile(
+            "headless-container", EnvironmentKind.HeadlessContainer,
+            "ghcr.io/rivoli-ai/andy-headless:latest");
+        await _db.SaveChangesAsync();
+
+        var service = BuildServiceWithDigestPinRequired();
+
+        var act = () => service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "profile-tagged",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            EnvironmentProfileId = profile.Id,
+        }, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ArgumentException>();
+        ex.Which.Message.Should().Contain("ghcr.io/rivoli-ai/andy-headless:latest",
+            "the resolved (profile) image is the one strict mode must check");
     }
 }

--- a/tests/Andy.Containers.Tests/Validation/OciReferenceValidatorTests.cs
+++ b/tests/Andy.Containers.Tests/Validation/OciReferenceValidatorTests.cs
@@ -85,4 +85,37 @@ public class OciReferenceValidatorTests
         act.Should().Throw<ArgumentException>()
             .Which.ParamName.Should().Be("templateBaseImage");
     }
+
+    // rivoli-ai/andy-containers#125 — IsDigestPinned ----------------------
+
+    [Theory]
+    [InlineData("ubuntu@sha256:1a2b3c4d5e6f7890abcdef0123456789abcdef0123456789abcdef0123456789")]
+    [InlineData("ghcr.io/rivoli-ai/andy:1.0@sha256:abcdef0123456789")]
+    [InlineData("name@sha512:abcdef00")]
+    public void IsDigestPinned_AcceptsDigestPinnedRefs(string reference)
+    {
+        OciReferenceValidator.IsDigestPinned(reference).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("ubuntu")]
+    [InlineData("ubuntu:24.04")]
+    [InlineData("ghcr.io/rivoli-ai/andy:latest")]
+    [InlineData("registry.rivoli.ai:5000/team/repo:v1.2.3")]
+    [InlineData("ubuntu@")]                              // bare @
+    [InlineData("ubuntu@:abc")]                          // missing algorithm
+    [InlineData("ubuntu@sha256:")]                       // empty hex
+    [InlineData("ubuntu@sha256:notHexChars$$$")]         // non-hex
+    public void IsDigestPinned_RejectsUnpinnedOrMalformed(string reference)
+    {
+        OciReferenceValidator.IsDigestPinned(reference).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDigestPinned_NullOrBlank_ReturnsFalse()
+    {
+        OciReferenceValidator.IsDigestPinned(null).Should().BeFalse();
+        OciReferenceValidator.IsDigestPinned("").Should().BeFalse();
+        OciReferenceValidator.IsDigestPinned("   ").Should().BeFalse();
+    }
 }


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#125

## Finding

\`DockerInfrastructureProvider.CreateImageAsync\` pulls whatever tag the template names; the seeded templates use \`:latest\`. No digest enforcement, no signature verification. A registry-side substitution would be silently accepted.

## Pragmatic-minimum fix

Delivers the security value without forcing dev workflows to chase digests for every template.

- **\`OciReferenceValidator.IsDigestPinned(ref)\`** — pure check for a well-formed \`@algorithm:hex\` discriminator. No I/O.
- **\`Containers:Image:RequireDigestPin\`** config flag (default \`false\`). When set, \`ContainerOrchestrationService.CreateContainerAsync\` rejects the request before any pull happens unless the **resolved** image (after X4 profile/template resolution) is digest-pinned. The error names the offending image and the flag so operators can self-correct.
- **Locally-built \`andy-desktop-*\` images are exempt** — built from the repo's own Dockerfiles, never pulled from a registry, so a substitution attacker can't reach them.
- **Audit log**: after a successful \`CreateImageAsync\`, the daemon's resolved \`RepoDigests\` lands in a log line. Best-effort; never fails provisioning if the inspect lookup doesn't pan out. Lets non-strict deploys detect tag mutation across pulls via log diffing.

## What's deliberately *not* in this PR

- **DB-backed digest cache + TOFU pin-on-first-use** — more state and a schema change than warranted; operators who want pinning use a digest in their template directly.
- **cosign / notation signature verification** — requires key-management + trust-policy infra; separate story.
- **Changing the seeded templates** — the flag is opt-in; strict-mode operators pin templates themselves so dev workflows that depend on \`:latest\` keep working.

## Test plan

- [x] 11 \`IsDigestPinned\` cases — accepts canonical digest refs, rejects unpinned tags + bare \`@\` + missing algorithm + empty hex + non-hex.
- [x] 5 \`RequireDigestPin\` orchestration cases — rejects tagged image, accepts digest-pinned image, exempts \`andy-desktop-*\`, default config still accepts tags (back-compat for dev), strict mode applies *after* profile resolution (catches a tagged profile even when the template is pinned).
- [x] Full unit suite: **1232 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)