### PR TITLE
Provider CLI: list + health (#191)

### DIFF
--- a/src/Andy.Containers.Cli/Commands/ProviderCommands.cs
+++ b/src/Andy.Containers.Cli/Commands/ProviderCommands.cs
@@ -1,0 +1,120 @@
+using System.CommandLine;
+using System.Text.Json;
+using Andy.Containers.Cli.Formatting;
+using Andy.Containers.Client;
+using Spectre.Console;
+
+namespace Andy.Containers.Cli.Commands;
+
+/// <summary>
+/// rivoli-ai/andy-containers#191. Read-only ops surface for
+/// multi-provider deployments. <c>list</c> shows every infrastructure
+/// provider; <c>health</c> probes one. CRUD remains admin-only via
+/// the REST/UI surface.
+/// </summary>
+public static class ProviderCommands
+{
+    private static readonly JsonSerializerOptions JsonOut = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+
+    public static Command Create()
+    {
+        var cmd = new Command("providers", "List + probe infrastructure providers");
+        cmd.AddCommand(CreateListCommand());
+        cmd.AddCommand(CreateHealthCommand());
+        return cmd;
+    }
+
+    private static Command CreateListCommand()
+    {
+        var cmd = new Command("list", "List infrastructure providers");
+        var orgOpt = new Option<string?>(
+            "--organization", "Filter by organization id (GUID).");
+        var formatOpt = OutputFormatOption.Create();
+        cmd.AddOption(orgOpt);
+        cmd.AddOption(formatOpt);
+
+        cmd.SetHandler(async (context) =>
+        {
+            var orgRaw = context.ParseResult.GetValueForOption(orgOpt);
+            var format = context.ParseResult.GetValueForOption(formatOpt);
+            var ct = context.GetCancellationToken();
+
+            Guid? orgId = null;
+            if (!string.IsNullOrWhiteSpace(orgRaw))
+            {
+                if (!Guid.TryParse(orgRaw, out var parsed) || parsed == Guid.Empty)
+                {
+                    AnsiConsole.MarkupLine("[red]--organization must be a non-empty GUID.[/]");
+                    context.ExitCode = 2;
+                    return;
+                }
+                orgId = parsed;
+            }
+
+            var client = ClientFactory.Create();
+            var providers = await client.ListProvidersAsync(orgId, ct);
+
+            if (format == OutputFormat.Json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(providers, JsonOut));
+                return;
+            }
+
+            TableFormatter.PrintProviderTable(providers);
+        });
+
+        return cmd;
+    }
+
+    private static Command CreateHealthCommand()
+    {
+        var cmd = new Command("health",
+            "Probe a provider's health and capabilities. Triggers a live check against the underlying infrastructure.");
+        var idArg = new Argument<string>("id",
+            "Provider id (GUID). Resolves via 'providers list' if you only have a code.");
+        var formatOpt = OutputFormatOption.Create();
+        cmd.AddArgument(idArg);
+        cmd.AddOption(formatOpt);
+
+        cmd.SetHandler(async (context) =>
+        {
+            var id = context.ParseResult.GetValueForArgument(idArg);
+            var format = context.ParseResult.GetValueForOption(formatOpt);
+            var ct = context.GetCancellationToken();
+
+            if (!Guid.TryParse(id, out _))
+            {
+                AnsiConsole.MarkupLine($"[red]Provider id must be a GUID. Use 'providers list' to find it.[/]");
+                context.ExitCode = 2;
+                return;
+            }
+
+            var client = ClientFactory.Create();
+            ContainersClient.ProviderHealthDto health;
+            try
+            {
+                health = await client.GetProviderHealthAsync(id, ct);
+            }
+            catch (ContainersApiException ex)
+                when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                AnsiConsole.MarkupLine($"[red]Provider '{Markup.Escape(id)}' not found.[/]");
+                context.ExitCode = 4;
+                return;
+            }
+
+            if (format == OutputFormat.Json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(health, JsonOut));
+                return;
+            }
+
+            TableFormatter.PrintProviderHealth(id, health);
+        });
+
+        return cmd;
+    }
+}

--- a/src/Andy.Containers.Cli/Formatting/TableFormatter.cs
+++ b/src/Andy.Containers.Cli/Formatting/TableFormatter.cs
@@ -380,4 +380,80 @@ public static class TableFormatter
 
         AnsiConsole.Write(table);
     }
+
+    // rivoli-ai/andy-containers#191. Provider list + health views.
+
+    public static void PrintProviderTable(IReadOnlyList<ContainersClient.ProviderDetailDto> providers)
+    {
+        if (providers.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[dim]No providers found.[/]");
+            return;
+        }
+
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .AddColumn("Code")
+            .AddColumn("Name")
+            .AddColumn("Type")
+            .AddColumn("Region")
+            .AddColumn("Health")
+            .AddColumn("Enabled")
+            .AddColumn("Last check");
+
+        foreach (var p in providers)
+        {
+            table.AddRow(
+                Markup.Escape(p.Code),
+                Markup.Escape(p.Name),
+                Markup.Escape(p.Type),
+                Markup.Escape(p.Region ?? "—"),
+                ProviderHealthColor(p.HealthStatus),
+                p.IsEnabled ? "[green]yes[/]" : "[dim]no[/]",
+                p.LastHealthCheck is { } lc
+                    ? lc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")
+                    : "[dim]—[/]");
+        }
+
+        AnsiConsole.Write(table);
+    }
+
+    public static void PrintProviderHealth(string providerId, ContainersClient.ProviderHealthDto health)
+    {
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .HideHeaders()
+            .AddColumn("")
+            .AddColumn("");
+
+        table.AddRow("Provider id", providerId);
+        table.AddRow("Status", ProviderHealthColor(health.Status));
+
+        if (health.Capabilities is { } caps)
+        {
+            if (!string.IsNullOrEmpty(caps.Type)) table.AddRow("Type", Markup.Escape(caps.Type));
+            if (caps.SupportedArchitectures is { Length: > 0 } a)
+                table.AddRow("Architectures", string.Join(", ", a.Select(Markup.Escape)));
+            if (caps.SupportedOperatingSystems is { Length: > 0 } o)
+                table.AddRow("OS", string.Join(", ", o.Select(Markup.Escape)));
+            if (caps.MaxCpuCores is { } cpu) table.AddRow("Max CPU", cpu.ToString());
+            if (caps.MaxMemoryMb is { } mem) table.AddRow("Max RAM", $"{mem} MB");
+            if (caps.MaxDiskGb is { } disk) table.AddRow("Max disk", $"{disk} GB");
+            table.AddRow("GPU", caps.SupportsGpu == true ? "[green]yes[/]" : "[dim]no[/]");
+            table.AddRow("Volume mounts", caps.SupportsVolumeMount == true ? "[green]yes[/]" : "[dim]no[/]");
+            table.AddRow("Port forwarding", caps.SupportsPortForwarding == true ? "[green]yes[/]" : "[dim]no[/]");
+            table.AddRow("Exec", caps.SupportsExec == true ? "[green]yes[/]" : "[dim]no[/]");
+        }
+
+        AnsiConsole.Write(table);
+    }
+
+    private static string ProviderHealthColor(string status) => status switch
+    {
+        "Healthy" => "[green]Healthy[/]",
+        "Degraded" => "[yellow]Degraded[/]",
+        "Unreachable" => "[red]Unreachable[/]",
+        "Unknown" => "[dim]Unknown[/]",
+        _ => Markup.Escape(status),
+    };
 }

--- a/src/Andy.Containers.Cli/Program.cs
+++ b/src/Andy.Containers.Cli/Program.cs
@@ -43,4 +43,7 @@ rootCommand.AddCommand(WorkspaceCommands.Create());
 // Template commands (rivoli-ai/andy-containers#190).
 rootCommand.AddCommand(TemplateCommands.Create());
 
+// Provider commands (rivoli-ai/andy-containers#191).
+rootCommand.AddCommand(ProviderCommands.Create());
+
 return await rootCommand.InvokeAsync(args);

--- a/src/Andy.Containers.Client/ContainersClient.cs
+++ b/src/Andy.Containers.Client/ContainersClient.cs
@@ -224,6 +224,31 @@ public sealed class ContainersClient
         return (await r.Content.ReadFromJsonAsync<TemplateDefinitionDto>(_json, ct))!;
     }
 
+    // Providers (rivoli-ai/andy-containers#191). Read-only ops surface
+    // for multi-provider deployments. CRUD remains admin-only via
+    // REST/UI. The legacy GetProvidersAsync keeps its narrow shape for
+    // ContainerCommands; ListProvidersAsync is the rich CLI view.
+
+    public async Task<ProviderDetailDto[]> ListProvidersAsync(
+        Guid? organizationId = null, CancellationToken ct = default)
+    {
+        var url = "api/providers";
+        if (organizationId.HasValue)
+        {
+            url += $"?organizationId={organizationId.Value}";
+        }
+        var r = await _http.GetAsync(url, ct);
+        await EnsureSuccessAsync(r, ct);
+        return (await r.Content.ReadFromJsonAsync<ProviderDetailDto[]>(_json, ct))!;
+    }
+
+    public async Task<ProviderHealthDto> GetProviderHealthAsync(string id, CancellationToken ct = default)
+    {
+        var r = await _http.GetAsync($"api/providers/{id}/health", ct);
+        await EnsureSuccessAsync(r, ct);
+        return (await r.Content.ReadFromJsonAsync<ProviderHealthDto>(_json, ct))!;
+    }
+
     public async Task<RunDto> CreateRunAsync(CreateRunRequest request, CancellationToken ct = default)
     {
         var r = await _http.PostAsJsonAsync("api/runs", request, _json, ct);
@@ -384,6 +409,40 @@ public sealed class ContainersClient
     /// when the file isn't on disk).
     /// </summary>
     public record TemplateDefinitionDto(string Code, string Content);
+
+    // Providers (rivoli-ai/andy-containers#191). Slim wire shape for
+    // the rich list+health CLI views.
+    public record ProviderDetailDto(
+        Guid Id,
+        string Code,
+        string Name,
+        string Type,
+        string? Region,
+        bool IsEnabled,
+        string HealthStatus,
+        DateTime? LastHealthCheck,
+        Guid? OrganizationId);
+
+    /// <summary>
+    /// Wire shape for <c>GET /api/providers/{id}/health</c>:
+    /// <c>{ status, capabilities }</c>. <c>capabilities</c> is the
+    /// provider's full <c>ProviderCapabilities</c> blob; we surface
+    /// it as a free-form record so a provider-side schema change
+    /// doesn't ripple into the CLI.
+    /// </summary>
+    public record ProviderHealthDto(string Status, ProviderCapabilitiesDto? Capabilities);
+
+    public record ProviderCapabilitiesDto(
+        string? Type,
+        string[]? SupportedArchitectures,
+        string[]? SupportedOperatingSystems,
+        int? MaxCpuCores,
+        int? MaxMemoryMb,
+        int? MaxDiskGb,
+        bool? SupportsGpu,
+        bool? SupportsVolumeMount,
+        bool? SupportsPortForwarding,
+        bool? SupportsExec);
 }
 
 public sealed class ContainersApiException : HttpRequestException

--- a/tests/Andy.Containers.Client.Tests/ContainersClientTests.cs
+++ b/tests/Andy.Containers.Client.Tests/ContainersClientTests.cs
@@ -540,4 +540,115 @@ public class ContainersClientTests
         await act.Should().ThrowAsync<ContainersApiException>()
             .Where(e => e.StatusCode == HttpStatusCode.NotFound);
     }
+
+    // rivoli-ai/andy-containers#191. Provider client wrappers.
+
+    [Fact]
+    public async Task ListProvidersAsync_NoFilter_HitsBareCollectionUrl()
+    {
+        var handler = new CannedHandler("[]", "application/json");
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://example.local/") };
+        var client = new ContainersClient(http);
+
+        var providers = await client.ListProvidersAsync();
+
+        providers.Should().BeEmpty();
+        handler.LastMethod.Should().Be(HttpMethod.Get);
+        handler.LastRequestUri!.AbsolutePath.Should().Be("/api/providers");
+        handler.LastRequestUri.Query.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListProvidersAsync_WithOrgFilter_AppendsQuery()
+    {
+        var handler = new CannedHandler("[]", "application/json");
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://example.local/") };
+        var client = new ContainersClient(http);
+
+        var orgId = Guid.NewGuid();
+        await client.ListProvidersAsync(orgId);
+
+        handler.LastRequestUri!.Query.Should().Contain($"organizationId={orgId}");
+    }
+
+    [Fact]
+    public async Task ListProvidersAsync_DeserialisesRichDetail()
+    {
+        var id = Guid.NewGuid();
+        var body = $$"""
+            [{
+              "id": "{{id}}",
+              "code": "docker-local",
+              "name": "Local Docker",
+              "type": "Docker",
+              "region": "local",
+              "isEnabled": true,
+              "healthStatus": "Healthy",
+              "lastHealthCheck": "2026-04-28T00:00:00Z",
+              "organizationId": null
+            }]
+            """;
+        var http = new HttpClient(new CannedHandler(body, "application/json"))
+        {
+            BaseAddress = new Uri("https://example.local/"),
+        };
+        var client = new ContainersClient(http);
+
+        var providers = await client.ListProvidersAsync();
+
+        providers.Should().ContainSingle();
+        providers[0].Code.Should().Be("docker-local");
+        providers[0].HealthStatus.Should().Be("Healthy");
+        providers[0].LastHealthCheck.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetProviderHealthAsync_HitsHealthRoute_AndUnpacksEnvelope()
+    {
+        var id = Guid.NewGuid();
+        var body = """
+            {
+              "status": "Healthy",
+              "capabilities": {
+                "type": "Docker",
+                "supportedArchitectures": ["amd64", "arm64"],
+                "supportedOperatingSystems": ["linux"],
+                "maxCpuCores": 8,
+                "maxMemoryMb": 16384,
+                "maxDiskGb": 100,
+                "supportsGpu": false,
+                "supportsVolumeMount": true,
+                "supportsPortForwarding": true,
+                "supportsExec": true
+              }
+            }
+            """;
+        var handler = new CannedHandler(body, "application/json");
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://example.local/") };
+        var client = new ContainersClient(http);
+
+        var health = await client.GetProviderHealthAsync(id.ToString());
+
+        handler.LastRequestUri!.AbsolutePath.Should().Be($"/api/providers/{id}/health");
+        health.Status.Should().Be("Healthy");
+        health.Capabilities.Should().NotBeNull();
+        health.Capabilities!.SupportedArchitectures.Should().Contain("amd64");
+        health.Capabilities.MaxCpuCores.Should().Be(8);
+    }
+
+    [Fact]
+    public async Task GetProviderHealthAsync_404_ThrowsContainersApiException()
+    {
+        var http = new HttpClient(
+            new CannedHandler("", "application/json", HttpStatusCode.NotFound))
+        {
+            BaseAddress = new Uri("https://example.local/"),
+        };
+        var client = new ContainersClient(http);
+
+        var act = async () => await client.GetProviderHealthAsync(Guid.NewGuid().ToString());
+
+        await act.Should().ThrowAsync<ContainersApiException>()
+            .Where(e => e.StatusCode == HttpStatusCode.NotFound);
+    }
 }


### PR DESCRIPTION
Closes rivoli-ai/andy-containers#191 — third and last of the parity-audit follow-ups (#76 → #189 / #190 / this).

## Summary

Adds the read-only ops surface for multi-provider deployments:

\`\`\`
andy-containers-cli providers list   [--organization ...] [--format table|json]
andy-containers-cli providers health <id>                [--format table|json]
\`\`\`

CRUD + cost-estimate + delete remain admin-only via REST/UI per the parity-audit doc's deliberate-omissions section.

Architecture mirrors AP9 / X7 / #189 / #190:

- **\`ContainersClient\`** gains \`ListProvidersAsync\` / \`GetProviderHealthAsync\`. New \`ProviderDetailDto\` / \`ProviderHealthDto\` / \`ProviderCapabilitiesDto\` records. Existing minimal \`GetProvidersAsync\` (used by \`ContainerCommands\`) stays untouched.
- **\`ProviderCommands.cs\`** — \`health\` rejects non-GUID inputs with code 2 and 404 with code 4. \`list --organization\` validates the GUID up-front.
- **\`TableFormatter.PrintProviderTable\`** + **\`PrintProviderHealth\`**. Health colour-coded across both views (Healthy green / Degraded yellow / Unreachable red / Unknown dim) so an operator scanning the list spots fleet-wide trouble immediately.
- **\`PrintProviderHealth\`** shows the resolved capability envelope (max cpu/ram/disk, GPU, volume mounts, port forwarding, exec) — an ops sweep can confirm a new provider matches deployment expectations without reaching for REST.

## Test plan

- [x] **5 new \`ContainersClientTests\`** cases: bare URL, org-filter query, rich detail deserialisation, health-envelope unpacking (\`{status, capabilities}\`), 404 → \`ContainersApiException\`.
- [x] CLI \`providers --help\` shows both subcommands.
- [x] Client tests: 29 passed (5 new + 24 pre-existing).

With #189 / #190 / this all merged, the parity audit's top-5 highest-value gaps drop to one (container lifecycle MCP, closed in #192). Remaining cells in the matrix are the deliberate-omissions documented in \`docs/api-mcp-cli-parity.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)