### PR TITLE
docs: refresh CLI reference + parity matrix after #189/#190/#191

### DIFF
--- a/docs/api-mcp-cli-parity.md
+++ b/docs/api-mcp-cli-parity.md
@@ -8,13 +8,13 @@ Authoritative sources read at audit time:
 - MCP — every `[McpServerTool(...)]` method in `src/Andy.Containers.Api/Mcp/`
 - CLI — every command tree assembled in `src/Andy.Containers.Cli/Program.cs` from `src/Andy.Containers.Cli/Commands/`
 
-Last refreshed: **2026-04-28** ([rivoli-ai/andy-containers#76](https://github.com/rivoli-ai/andy-containers/issues/76)).
+Last refreshed: **2026-04-27** — after the #76 follow-ups landed (#189 workspace CLI, #190 template CLI, #191 provider CLI).
 
 ## Counts at a glance
 
 - **REST endpoints (business)**: 75
-- **MCP coverage**: 14 tools across ~19% of REST endpoints
-- **CLI coverage**: 19 commands across ~25% of REST endpoints
+- **MCP coverage**: ~35 tools (~47% of REST endpoints)
+- **CLI coverage**: ~28 commands (~37% of REST endpoints)
 
 Numbers exclude health checks, Swagger, and WebSocket attach surfaces (which don't map to MCP/CLI by design).
 
@@ -29,10 +29,10 @@ Numbers exclude health checks, Swagger, and WebSocket attach surfaces (which don
 | `GET /api/containers` | `ListContainers` ✅ | `andy-containers-cli list` ✅ |
 | `GET /api/containers/{id}` | `GetContainer` ✅ | `andy-containers-cli info {id}` ✅ |
 | `POST /api/containers` | ❌ | `andy-containers-cli create` ✅ |
-| `POST /api/containers/{id}/start` | ✅ (this PR) | `andy-containers-cli start {id}` ✅ |
-| `POST /api/containers/{id}/stop` | ✅ (this PR) | `andy-containers-cli stop {id}` ✅ |
-| `DELETE /api/containers/{id}` | ✅ (this PR) | `andy-containers-cli destroy {id}` ✅ |
-| `POST /api/containers/{id}/exec` | ✅ (this PR) | `andy-containers-cli exec {id} ...` ✅ |
+| `POST /api/containers/{id}/start` | ✅ | `andy-containers-cli start {id}` ✅ |
+| `POST /api/containers/{id}/stop` | ✅ | `andy-containers-cli stop {id}` ✅ |
+| `DELETE /api/containers/{id}` | ✅ | `andy-containers-cli destroy {id}` ✅ |
+| `POST /api/containers/{id}/exec` | ✅ | `andy-containers-cli exec {id} ...` ✅ |
 | `GET /api/containers/{id}/connection` | ❌ | ❌ |
 | `PUT /api/containers/{id}/resources` | ❌ | ❌ |
 | `GET /api/containers/{id}/screenshot` | — | — |
@@ -69,22 +69,22 @@ The catalog is read-only; by-id is rarely the access path (slug lookup is canoni
 
 | REST | MCP | CLI |
 |---|---|---|
-| `GET /api/workspaces` | `ListWorkspaces` ✅ | stub |
-| `GET /api/workspaces/{id}` | ❌ | ❌ |
-| `POST /api/workspaces` | ❌ | stub |
-| `PUT /api/workspaces/{id}` | ❌ | ❌ |
-| `DELETE /api/workspaces/{id}` | ❌ | ❌ |
+| `GET /api/workspaces` | `ListWorkspaces` ✅ | `andy-containers-cli workspace list` ✅ |
+| `GET /api/workspaces/{id}` | ❌ | `andy-containers-cli workspace get` ✅ |
+| `POST /api/workspaces` | ❌ | `andy-containers-cli workspace create` ✅ |
+| `PUT /api/workspaces/{id}` | ❌ | — |
+| `DELETE /api/workspaces/{id}` | ❌ | `andy-containers-cli workspace delete` ✅ |
 
-CLI stubs exist in `Program.cs` but aren't wired to real commands. Tracked as a follow-up.
+`workspace update` is intentionally absent from CLI: `UpdateWorkspaceDto` doesn't expose the governance fields anyway (X5 keeps the EnvironmentProfile binding immutable for the workspace's life), and operators rarely reach for it.
 
 ### Templates
 
 | REST | MCP | CLI |
 |---|---|---|
-| `GET /api/templates` | `BrowseTemplates` ✅ | stub |
+| `GET /api/templates` | `BrowseTemplates` ✅ | `andy-containers-cli templates list` ✅ |
 | `GET /api/templates/{id}` | ❌ | ❌ |
-| `GET /api/templates/by-code/{code}` | ❌ | ❌ |
-| `GET /api/templates/{id}/definition` | ❌ | ❌ |
+| `GET /api/templates/by-code/{code}` | ❌ | `andy-containers-cli templates info` ✅ |
+| `GET /api/templates/{id}/definition` | ❌ | `andy-containers-cli templates definition` ✅ |
 | `POST /api/templates` | ❌ | ❌ |
 | `PUT /api/templates/{id}` | ❌ | ❌ |
 | `POST /api/templates/{id}/publish` | ❌ | ❌ |
@@ -102,14 +102,14 @@ The CRUD + publish + validate surface is admin-only and lives behind `template:w
 
 | REST | MCP | CLI |
 |---|---|---|
-| `GET /api/providers` | `ListProviders` ✅ | ❌ |
+| `GET /api/providers` | `ListProviders` ✅ | `andy-containers-cli providers list` ✅ |
 | `GET /api/providers/{id}` | ❌ | ❌ |
-| `POST /api/providers` | ❌ | ❌ |
-| `GET /api/providers/{id}/health` | ❌ | ❌ |
+| `POST /api/providers` | ❌ | — |
+| `GET /api/providers/{id}/health` | ❌ | `andy-containers-cli providers health` ✅ |
 | `GET /api/providers/{id}/cost-estimate` | ❌ | ❌ |
-| `DELETE /api/providers/{id}` | ❌ | ❌ |
+| `DELETE /api/providers/{id}` | ❌ | — |
 
-CRUD is admin-only. `list` + `health` over CLI would unblock ops; tracked as a follow-up.
+CRUD is admin-only via REST; deliberately not wired to the user CLI. Ops-shaped operations (`list`, `health`) are surfaced.
 
 ### Images
 
@@ -153,21 +153,27 @@ Org admin lives in the platform-admin UI / a separate admin CLI; mixing it into 
 
 Device flow is interactive and CLI-shaped; not an MCP-tool concern.
 
-## Top 5 highest-value gaps
+## Recently closed gaps
 
-The following are tracked as separate follow-up issues, ordered by impact-to-effort ratio:
+- **Container lifecycle MCP tools** — `start` / `stop` / `destroy` / `exec` over MCP. Closed in #192.
+- **Workspace CLI** (full implementation) — `list` / `get` / `create` / `delete`. Closed in #189.
+- **Template CLI** (full implementation) — `list` / `info` / `definition`. Closed in #190.
+- **Provider CLI** — `list` + `health`. Closed in #191.
 
-1. **Container lifecycle MCP tools** — start / stop / destroy / exec. **Closed in this PR.**
-2. **Workspace CLI** (full implementation) — stubs exist; ~2-3 hours to wire real `create` / `list` / `get` / `delete`.
-3. **Template CLI** (full implementation) — stubs exist; ~1-2 hours for `list` / `info` / `definition`.
-4. **Provider CLI** (`list` + `health`) — ops visibility for multi-provider deployments.
-5. **Image-build CLI** (`build` + `status`) — ops trigger for custom-image rebuilds without dropping to curl.
+## Remaining open gaps
+
+Ordered by impact-to-effort ratio. Open one issue per item if/when prioritised:
+
+1. **Image-build CLI** (`build` + `status`) — ops trigger for custom-image rebuilds without dropping to curl.
+2. **Container resource update** (`PUT /api/containers/{id}/resources`) — neither MCP nor CLI; rare path, but the only way to bump CPU/RAM today is HTTP.
+3. **Container events SSE** — MCP cannot stream; CLI could mirror the NDJSON pattern from `runs events`.
+4. **Provider cost-estimate** — CLI surface would help capacity-planning runs.
 
 ## Top 3 deliberate omissions
 
 1. **API keys + git credentials over MCP/CLI** — secrets shouldn't transit shell history or the MCP wire. REST + HTTPS only.
 2. **File uploads via MCP** (e.g. custom Dockerfiles in container-create) — MCP has no streaming primitive. REST multipart is the right shape.
-3. **Admin operations (org / provider / template publish) over CLI** — separate-concern surface; should not share a binary with user-facing commands.
+3. **Admin operations (org / provider / template publish / workspace update) over CLI** — separate-concern surface; should not share a binary with user-facing commands.
 
 ## Maintaining this document
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,18 +1,43 @@
 # CLI Reference
 
+The `andy-containers` CLI is the user-facing entry point to the same surface served by REST (`/api/*`) and MCP. The full transport-by-transport coverage map lives in [API / MCP / CLI parity](api-mcp-cli-parity.md).
+
 ## Installation
 
 ```bash
 dotnet tool install -g Andy.Containers.Cli
 ```
 
-Or run from source:
+Or from source:
 
 ```bash
 dotnet run --project src/Andy.Containers.Cli -- <command>
 ```
 
-The CLI is built with **System.CommandLine** and **Spectre.Console** for rich terminal output.
+Built on **System.CommandLine** (parsing) and **Spectre.Console** (output).
+
+## Global options
+
+| Option | Default | Description |
+|---|---|---|
+| `--api-url` | `https://localhost:5200` | API server URL. Persisted via `auth login --api-url`. |
+| `--format` / `-o` | `table` | Output format. `table` is the default human view; `json` emits one record per response, suitable for piping to `jq`. Supported on commands listed below. |
+| `--help` | — | Show help for any command. |
+| `--version` | — | Print CLI version. |
+
+`--format` is honoured by: `environments {list,get}`, `workspace {list,get,create}`, `templates {list,info}`, `providers {list,health}`. `templates definition` always prints raw YAML to stdout (no markup, no envelope) so `> file.yaml` produces a clean file.
+
+## Exit codes
+
+The CLI follows the Epic AN exit-code contract:
+
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | Generic error |
+| `2` | Usage error (bad flag, malformed GUID, invalid enum value) |
+| `3` | Authentication required / token expired |
+| `4` | Resource not found |
 
 ## Authentication
 
@@ -30,85 +55,129 @@ andy-containers auth status
 andy-containers auth logout
 ```
 
-## Container Management
+Credentials are stored in `~/.andy/credentials.json` with permission bits `600`.
+
+## Containers
 
 ```bash
-# List all containers
+# List
 andy-containers list
 
-# Create a container
+# Create
 andy-containers create --name my-dev --template dotnet-8-alpine
-
-# Create with a specific provider
 andy-containers create --name my-dev --template dotnet-8-alpine --provider local-docker
-
-# Create with code assistant and model
 andy-containers create --name ai-dev --template dotnet-8-alpine \
   --code-assistant Aider --model gpt-4o
 
-# Show container details
+# Inspect
 andy-containers info <id>
+andy-containers stats <id>          # CPU / RAM / disk with bars
 
-# Start / Stop / Destroy
+# Lifecycle
 andy-containers start <id>
 andy-containers stop <id>
 andy-containers destroy <id>
 
-# Execute a command
+# Run a command (one-shot)
 andy-containers exec <id> "dotnet --version"
 
-# SSH into a running container
-andy-containers ssh <id>
-
-# Show resource usage (CPU, RAM, disk with visual bars)
-andy-containers stats <id>
+# Interactive shell
+andy-containers connect <id>        # prefers SSH, falls back to web terminal
 ```
 
-## Template Catalog
+`create` flags: `--name` (required), `--template` (required), `--provider`, `--code-assistant`, `--model`, `--base-url`.
+
+## Workspaces
 
 ```bash
-# List all available templates
-andy-containers templates list
+andy-containers workspace list [--owner <id>] [--organization <guid>] [-o json]
+andy-containers workspace get <id> [-o json]
 
-# Show template details
-andy-containers templates info <code>
+# --environment-profile is required (X5 governance anchor: each
+# workspace pins one EnvironmentProfile slug for life).
+andy-containers workspace create <name> \
+  --environment-profile headless-container \
+  [--description ...] [--organization <guid>] [--team <guid>] \
+  [--git-repo <url>] [--branch <name>] [-o json]
+
+andy-containers workspace delete <id>
 ```
 
-## Provider Management
+`update` is intentionally absent — the API's `UpdateWorkspaceDto` doesn't expose the governance fields and operators rarely need it from CLI.
+
+## Runs (Epic AP)
 
 ```bash
-# List infrastructure providers
-andy-containers providers list
+# Submit a run. --environment-profile is required.
+andy-containers runs create <agent-slug> \
+  --environment-profile <guid> \
+  [--mode Headless|Terminal|Desktop] \
+  [--agent-revision <int>] \
+  [--workspace <guid> [--branch <name>]] \
+  [--policy <guid>] \
+  [--correlation-id <guid>]
+
+andy-containers runs get <id>
+andy-containers runs cancel <id>
+andy-containers runs events <id>     # NDJSON stream until terminal state
 ```
 
-## Command Summary
+`runs events` follows the run until it hits a terminal state (`finished` / `failed` / `cancelled` / `timeout`) and prints colour-coded lifecycle events with timestamps.
+
+## Environment profiles (Epic X)
+
+```bash
+andy-containers environments list [--kind HeadlessContainer|Terminal|Desktop] [-o json]
+andy-containers environments get <code> [-o json]    # e.g. 'headless-container'
+```
+
+Lookup is by slug — slugs are the stable identifier; ids are not exposed at the CLI.
+
+## Templates
+
+```bash
+andy-containers templates list [--scope Global|Organization|Team|User] [--search <text>] [-o json]
+andy-containers templates info <code> [-o json]
+andy-containers templates definition <code-or-id>     # raw YAML to stdout
+```
+
+`templates definition` accepts either a slug or a GUID. CRUD + publish + image-build remain admin-only via REST/UI — see the [parity matrix](api-mcp-cli-parity.md#templates).
+
+## Providers
+
+```bash
+andy-containers providers list [--organization <guid>] [-o json]
+
+# Live probe — issues a real health check against the underlying provider.
+andy-containers providers health <provider-id> [-o json]
+```
+
+CRUD remains admin-only via REST. Only ops-shaped operations (`list`, `health`) live on the CLI.
+
+## Command summary
 
 | Command | Description |
-|---------|-------------|
-| `auth login` | Authenticate via OAuth Device Flow or direct token |
+|---|---|
+| `auth login` | OAuth Device Flow or direct-token sign-in |
 | `auth logout` | Clear stored credentials |
 | `auth status` | Show current user and token expiry |
-| `list` | List all containers with status and uptime |
-| `create` | Create a new container from a template |
-| `start <id>` | Start a stopped container |
-| `stop <id>` | Stop a running container |
-| `destroy <id>` | Permanently destroy a container |
-| `exec <id> <cmd>` | Execute a command in a container |
-| `ssh <id>` | SSH into a running container |
-| `info <id>` | Show detailed container information |
-| `stats <id>` | Show CPU, RAM, and disk usage |
-| `templates list` | Browse the template catalog |
-| `templates info <code>` | Show template details |
-| `providers list` | List infrastructure providers |
+| `list` | List containers |
+| `create` | Create a container from a template |
+| `info <id>` | Show container details |
+| `stats <id>` | CPU / RAM / disk usage |
+| `start <id>` / `stop <id>` / `destroy <id>` | Container lifecycle |
+| `exec <id> <cmd>` | Run a command in a container |
+| `connect <id>` | Interactive shell (SSH preferred, web terminal fallback) |
+| `workspace list` / `get` / `create` / `delete` | Workspace CRUD (no update — see above) |
+| `runs create` / `get` / `cancel` / `events` | Agent-run lifecycle (Epic AP) |
+| `environments list` / `get` | EnvironmentProfile catalog (Epic X) |
+| `templates list` / `info` / `definition` | Template catalog browse |
+| `providers list` / `health` | Infrastructure provider list + live probe |
 
-## Global Options
+## Cross-references
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--api-url` | https://localhost:5200 | API server URL |
-| `--help` | -- | Show help |
-| `--version` | -- | Show version |
-
-## Credentials
-
-Stored in `~/.andy/credentials.json` with Unix file permissions 600.
+- [API / MCP / CLI parity](api-mcp-cli-parity.md) — what is/isn't surfaced on each transport
+- [Run docs](runs.md) — agent-run lifecycle and event semantics
+- [Run configurator](run-configurator.md) — AQ1/AQ2 contract with `andy-cli`
+- ADR 0002 — environment profiles (`docs/adr/0002-environment-profiles.md`)
+- ADR 0003 — agent run execution (`docs/adr/0003-agent-run-execution.md`)


### PR DESCRIPTION
## Summary

- **`docs/cli-reference.md`** was last updated before runs / environments / workspaces / templates / providers landed. Rewrote it from the current `Program.cs` so every command has an entry, plus the global `--format/-o`, `--api-url` flags and the Epic AN exit-code contract.
- **`docs/api-mcp-cli-parity.md`** still annotated work that merged in #189 / #190 / #191 / #192 as "(this PR)" or "stub". Replaced those with ✅, marked workspace `update` and provider CRUD as intentional CLI omissions, and split the gap list into "Recently closed" (4 done) vs "Remaining open" (image-build CLI, resource update, events SSE, cost-estimate).
- Bumped counts-at-a-glance and the last-refreshed date.

`mkdocs build --strict` is clean. (The pre-existing `presentation.md` nav warning is unrelated.)

## Test plan

- [x] `mkdocs build --strict` succeeds
- [x] Every command in `src/Andy.Containers.Cli/Program.cs` has an entry in `cli-reference.md`
- [x] Every CLI cell that was "stub" or `(this PR)` in the parity matrix now reflects merged state

🤖 Generated with [Claude Code](https://claude.com/claude-code)