### PR TITLE
Workspace CLI: list / get / create / delete (#189)

### DIFF
--- a/src/Andy.Containers.Cli/Commands/WorkspaceCommands.cs
+++ b/src/Andy.Containers.Cli/Commands/WorkspaceCommands.cs
@@ -1,0 +1,239 @@
+using System.CommandLine;
+using System.Text.Json;
+using Andy.Containers.Cli.Formatting;
+using Andy.Containers.Client;
+using Spectre.Console;
+
+namespace Andy.Containers.Cli.Commands;
+
+/// <summary>
+/// rivoli-ai/andy-containers#189. Wraps the <c>/api/workspaces</c>
+/// surface (list / get / create / delete). Update is intentionally
+/// omitted — operators rarely need it from CLI and the
+/// <c>UpdateWorkspaceDto</c> doesn't expose the governance fields
+/// anyway (X5 keeps the EnvironmentProfile binding immutable).
+/// </summary>
+public static class WorkspaceCommands
+{
+    private static readonly JsonSerializerOptions JsonOut = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+
+    public static Command Create()
+    {
+        var cmd = new Command("workspace", "Manage workspaces");
+        cmd.AddCommand(CreateListCommand());
+        cmd.AddCommand(CreateGetCommand());
+        cmd.AddCommand(CreateCreateCommand());
+        cmd.AddCommand(CreateDeleteCommand());
+        return cmd;
+    }
+
+    private static Command CreateListCommand()
+    {
+        var cmd = new Command("list", "List workspaces");
+        var ownerOpt = new Option<string?>("--owner", "Filter by owner id (admin only).");
+        var orgOpt = new Option<string?>("--organization", "Filter by organization id (GUID).");
+        var formatOpt = OutputFormatOption.Create();
+        cmd.AddOption(ownerOpt);
+        cmd.AddOption(orgOpt);
+        cmd.AddOption(formatOpt);
+
+        cmd.SetHandler(async (context) =>
+        {
+            var owner = context.ParseResult.GetValueForOption(ownerOpt);
+            var orgRaw = context.ParseResult.GetValueForOption(orgOpt);
+            var format = context.ParseResult.GetValueForOption(formatOpt);
+            var ct = context.GetCancellationToken();
+
+            Guid? orgId = null;
+            if (!string.IsNullOrWhiteSpace(orgRaw))
+            {
+                if (!Guid.TryParse(orgRaw, out var parsed) || parsed == Guid.Empty)
+                {
+                    AnsiConsole.MarkupLine("[red]--organization must be a non-empty GUID.[/]");
+                    context.ExitCode = 2;
+                    return;
+                }
+                orgId = parsed;
+            }
+
+            var client = ClientFactory.Create();
+            var page = await client.ListWorkspacesAsync(owner, orgId, ct: ct);
+
+            if (format == OutputFormat.Json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(page.Items, JsonOut));
+                return;
+            }
+
+            TableFormatter.PrintWorkspaceTable(page.Items);
+            if (page.TotalCount > page.Items.Length)
+            {
+                AnsiConsole.MarkupLine(
+                    $"[dim]Showing {page.Items.Length} of {page.TotalCount} workspace(s).[/]");
+            }
+        });
+
+        return cmd;
+    }
+
+    private static Command CreateGetCommand()
+    {
+        var cmd = new Command("get", "Show workspace details");
+        var idArg = new Argument<string>("id", "Workspace id (GUID).");
+        var formatOpt = OutputFormatOption.Create();
+        cmd.AddArgument(idArg);
+        cmd.AddOption(formatOpt);
+
+        cmd.SetHandler(async (context) =>
+        {
+            var id = context.ParseResult.GetValueForArgument(idArg);
+            var format = context.ParseResult.GetValueForOption(formatOpt);
+            var ct = context.GetCancellationToken();
+
+            var client = ClientFactory.Create();
+            ContainersClient.WorkspaceDto ws;
+            try
+            {
+                ws = await client.GetWorkspaceAsync(id, ct);
+            }
+            catch (ContainersApiException ex)
+                when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                AnsiConsole.MarkupLine($"[red]Workspace '{Markup.Escape(id)}' not found.[/]");
+                context.ExitCode = 4;
+                return;
+            }
+
+            if (format == OutputFormat.Json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(ws, JsonOut));
+                return;
+            }
+
+            TableFormatter.PrintWorkspaceDetail(ws);
+        });
+
+        return cmd;
+    }
+
+    private static Command CreateCreateCommand()
+    {
+        var cmd = new Command("create", "Create a workspace");
+        var nameArg = new Argument<string>("name", "Workspace name.");
+        var profileOpt = new Option<string>(
+            "--environment-profile",
+            "EnvironmentProfile slug (e.g. 'headless-container'). Required (X5 governance anchor).")
+        {
+            IsRequired = true,
+        };
+        var descOpt = new Option<string?>("--description", "Optional description.");
+        var orgOpt = new Option<string?>("--organization", "Optional organization id (GUID).");
+        var teamOpt = new Option<string?>("--team", "Optional team id (GUID).");
+        var gitUrlOpt = new Option<string?>("--git-repo", "Optional primary git repository URL.");
+        var gitBranchOpt = new Option<string?>("--branch", "Optional git branch.");
+        var formatOpt = OutputFormatOption.Create();
+
+        cmd.AddArgument(nameArg);
+        cmd.AddOption(profileOpt);
+        cmd.AddOption(descOpt);
+        cmd.AddOption(orgOpt);
+        cmd.AddOption(teamOpt);
+        cmd.AddOption(gitUrlOpt);
+        cmd.AddOption(gitBranchOpt);
+        cmd.AddOption(formatOpt);
+
+        cmd.SetHandler(async (context) =>
+        {
+            var name = context.ParseResult.GetValueForArgument(nameArg);
+            var profile = context.ParseResult.GetValueForOption(profileOpt)!;
+            var description = context.ParseResult.GetValueForOption(descOpt);
+            var orgRaw = context.ParseResult.GetValueForOption(orgOpt);
+            var teamRaw = context.ParseResult.GetValueForOption(teamOpt);
+            var gitUrl = context.ParseResult.GetValueForOption(gitUrlOpt);
+            var gitBranch = context.ParseResult.GetValueForOption(gitBranchOpt);
+            var format = context.ParseResult.GetValueForOption(formatOpt);
+            var ct = context.GetCancellationToken();
+
+            Guid? ParseOptionalGuid(string? raw, string flagName)
+            {
+                if (string.IsNullOrWhiteSpace(raw)) return null;
+                if (!Guid.TryParse(raw, out var g) || g == Guid.Empty)
+                {
+                    AnsiConsole.MarkupLine($"[red]{flagName} must be a non-empty GUID.[/]");
+                    context.ExitCode = 2;
+                    return null;
+                }
+                return g;
+            }
+
+            var orgId = ParseOptionalGuid(orgRaw, "--organization");
+            if (context.ExitCode != 0) return;
+            var teamId = ParseOptionalGuid(teamRaw, "--team");
+            if (context.ExitCode != 0) return;
+
+            var request = new ContainersClient.CreateWorkspaceRequest(
+                name, description, orgId, teamId, gitUrl, gitBranch, profile);
+
+            var client = ClientFactory.Create();
+            ContainersClient.WorkspaceDto ws;
+            try
+            {
+                ws = await client.CreateWorkspaceAsync(request, ct);
+            }
+            catch (ContainersApiException ex)
+                when (ex.StatusCode == System.Net.HttpStatusCode.BadRequest)
+            {
+                AnsiConsole.MarkupLine(
+                    $"[red]Bad request:[/] {Markup.Escape(ex.ResponseBody ?? ex.Message)}");
+                context.ExitCode = 2;
+                return;
+            }
+
+            AnsiConsole.MarkupLine(
+                $"[green]Created workspace[/] [bold]{Markup.Escape(ws.Name)}[/] ([dim]{ws.Id}[/])");
+
+            if (format == OutputFormat.Json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(ws, JsonOut));
+                return;
+            }
+
+            TableFormatter.PrintWorkspaceDetail(ws);
+        });
+
+        return cmd;
+    }
+
+    private static Command CreateDeleteCommand()
+    {
+        var cmd = new Command("delete", "Delete a workspace");
+        var idArg = new Argument<string>("id", "Workspace id (GUID).");
+        cmd.AddArgument(idArg);
+
+        cmd.SetHandler(async (context) =>
+        {
+            var id = context.ParseResult.GetValueForArgument(idArg);
+            var ct = context.GetCancellationToken();
+
+            var client = ClientFactory.Create();
+            try
+            {
+                await client.DeleteWorkspaceAsync(id, ct);
+            }
+            catch (ContainersApiException ex)
+                when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                AnsiConsole.MarkupLine($"[red]Workspace '{Markup.Escape(id)}' not found.[/]");
+                context.ExitCode = 4;
+                return;
+            }
+
+            AnsiConsole.MarkupLine($"[green]Deleted workspace[/] [dim]{Markup.Escape(id)}[/]");
+        });
+
+        return cmd;
+    }
+}

--- a/src/Andy.Containers.Cli/Formatting/TableFormatter.cs
+++ b/src/Andy.Containers.Cli/Formatting/TableFormatter.cs
@@ -244,4 +244,70 @@ public static class TableFormatter
         AuditMode.None => "[dim]None[/]",
         _ => mode.ToString(),
     };
+
+    // rivoli-ai/andy-containers#189. Workspace catalog views.
+
+    public static void PrintWorkspaceTable(IReadOnlyList<ContainersClient.WorkspaceDto> workspaces)
+    {
+        if (workspaces.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[dim]No workspaces found.[/]");
+            return;
+        }
+
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .AddColumn("Name")
+            .AddColumn("Status")
+            .AddColumn("Owner")
+            .AddColumn("Profile")
+            .AddColumn("Branch")
+            .AddColumn("ID");
+
+        foreach (var w in workspaces)
+        {
+            var statusColor = w.Status switch
+            {
+                "Active" => "green",
+                "Suspended" => "yellow",
+                "Archived" => "dim",
+                _ => "white",
+            };
+            table.AddRow(
+                Markup.Escape(w.Name),
+                $"[{statusColor}]{w.Status}[/]",
+                Markup.Escape(w.OwnerId),
+                w.EnvironmentProfileId is { } pid ? Markup.Escape(pid.ToString()[..8]) : "[dim]—[/]",
+                w.GitBranch is { } b ? Markup.Escape(b) : "[dim]—[/]",
+                w.Id.ToString()[..8]);
+        }
+
+        AnsiConsole.Write(table);
+    }
+
+    public static void PrintWorkspaceDetail(ContainersClient.WorkspaceDto w)
+    {
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .HideHeaders()
+            .AddColumn("")
+            .AddColumn("");
+
+        table.AddRow("Id", w.Id.ToString());
+        table.AddRow("Name", Markup.Escape(w.Name));
+        if (!string.IsNullOrEmpty(w.Description)) table.AddRow("Description", Markup.Escape(w.Description));
+        table.AddRow("Status", w.Status);
+        table.AddRow("Owner", Markup.Escape(w.OwnerId));
+        if (w.OrganizationId is { } o) table.AddRow("Organization", o.ToString());
+        if (w.TeamId is { } t) table.AddRow("Team", t.ToString());
+        if (w.EnvironmentProfileId is { } p) table.AddRow("Environment profile", p.ToString());
+        if (w.DefaultContainerId is { } c) table.AddRow("Default container", c.ToString());
+        if (!string.IsNullOrEmpty(w.GitRepositoryUrl)) table.AddRow("Git repository", Markup.Escape(w.GitRepositoryUrl));
+        if (!string.IsNullOrEmpty(w.GitBranch)) table.AddRow("Git branch", Markup.Escape(w.GitBranch));
+        table.AddRow("Created", w.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss"));
+        if (w.UpdatedAt is { } u) table.AddRow("Updated", u.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss"));
+        if (w.LastAccessedAt is { } a) table.AddRow("Last accessed", a.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss"));
+
+        AnsiConsole.Write(table);
+    }
 }

--- a/src/Andy.Containers.Cli/Program.cs
+++ b/src/Andy.Containers.Cli/Program.cs
@@ -37,11 +37,8 @@ rootCommand.AddCommand(RunCommands.Create());
 // Environment-profile catalog (X7 — rivoli-ai/andy-containers#97).
 rootCommand.AddCommand(EnvironmentCommands.Create());
 
-// Workspace commands (stubs for future)
-var workspaceCommand = new Command("workspace", "Manage workspaces");
-workspaceCommand.AddCommand(new Command("create", "Create a workspace"));
-workspaceCommand.AddCommand(new Command("list", "List workspaces"));
-rootCommand.AddCommand(workspaceCommand);
+// Workspace commands (rivoli-ai/andy-containers#189).
+rootCommand.AddCommand(WorkspaceCommands.Create());
 
 // Template commands (stubs for future)
 var templatesCommand = new Command("templates", "Manage template catalog");

--- a/src/Andy.Containers.Client/ContainersClient.cs
+++ b/src/Andy.Containers.Client/ContainersClient.cs
@@ -144,6 +144,51 @@ public sealed class ContainersClient
         return (await r.Content.ReadFromJsonAsync<EnvironmentProfileDto>(_json, ct))!;
     }
 
+    // Workspaces (rivoli-ai/andy-containers#189).
+    //
+    // The controller returns the Workspace EF entity directly, but the
+    // CLI only needs a small shape (name, owner, status, profile id,
+    // git binding, timestamps). WorkspaceDto pins that subset so a
+    // future EF schema change on the server doesn't silently change
+    // the client's deserialisation surface.
+
+    public async Task<PaginatedResult<WorkspaceDto>> ListWorkspacesAsync(
+        string? ownerId = null, Guid? organizationId = null,
+        int? skip = null, int? take = null, CancellationToken ct = default)
+    {
+        var query = new List<string>();
+        if (!string.IsNullOrWhiteSpace(ownerId)) query.Add($"ownerId={Uri.EscapeDataString(ownerId)}");
+        if (organizationId.HasValue) query.Add($"organizationId={organizationId.Value}");
+        if (skip.HasValue) query.Add($"skip={skip.Value}");
+        if (take.HasValue) query.Add($"take={take.Value}");
+        var url = "api/workspaces" + (query.Count > 0 ? "?" + string.Join("&", query) : "");
+
+        var r = await _http.GetAsync(url, ct);
+        await EnsureSuccessAsync(r, ct);
+        return (await r.Content.ReadFromJsonAsync<PaginatedResult<WorkspaceDto>>(_json, ct))!;
+    }
+
+    public async Task<WorkspaceDto> GetWorkspaceAsync(string id, CancellationToken ct = default)
+    {
+        var r = await _http.GetAsync($"api/workspaces/{id}", ct);
+        await EnsureSuccessAsync(r, ct);
+        return (await r.Content.ReadFromJsonAsync<WorkspaceDto>(_json, ct))!;
+    }
+
+    public async Task<WorkspaceDto> CreateWorkspaceAsync(
+        CreateWorkspaceRequest request, CancellationToken ct = default)
+    {
+        var r = await _http.PostAsJsonAsync("api/workspaces", request, _json, ct);
+        await EnsureSuccessAsync(r, ct);
+        return (await r.Content.ReadFromJsonAsync<WorkspaceDto>(_json, ct))!;
+    }
+
+    public async Task DeleteWorkspaceAsync(string id, CancellationToken ct = default)
+    {
+        var r = await _http.DeleteAsync($"api/workspaces/{id}", ct);
+        await EnsureSuccessAsync(r, ct);
+    }
+
     public async Task<RunDto> CreateRunAsync(CreateRunRequest request, CancellationToken ct = default)
     {
         var r = await _http.PostAsJsonAsync("api/runs", request, _json, ct);
@@ -246,6 +291,34 @@ public sealed class ContainersClient
         double MemoryPercent, long DiskUsageBytes, long DiskLimitBytes, double DiskPercent);
     public record ConnectionInfoDto(string? IpAddress, string? SshEndpoint, string? IdeEndpoint,
         string? VncEndpoint, Dictionary<string, int>? PortMappings);
+
+    // Workspaces (rivoli-ai/andy-containers#189). Slim wire shape pinned
+    // here so a server-side EF schema change on Workspace doesn't ripple
+    // into the CLI silently. Add fields when a CLI command needs them.
+    public record WorkspaceDto(
+        Guid Id,
+        string Name,
+        string? Description,
+        string OwnerId,
+        Guid? OrganizationId,
+        Guid? TeamId,
+        string Status,
+        Guid? DefaultContainerId,
+        string? GitRepositoryUrl,
+        string? GitBranch,
+        Guid? EnvironmentProfileId,
+        DateTime CreatedAt,
+        DateTime? UpdatedAt,
+        DateTime? LastAccessedAt);
+
+    public record CreateWorkspaceRequest(
+        string Name,
+        string? Description,
+        Guid? OrganizationId,
+        Guid? TeamId,
+        string? GitRepositoryUrl,
+        string? GitBranch,
+        string EnvironmentProfileCode);
 }
 
 public sealed class ContainersApiException : HttpRequestException

--- a/tests/Andy.Containers.Client.Tests/ContainersClientTests.cs
+++ b/tests/Andy.Containers.Client.Tests/ContainersClientTests.cs
@@ -304,4 +304,138 @@ public class ContainersClientTests
         await act.Should().ThrowAsync<ContainersApiException>()
             .Where(e => e.StatusCode == HttpStatusCode.NotFound);
     }
+
+    // rivoli-ai/andy-containers#189. Workspace client wrappers. Same
+    // pattern as the environment cases above: pin URL shapes and
+    // round-tripping so a future regression breaks here, not in the
+    // CLI integration.
+
+    [Fact]
+    public async Task ListWorkspacesAsync_NoFilters_HitsBareCollectionUrl()
+    {
+        var handler = new CannedHandler(
+            """{"items":[],"totalCount":0}""", "application/json");
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://example.local/") };
+        var client = new ContainersClient(http);
+
+        var page = await client.ListWorkspacesAsync();
+
+        page.TotalCount.Should().Be(0);
+        handler.LastMethod.Should().Be(HttpMethod.Get);
+        handler.LastRequestUri!.AbsolutePath.Should().Be("/api/workspaces");
+        handler.LastRequestUri.Query.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListWorkspacesAsync_WithFilters_AppendsQueryParams()
+    {
+        var handler = new CannedHandler(
+            """{"items":[],"totalCount":0}""", "application/json");
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://example.local/") };
+        var client = new ContainersClient(http);
+
+        var orgId = Guid.NewGuid();
+        await client.ListWorkspacesAsync(ownerId: "alice user", organizationId: orgId, take: 50);
+
+        var query = handler.LastRequestUri!.Query;
+        query.Should().Contain("ownerId=alice%20user", "spaces in user-supplied owner must URL-encode");
+        query.Should().Contain($"organizationId={orgId}");
+        query.Should().Contain("take=50");
+    }
+
+    [Fact]
+    public async Task GetWorkspaceAsync_HitsByIdRoute_AndDeserialises()
+    {
+        var id = Guid.NewGuid();
+        var body = $$"""
+            {
+              "id": "{{id}}",
+              "name": "demo",
+              "description": "test ws",
+              "ownerId": "alice",
+              "organizationId": null,
+              "teamId": null,
+              "status": "Active",
+              "defaultContainerId": null,
+              "gitRepositoryUrl": null,
+              "gitBranch": null,
+              "environmentProfileId": "11111111-2222-3333-4444-555555555555",
+              "createdAt": "2026-04-28T00:00:00Z",
+              "updatedAt": null,
+              "lastAccessedAt": null
+            }
+            """;
+        var handler = new CannedHandler(body, "application/json");
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://example.local/") };
+        var client = new ContainersClient(http);
+
+        var ws = await client.GetWorkspaceAsync(id.ToString());
+
+        handler.LastRequestUri!.AbsolutePath.Should().Be($"/api/workspaces/{id}");
+        ws.Name.Should().Be("demo");
+        ws.Status.Should().Be("Active");
+        ws.EnvironmentProfileId.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CreateWorkspaceAsync_PostsRequest_AndReturnsDto()
+    {
+        var newId = Guid.NewGuid();
+        var responseBody = $$"""
+            {
+              "id": "{{newId}}",
+              "name": "new",
+              "description": null,
+              "ownerId": "alice",
+              "organizationId": null,
+              "teamId": null,
+              "status": "Active",
+              "defaultContainerId": null,
+              "gitRepositoryUrl": null,
+              "gitBranch": null,
+              "environmentProfileId": null,
+              "createdAt": "2026-04-28T00:00:00Z",
+              "updatedAt": null,
+              "lastAccessedAt": null
+            }
+            """;
+        var handler = new CannedHandler(responseBody, "application/json");
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://example.local/") };
+        var client = new ContainersClient(http);
+
+        var request = new ContainersClient.CreateWorkspaceRequest(
+            "new", null, null, null, null, null, "headless-container");
+        var ws = await client.CreateWorkspaceAsync(request);
+
+        handler.LastMethod.Should().Be(HttpMethod.Post);
+        handler.LastRequestUri!.AbsolutePath.Should().Be("/api/workspaces");
+        ws.Id.Should().Be(newId);
+    }
+
+    [Fact]
+    public async Task DeleteWorkspaceAsync_HitsByIdRoute()
+    {
+        var id = Guid.NewGuid();
+        var handler = new CannedHandler("", "application/json", HttpStatusCode.NoContent);
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://example.local/") };
+        var client = new ContainersClient(http);
+
+        await client.DeleteWorkspaceAsync(id.ToString());
+
+        handler.LastMethod.Should().Be(HttpMethod.Delete);
+        handler.LastRequestUri!.AbsolutePath.Should().Be($"/api/workspaces/{id}");
+    }
+
+    [Fact]
+    public async Task DeleteWorkspaceAsync_404_ThrowsContainersApiException()
+    {
+        var handler = new CannedHandler("", "application/json", HttpStatusCode.NotFound);
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://example.local/") };
+        var client = new ContainersClient(http);
+
+        var act = async () => await client.DeleteWorkspaceAsync(Guid.NewGuid().ToString());
+
+        await act.Should().ThrowAsync<ContainersApiException>()
+            .Where(e => e.StatusCode == HttpStatusCode.NotFound);
+    }
 }


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#189 — first parity-audit follow-up after #76.

## Summary

Replaces the \`workspace\` stub in \`Program.cs\` with real subcommands wrapping \`/api/workspaces\`:

\`\`\`
andy-containers-cli workspace list [--owner ...] [--organization ...] [--format table|json]
andy-containers-cli workspace get <id>           [--format table|json]
andy-containers-cli workspace create <name> --environment-profile <slug> [...]
andy-containers-cli workspace delete <id>
\`\`\`

Architecture mirrors AP9 (\`RunCommands\`) and X7 (\`EnvironmentCommands\`):

- **\`ContainersClient\`** gains \`ListWorkspacesAsync\` / \`GetWorkspaceAsync\` / \`CreateWorkspaceAsync\` / \`DeleteWorkspaceAsync\`. Slim \`WorkspaceDto\` + \`CreateWorkspaceRequest\` records pinned in the client so a server-side EF schema change on \`Workspace\` doesn't silently change the client's deserialisation surface.
- **\`WorkspaceCommands.cs\`** wires the tree. \`create\` takes the X5-required \`--environment-profile\` option; bad GUIDs in \`--organization\` / \`--team\` exit with code 2; not-found on get/delete exits with code 4 (Epic AN contract).
- **\`TableFormatter\`** gains \`PrintWorkspaceTable\` + \`PrintWorkspaceDetail\`. Status colour-coded (Active green / Suspended yellow / Archived dim); profile id and branch render as "—" when null.

\`update\` is intentionally omitted — operators rarely need it from CLI and \`UpdateWorkspaceDto\` doesn't expose the governance fields anyway (X5 keeps the EnvironmentProfile binding immutable).

## Test plan

- [x] **6 new \`ContainersClientTests\`** cases via the existing \`CannedHandler\`: bare URL, query-param encoding (spaces URL-escape), get round-trip, post round-trip, delete URL + method, 404 → \`ContainersApiException\`.
- [x] CLI \`workspace --help\` shows all four subcommands.
- [x] Full unit suite: **1261 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)