### PR TITLE
Template CLI: list / info / definition (#190)

### DIFF
--- a/src/Andy.Containers.Cli/Commands/TemplateCommands.cs
+++ b/src/Andy.Containers.Cli/Commands/TemplateCommands.cs
@@ -1,0 +1,172 @@
+using System.CommandLine;
+using System.Text.Json;
+using Andy.Containers.Cli.Formatting;
+using Andy.Containers.Client;
+using Spectre.Console;
+
+namespace Andy.Containers.Cli.Commands;
+
+/// <summary>
+/// rivoli-ai/andy-containers#190. Read-only browse over the
+/// <c>/api/templates</c> catalog. CRUD + publish + image-build
+/// remain admin-only via the REST/UI surface.
+/// </summary>
+public static class TemplateCommands
+{
+    private static readonly JsonSerializerOptions JsonOut = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+
+    public static Command Create()
+    {
+        var cmd = new Command("templates", "Browse the container template catalog");
+        cmd.AddCommand(CreateListCommand());
+        cmd.AddCommand(CreateInfoCommand());
+        cmd.AddCommand(CreateDefinitionCommand());
+        return cmd;
+    }
+
+    private static Command CreateListCommand()
+    {
+        var cmd = new Command("list", "List templates");
+        var scopeOpt = new Option<string?>(
+            "--scope", "Filter by scope: Global, Organization, Team, User.");
+        var searchOpt = new Option<string?>(
+            "--search", "Filter by name / description / code substring.");
+        var formatOpt = OutputFormatOption.Create();
+        cmd.AddOption(scopeOpt);
+        cmd.AddOption(searchOpt);
+        cmd.AddOption(formatOpt);
+
+        cmd.SetHandler(async (context) =>
+        {
+            var scope = context.ParseResult.GetValueForOption(scopeOpt);
+            var search = context.ParseResult.GetValueForOption(searchOpt);
+            var format = context.ParseResult.GetValueForOption(formatOpt);
+            var ct = context.GetCancellationToken();
+
+            var client = ClientFactory.Create();
+            var page = await client.ListTemplatesAsync(scope, search, ct: ct);
+
+            if (format == OutputFormat.Json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(page.Items, JsonOut));
+                return;
+            }
+
+            TableFormatter.PrintTemplateTable(page.Items);
+            if (page.TotalCount > page.Items.Length)
+            {
+                AnsiConsole.MarkupLine(
+                    $"[dim]Showing {page.Items.Length} of {page.TotalCount} template(s).[/]");
+            }
+        });
+
+        return cmd;
+    }
+
+    private static Command CreateInfoCommand()
+    {
+        var cmd = new Command("info", "Show template details");
+        var codeArg = new Argument<string>("code", "Template code (slug, e.g. 'andy-cli-dev').");
+        var formatOpt = OutputFormatOption.Create();
+        cmd.AddArgument(codeArg);
+        cmd.AddOption(formatOpt);
+
+        cmd.SetHandler(async (context) =>
+        {
+            var code = context.ParseResult.GetValueForArgument(codeArg);
+            var format = context.ParseResult.GetValueForOption(formatOpt);
+            var ct = context.GetCancellationToken();
+
+            var client = ClientFactory.Create();
+            ContainersClient.TemplateDetailDto t;
+            try
+            {
+                t = await client.GetTemplateByCodeAsync(code, ct);
+            }
+            catch (ContainersApiException ex)
+                when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                AnsiConsole.MarkupLine($"[red]Template '{Markup.Escape(code)}' not found.[/]");
+                context.ExitCode = 4;
+                return;
+            }
+
+            if (format == OutputFormat.Json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(t, JsonOut));
+                return;
+            }
+
+            TableFormatter.PrintTemplateDetail(t);
+        });
+
+        return cmd;
+    }
+
+    private static Command CreateDefinitionCommand()
+    {
+        var cmd = new Command("definition",
+            "Print the template's YAML definition. Pipe into editors / yq / etc.");
+        var codeArg = new Argument<string>("code",
+            "Template code or id. Resolves to the row's id internally.");
+        cmd.AddArgument(codeArg);
+
+        cmd.SetHandler(async (context) =>
+        {
+            var codeOrId = context.ParseResult.GetValueForArgument(codeArg);
+            var ct = context.GetCancellationToken();
+
+            var client = ClientFactory.Create();
+
+            // The /definition endpoint takes an id; resolve via by-code
+            // first when the caller passed a slug. Distinguish using a
+            // GUID-parse — robust enough for the two input shapes.
+            string id;
+            if (Guid.TryParse(codeOrId, out _))
+            {
+                id = codeOrId;
+            }
+            else
+            {
+                try
+                {
+                    var t = await client.GetTemplateByCodeAsync(codeOrId, ct);
+                    id = t.Id.ToString();
+                }
+                catch (ContainersApiException ex)
+                    when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+                {
+                    AnsiConsole.MarkupLine($"[red]Template '{Markup.Escape(codeOrId)}' not found.[/]");
+                    context.ExitCode = 4;
+                    return;
+                }
+            }
+
+            ContainersClient.TemplateDefinitionDto def;
+            try
+            {
+                def = await client.GetTemplateDefinitionAsync(id, ct);
+            }
+            catch (ContainersApiException ex)
+                when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                AnsiConsole.MarkupLine($"[red]Template '{Markup.Escape(codeOrId)}' not found.[/]");
+                context.ExitCode = 4;
+                return;
+            }
+
+            // Plain Console.Write — no Spectre markup — so `... > file.yaml`
+            // captures clean YAML without ANSI escape sequences.
+            Console.Write(def.Content);
+            if (!def.Content.EndsWith('\n'))
+            {
+                Console.WriteLine();
+            }
+        });
+
+        return cmd;
+    }
+}

--- a/src/Andy.Containers.Cli/Formatting/TableFormatter.cs
+++ b/src/Andy.Containers.Cli/Formatting/TableFormatter.cs
@@ -310,4 +310,74 @@ public static class TableFormatter
 
         AnsiConsole.Write(table);
     }
+
+    // rivoli-ai/andy-containers#190. Template catalog views.
+
+    public static void PrintTemplateTable(IReadOnlyList<ContainersClient.TemplateDetailDto> templates)
+    {
+        if (templates.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[dim]No templates found.[/]");
+            return;
+        }
+
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .AddColumn("Code")
+            .AddColumn("Name")
+            .AddColumn("Version")
+            .AddColumn("Scope")
+            .AddColumn("IDE")
+            .AddColumn("GPU")
+            .AddColumn("Base image");
+
+        foreach (var t in templates)
+        {
+            var scopeColor = t.CatalogScope switch
+            {
+                "Global" => "green",
+                "Organization" => "cyan",
+                "Team" => "yellow",
+                "User" => "magenta",
+                _ => "white",
+            };
+            table.AddRow(
+                Markup.Escape(t.Code),
+                Markup.Escape(t.Name),
+                Markup.Escape(t.Version),
+                $"[{scopeColor}]{t.CatalogScope}[/]",
+                Markup.Escape(t.IdeType),
+                t.GpuRequired ? "[yellow]required[/]" : (t.GpuPreferred ? "[dim]preferred[/]" : "[dim]no[/]"),
+                Markup.Escape(t.BaseImage));
+        }
+
+        AnsiConsole.Write(table);
+    }
+
+    public static void PrintTemplateDetail(ContainersClient.TemplateDetailDto t)
+    {
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .HideHeaders()
+            .AddColumn("")
+            .AddColumn("");
+
+        table.AddRow("Id", t.Id.ToString());
+        table.AddRow("Code", Markup.Escape(t.Code));
+        table.AddRow("Name", Markup.Escape(t.Name));
+        if (!string.IsNullOrEmpty(t.Description)) table.AddRow("Description", Markup.Escape(t.Description));
+        table.AddRow("Version", Markup.Escape(t.Version));
+        table.AddRow("Base image", Markup.Escape(t.BaseImage));
+        table.AddRow("Scope", t.CatalogScope);
+        table.AddRow("IDE type", t.IdeType);
+        table.AddRow("GPU", t.GpuRequired ? "required" : (t.GpuPreferred ? "preferred" : "not used"));
+        table.AddRow("Published", t.IsPublished ? "[green]yes[/]" : "[dim]no[/]");
+        if (t.OrganizationId is { } o) table.AddRow("Organization", o.ToString());
+        if (t.TeamId is { } tm) table.AddRow("Team", tm.ToString());
+        if (!string.IsNullOrEmpty(t.Tags)) table.AddRow("Tags", Markup.Escape(t.Tags));
+        table.AddRow("Created", t.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss"));
+        if (t.UpdatedAt is { } u) table.AddRow("Updated", u.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss"));
+
+        AnsiConsole.Write(table);
+    }
 }

--- a/src/Andy.Containers.Cli/Program.cs
+++ b/src/Andy.Containers.Cli/Program.cs
@@ -40,9 +40,7 @@ rootCommand.AddCommand(EnvironmentCommands.Create());
 // Workspace commands (rivoli-ai/andy-containers#189).
 rootCommand.AddCommand(WorkspaceCommands.Create());
 
-// Template commands (stubs for future)
-var templatesCommand = new Command("templates", "Manage template catalog");
-templatesCommand.AddCommand(new Command("list", "Browse template catalog"));
-rootCommand.AddCommand(templatesCommand);
+// Template commands (rivoli-ai/andy-containers#190).
+rootCommand.AddCommand(TemplateCommands.Create());
 
 return await rootCommand.InvokeAsync(args);

--- a/src/Andy.Containers.Client/ContainersClient.cs
+++ b/src/Andy.Containers.Client/ContainersClient.cs
@@ -189,6 +189,41 @@ public sealed class ContainersClient
         await EnsureSuccessAsync(r, ct);
     }
 
+    // Templates (rivoli-ai/andy-containers#190). Read-only catalog
+    // surface from the CLI. CRUD + publish + image-build remain
+    // admin-only via REST/UI; CLI covers what operators routinely
+    // script against.
+
+    public async Task<PaginatedResult<TemplateDetailDto>> ListTemplatesAsync(
+        string? scope = null, string? search = null,
+        int? skip = null, int? take = null, CancellationToken ct = default)
+    {
+        var query = new List<string>();
+        if (!string.IsNullOrWhiteSpace(scope)) query.Add($"scope={Uri.EscapeDataString(scope)}");
+        if (!string.IsNullOrWhiteSpace(search)) query.Add($"search={Uri.EscapeDataString(search)}");
+        if (skip.HasValue) query.Add($"skip={skip.Value}");
+        if (take.HasValue) query.Add($"take={take.Value}");
+        var url = "api/templates" + (query.Count > 0 ? "?" + string.Join("&", query) : "");
+
+        var r = await _http.GetAsync(url, ct);
+        await EnsureSuccessAsync(r, ct);
+        return (await r.Content.ReadFromJsonAsync<PaginatedResult<TemplateDetailDto>>(_json, ct))!;
+    }
+
+    public async Task<TemplateDetailDto> GetTemplateByCodeAsync(string code, CancellationToken ct = default)
+    {
+        var r = await _http.GetAsync($"api/templates/by-code/{Uri.EscapeDataString(code)}", ct);
+        await EnsureSuccessAsync(r, ct);
+        return (await r.Content.ReadFromJsonAsync<TemplateDetailDto>(_json, ct))!;
+    }
+
+    public async Task<TemplateDefinitionDto> GetTemplateDefinitionAsync(string id, CancellationToken ct = default)
+    {
+        var r = await _http.GetAsync($"api/templates/{id}/definition", ct);
+        await EnsureSuccessAsync(r, ct);
+        return (await r.Content.ReadFromJsonAsync<TemplateDefinitionDto>(_json, ct))!;
+    }
+
     public async Task<RunDto> CreateRunAsync(CreateRunRequest request, CancellationToken ct = default)
     {
         var r = await _http.PostAsJsonAsync("api/runs", request, _json, ct);
@@ -319,6 +354,36 @@ public sealed class ContainersClient
         string? GitRepositoryUrl,
         string? GitBranch,
         string EnvironmentProfileCode);
+
+    // Templates (rivoli-ai/andy-containers#190). Slim wire shape pinned
+    // here so a server-side EF schema change on ContainerTemplate
+    // doesn't ripple into the CLI silently. Mirrors the controller
+    // payload (entity-direct serialisation).
+    public record TemplateDetailDto(
+        Guid Id,
+        string Code,
+        string Name,
+        string? Description,
+        string Version,
+        string BaseImage,
+        string CatalogScope,
+        string IdeType,
+        bool GpuRequired,
+        bool GpuPreferred,
+        bool IsPublished,
+        Guid? OrganizationId,
+        Guid? TeamId,
+        string? Tags,
+        DateTime CreatedAt,
+        DateTime? UpdatedAt);
+
+    /// <summary>
+    /// YAML-definition envelope returned by
+    /// <c>GET /api/templates/{id}/definition</c>: <c>{ code, content }</c>
+    /// where <c>content</c> is the raw YAML (or a synthesised stand-in
+    /// when the file isn't on disk).
+    /// </summary>
+    public record TemplateDefinitionDto(string Code, string Content);
 }
 
 public sealed class ContainersApiException : HttpRequestException

--- a/tests/Andy.Containers.Client.Tests/ContainersClientTests.cs
+++ b/tests/Andy.Containers.Client.Tests/ContainersClientTests.cs
@@ -438,4 +438,106 @@ public class ContainersClientTests
         await act.Should().ThrowAsync<ContainersApiException>()
             .Where(e => e.StatusCode == HttpStatusCode.NotFound);
     }
+
+    // rivoli-ai/andy-containers#190. Template client wrappers.
+
+    [Fact]
+    public async Task ListTemplatesAsync_NoFilters_HitsBareCollectionUrl()
+    {
+        var handler = new CannedHandler(
+            """{"items":[],"totalCount":0}""", "application/json");
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://example.local/") };
+        var client = new ContainersClient(http);
+
+        var page = await client.ListTemplatesAsync();
+
+        page.TotalCount.Should().Be(0);
+        handler.LastMethod.Should().Be(HttpMethod.Get);
+        handler.LastRequestUri!.AbsolutePath.Should().Be("/api/templates");
+        handler.LastRequestUri.Query.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListTemplatesAsync_WithFilters_AppendsQueryParams()
+    {
+        var handler = new CannedHandler(
+            """{"items":[],"totalCount":0}""", "application/json");
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://example.local/") };
+        var client = new ContainersClient(http);
+
+        await client.ListTemplatesAsync(scope: "Global", search: "andy cli", take: 50);
+
+        var query = handler.LastRequestUri!.Query;
+        query.Should().Contain("scope=Global");
+        query.Should().Contain("search=andy%20cli", "spaces in --search must URL-encode");
+        query.Should().Contain("take=50");
+    }
+
+    [Fact]
+    public async Task GetTemplateByCodeAsync_HitsByCodeRoute_AndDeserialises()
+    {
+        var id = Guid.NewGuid();
+        var body = $$"""
+            {
+              "id": "{{id}}",
+              "code": "andy-cli-dev",
+              "name": "Andy CLI Development",
+              "description": "Pre-installed CLI",
+              "version": "1.0.0",
+              "baseImage": "ubuntu:24.04",
+              "catalogScope": "Global",
+              "ideType": "CodeServer",
+              "gpuRequired": false,
+              "gpuPreferred": false,
+              "isPublished": true,
+              "organizationId": null,
+              "teamId": null,
+              "tags": null,
+              "createdAt": "2026-04-28T00:00:00Z",
+              "updatedAt": null
+            }
+            """;
+        var handler = new CannedHandler(body, "application/json");
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://example.local/") };
+        var client = new ContainersClient(http);
+
+        var t = await client.GetTemplateByCodeAsync("andy-cli-dev");
+
+        handler.LastRequestUri!.AbsolutePath.Should().Be("/api/templates/by-code/andy-cli-dev");
+        t.Code.Should().Be("andy-cli-dev");
+        t.CatalogScope.Should().Be("Global");
+        t.IsPublished.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetTemplateDefinitionAsync_HitsDefinitionRoute_AndUnpacksContentEnvelope()
+    {
+        var id = Guid.NewGuid();
+        var body = """{"code":"andy-cli-dev","content":"code: andy-cli-dev\nname: Demo\n"}""";
+        var handler = new CannedHandler(body, "application/json");
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://example.local/") };
+        var client = new ContainersClient(http);
+
+        var def = await client.GetTemplateDefinitionAsync(id.ToString());
+
+        handler.LastRequestUri!.AbsolutePath.Should().Be($"/api/templates/{id}/definition");
+        def.Code.Should().Be("andy-cli-dev");
+        def.Content.Should().Contain("name: Demo");
+    }
+
+    [Fact]
+    public async Task GetTemplateByCodeAsync_404_ThrowsContainersApiException()
+    {
+        var http = new HttpClient(
+            new CannedHandler("", "application/json", HttpStatusCode.NotFound))
+        {
+            BaseAddress = new Uri("https://example.local/"),
+        };
+        var client = new ContainersClient(http);
+
+        var act = async () => await client.GetTemplateByCodeAsync("nope");
+
+        await act.Should().ThrowAsync<ContainersApiException>()
+            .Where(e => e.StatusCode == HttpStatusCode.NotFound);
+    }
 }


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#190 — second parity-audit follow-up.

## Summary

Replaces the \`templates\` stub with read-only catalog browse:

\`\`\`
andy-containers-cli templates list       [--scope ...] [--search ...] [--format table|json]
andy-containers-cli templates info       <code>        [--format table|json]
andy-containers-cli templates definition <code|id>
\`\`\`

Architecture mirrors AP9 / X7 / #189:

- **\`ContainersClient\`** gains \`ListTemplatesAsync\` / \`GetTemplateByCodeAsync\` / \`GetTemplateDefinitionAsync\`. New \`TemplateDetailDto\` + \`TemplateDefinitionDto\` records pinned locally; the existing minimal \`TemplateDto\` (nested on \`ContainerDto\`) stays untouched.
- **\`TemplateCommands.cs\`** — \`info\` and \`definition\` exit with code 4 (Epic AN not-found). \`definition\` accepts either a code or a GUID; codes resolve to ids internally so operators keep using slugs.
- **\`definition\` uses \`Console.Write\` (no Spectre markup)** so \`... > template.yaml\` captures clean YAML without ANSI escape sequences.
- **\`TableFormatter\`** — scope colour-coded (Global green / Organization cyan / Team yellow / User magenta); GPU shows "required" / "preferred" / "no" rather than booleans.

CRUD + publish + image-build remain admin-only via REST/UI, per the parity audit's deliberate-omissions section.

## Test plan

- [x] **5 new \`ContainersClientTests\`** cases: bare list URL, scope+search filters URL-encode, get-by-code round-trip, definition envelope unpacking (\`{code, content}\`), 404 → \`ContainersApiException\`.
- [x] CLI \`templates --help\` shows all three subcommands.
- [x] Full client tests: 24 passed (19 pre-existing + 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)