### PR TITLE
feat(themes): catalog endpoint + container/template attachment (rivoli-ai/conductor#886)

### DIFF
--- a/config/themes/global/dracula.yaml
+++ b/config/themes/global/dracula.yaml
@@ -1,0 +1,28 @@
+# Dracula — the popular dark theme with vibrant accents.
+# Source: https://draculatheme.com/contribute (canonical palette)
+id: dracula
+name: dracula
+display_name: Dracula
+kind: terminal
+version: 1
+palette:
+  background: "#282a36"
+  foreground: "#f8f8f2"
+  cursor: "#f8f8f2"
+  selection: "#44475a"
+  ansi_0: "#21222c"
+  ansi_1: "#ff5555"
+  ansi_2: "#50fa7b"
+  ansi_3: "#f1fa8c"
+  ansi_4: "#bd93f9"
+  ansi_5: "#ff79c6"
+  ansi_6: "#8be9fd"
+  ansi_7: "#f8f8f2"
+  ansi_8: "#6272a4"
+  ansi_9: "#ff6e6e"
+  ansi_10: "#69ff94"
+  ansi_11: "#ffffa5"
+  ansi_12: "#d6acff"
+  ansi_13: "#ff92df"
+  ansi_14: "#a4ffff"
+  ansi_15: "#ffffff"

--- a/config/themes/global/github-dark.yaml
+++ b/config/themes/global/github-dark.yaml
@@ -1,0 +1,27 @@
+# GitHub Dark — the dark variant of the GitHub editor theme.
+id: github-dark
+name: github-dark
+display_name: GitHub Dark
+kind: terminal
+version: 1
+palette:
+  background: "#0d1117"
+  foreground: "#c9d1d9"
+  cursor: "#c9d1d9"
+  selection: "#3392ff44"
+  ansi_0: "#484f58"
+  ansi_1: "#ff7b72"
+  ansi_2: "#3fb950"
+  ansi_3: "#d29922"
+  ansi_4: "#58a6ff"
+  ansi_5: "#bc8cff"
+  ansi_6: "#39c5cf"
+  ansi_7: "#b1bac4"
+  ansi_8: "#6e7681"
+  ansi_9: "#ffa198"
+  ansi_10: "#56d364"
+  ansi_11: "#e3b341"
+  ansi_12: "#79c0ff"
+  ansi_13: "#d2a8ff"
+  ansi_14: "#56d4dd"
+  ansi_15: "#f0f6fc"

--- a/config/themes/global/monokai.yaml
+++ b/config/themes/global/monokai.yaml
@@ -1,0 +1,27 @@
+# Monokai — Wimer Hazenberg's high-contrast palette popularised by Sublime Text.
+id: monokai
+name: monokai
+display_name: Monokai
+kind: terminal
+version: 1
+palette:
+  background: "#272822"
+  foreground: "#f8f8f2"
+  cursor: "#f8f8f0"
+  selection: "#49483e"
+  ansi_0: "#272822"
+  ansi_1: "#f92672"
+  ansi_2: "#a6e22e"
+  ansi_3: "#f4bf75"
+  ansi_4: "#66d9ef"
+  ansi_5: "#ae81ff"
+  ansi_6: "#a1efe4"
+  ansi_7: "#f8f8f2"
+  ansi_8: "#75715e"
+  ansi_9: "#f92672"
+  ansi_10: "#a6e22e"
+  ansi_11: "#f4bf75"
+  ansi_12: "#66d9ef"
+  ansi_13: "#ae81ff"
+  ansi_14: "#a1efe4"
+  ansi_15: "#f9f8f5"

--- a/config/themes/global/nord.yaml
+++ b/config/themes/global/nord.yaml
@@ -1,0 +1,27 @@
+# Nord — Arctic-inspired pastel palette.
+id: nord
+name: nord
+display_name: Nord
+kind: terminal
+version: 1
+palette:
+  background: "#2e3440"
+  foreground: "#d8dee9"
+  cursor: "#d8dee9"
+  selection: "#434c5e"
+  ansi_0: "#3b4252"
+  ansi_1: "#bf616a"
+  ansi_2: "#a3be8c"
+  ansi_3: "#ebcb8b"
+  ansi_4: "#81a1c1"
+  ansi_5: "#b48ead"
+  ansi_6: "#88c0d0"
+  ansi_7: "#e5e9f0"
+  ansi_8: "#4c566a"
+  ansi_9: "#bf616a"
+  ansi_10: "#a3be8c"
+  ansi_11: "#ebcb8b"
+  ansi_12: "#81a1c1"
+  ansi_13: "#b48ead"
+  ansi_14: "#8fbcbb"
+  ansi_15: "#eceff4"

--- a/config/themes/global/solarized-dark.yaml
+++ b/config/themes/global/solarized-dark.yaml
@@ -1,0 +1,27 @@
+# Solarized Dark — Ethan Schoonover's classic high-contrast palette.
+id: solarized-dark
+name: solarized-dark
+display_name: Solarized Dark
+kind: terminal
+version: 1
+palette:
+  background: "#002b36"
+  foreground: "#839496"
+  cursor: "#93a1a1"
+  selection: "#073642"
+  ansi_0: "#073642"
+  ansi_1: "#dc322f"
+  ansi_2: "#859900"
+  ansi_3: "#b58900"
+  ansi_4: "#268bd2"
+  ansi_5: "#d33682"
+  ansi_6: "#2aa198"
+  ansi_7: "#eee8d5"
+  ansi_8: "#002b36"
+  ansi_9: "#cb4b16"
+  ansi_10: "#586e75"
+  ansi_11: "#657b83"
+  ansi_12: "#839496"
+  ansi_13: "#6c71c4"
+  ansi_14: "#93a1a1"
+  ansi_15: "#fdf6e3"

--- a/src/Andy.Containers.Api/Controllers/ContainersController.cs
+++ b/src/Andy.Containers.Api/Controllers/ContainersController.cs
@@ -245,6 +245,44 @@ public class ContainersController : ControllerBase
         return Ok(info);
     }
 
+    /// <summary>
+    /// Conductor #886. Sets or clears the container's preferred
+    /// theme. The body is <c>{ "themeId": "..." }</c> for set,
+    /// <c>{ "themeId": null }</c> for clear (resolves back to
+    /// template default → user pref → hardcoded).
+    ///
+    /// Validates against the catalog — unknown id returns 422
+    /// with a structured envelope so the client can show the
+    /// rejection without a generic error.
+    /// </summary>
+    [HttpPatch("{id:guid}/theme")]
+    [RequirePermission("container:write")]
+    public async Task<IActionResult> SetTheme(Guid id, [FromBody] SetThemeRequest request, CancellationToken ct)
+    {
+        var container = await _db.Containers.FirstOrDefaultAsync(c => c.Id == id, ct);
+        if (container is null) return NotFound();
+        if (!CanAccess(container)) return Forbid();
+
+        if (!string.IsNullOrEmpty(request.ThemeId))
+        {
+            var themeExists = await _db.Themes
+                .AsNoTracking()
+                .AnyAsync(t => t.Id == request.ThemeId, ct);
+            if (!themeExists)
+            {
+                return UnprocessableEntity(new
+                {
+                    code = "unknown_theme",
+                    message = $"Theme '{request.ThemeId}' is not in the catalog.",
+                });
+            }
+        }
+
+        container.ThemeId = string.IsNullOrEmpty(request.ThemeId) ? null : request.ThemeId;
+        await _db.SaveChangesAsync(ct);
+        return Ok(container);
+    }
+
     [HttpPut("{id:guid}/resources")]
     [RequirePermission("container:execute")]
     public async Task<IActionResult> Resize(Guid id, [FromBody] ResizeRequest request, CancellationToken ct)
@@ -510,4 +548,17 @@ public class ResizeRequest
     public double CpuCores { get; set; } = 2;
     public int MemoryMb { get; set; } = 4096;
     public int DiskGb { get; set; } = 20;
+}
+
+/// <summary>
+/// Body for PATCH /api/containers/{id}/theme. Conductor #886.
+/// </summary>
+public class SetThemeRequest
+{
+    /// <summary>
+    /// Theme catalog id ("dracula", "github-dark", …). Pass null
+    /// or empty to clear the override and fall back through the
+    /// resolution chain (template → user pref → hardcoded).
+    /// </summary>
+    public string? ThemeId { get; set; }
 }

--- a/src/Andy.Containers.Api/Controllers/TemplatesController.cs
+++ b/src/Andy.Containers.Api/Controllers/TemplatesController.cs
@@ -199,6 +199,24 @@ public class TemplatesController : ControllerBase
         template.Version = update.Version;
         template.IdeType = update.IdeType;
         template.Tags = update.Tags;
+        // Conductor #886. ThemeId may be set, cleared, or left
+        // unchanged via this endpoint. Validate against the
+        // catalog when set — unknown id → 422.
+        if (!string.IsNullOrEmpty(update.ThemeId))
+        {
+            var themeExists = await _db.Themes
+                .AsNoTracking()
+                .AnyAsync(t => t.Id == update.ThemeId, ct);
+            if (!themeExists)
+            {
+                return UnprocessableEntity(new
+                {
+                    code = "unknown_theme",
+                    message = $"Theme '{update.ThemeId}' is not in the catalog.",
+                });
+            }
+        }
+        template.ThemeId = update.ThemeId;
         template.UpdatedAt = DateTime.UtcNow;
         await _db.SaveChangesAsync(ct);
         return Ok(template);

--- a/src/Andy.Containers.Api/Controllers/ThemesController.cs
+++ b/src/Andy.Containers.Api/Controllers/ThemesController.cs
@@ -1,0 +1,99 @@
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using Andy.Rbac.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
+
+namespace Andy.Containers.Api.Controllers;
+
+/// <summary>
+/// Conductor #886. Read-only catalog endpoint for predefined
+/// visual themes seeded from <c>config/themes/global/*.yaml</c>.
+///
+/// Why read-only in v1: themes are operator-curated artefacts —
+/// adding one means landing a YAML file via PR, not a runtime
+/// API call. User-defined themes are explicitly out of scope.
+/// </summary>
+[ApiController]
+[Route("api/themes")]
+[Authorize]
+public class ThemesController : ControllerBase
+{
+    private readonly ContainersDbContext _db;
+    private readonly ILogger<ThemesController> _logger;
+
+    public ThemesController(ContainersDbContext db, ILogger<ThemesController> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns the full theme catalog. Optionally filter by
+    /// <paramref name="kind"/> (<c>terminal</c>, <c>ide</c>,
+    /// <c>vnc</c>) so the picker UI doesn't have to filter
+    /// client-side. Unknown filter returns an empty list rather
+    /// than 400 — the catalog is still authoritative.
+    /// </summary>
+    [HttpGet]
+    [RequirePermission("container:read")]
+    public async Task<IActionResult> List([FromQuery] string? kind, CancellationToken ct)
+    {
+        IQueryable<Theme> query = _db.Themes.AsNoTracking();
+        if (!string.IsNullOrWhiteSpace(kind))
+        {
+            query = query.Where(t => t.Kind == kind);
+        }
+
+        var rows = await query
+            .OrderBy(t => t.DisplayName)
+            .ToListAsync(ct);
+
+        // Project to the wire shape — palette comes back as a
+        // parsed dictionary so the Conductor client doesn't have
+        // to double-decode the JSON envelope.
+        var dtos = rows
+            .Select(t => new ThemeDto(
+                t.Id,
+                t.Name,
+                t.DisplayName,
+                t.Kind,
+                ParsePalette(t.PaletteJson),
+                t.Version
+            ))
+            .ToList();
+
+        return Ok(new { items = dtos });
+    }
+
+    private Dictionary<string, string> ParsePalette(string json)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, string>>(json)
+                ?? new Dictionary<string, string>();
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex,
+                "ThemesController: failed to parse palette JSON; returning empty palette. Theme rows are seeded from YAML so a parse failure here usually means the YAML was malformed.");
+            return new Dictionary<string, string>();
+        }
+    }
+}
+
+/// <summary>
+/// Wire shape for catalog responses. Kept distinct from the
+/// EF entity so palette comes back as a dictionary instead of a
+/// raw JSON string.
+/// </summary>
+public record ThemeDto(
+    string Id,
+    string Name,
+    string DisplayName,
+    string Kind,
+    Dictionary<string, string> Palette,
+    int Version
+);

--- a/src/Andy.Containers.Api/Data/ThemeSeeder.cs
+++ b/src/Andy.Containers.Api/Data/ThemeSeeder.cs
@@ -1,0 +1,231 @@
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Andy.Containers.Api.Data;
+
+/// <summary>
+/// Conductor #886. Loads the global Theme catalog from
+/// <c>config/themes/global/*.yaml</c> at startup and upserts each
+/// by <see cref="Theme.Id"/>. Idempotent on re-run; existing rows
+/// get their mutable fields (display_name, palette, version)
+/// refreshed so an operator-edited YAML re-deploys cleanly.
+///
+/// Search-paths logic mirrors
+/// <see cref="EnvironmentProfileSeeder"/>'s — same project-dir /
+/// repo-root / parent-walk pattern. A malformed file is logged
+/// and skipped; host startup never aborts on a bad seed.
+///
+/// Why upsert (not insert-only) on re-run, unlike
+/// EnvironmentProfileSeeder?
+/// EnvironmentProfile rows are operator-editable via the API
+/// (X3+) — we deliberately don't overwrite an operator's
+/// hand-tuned profile from a stale YAML. Themes are read-only:
+/// no <c>POST /api/themes</c> in v1, so the YAML is the only
+/// source of truth and we always converge to it.
+/// </summary>
+public static class ThemeSeeder
+{
+    private static readonly IDeserializer Yaml = new DeserializerBuilder()
+        .WithNamingConvention(UnderscoredNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    /// <summary>
+    /// Load and upsert every theme YAML found under
+    /// <c>config/themes/global</c>. Returns the number of rows
+    /// inserted or updated for diagnostics.
+    /// </summary>
+    public static async Task<int> SeedAsync(
+        ContainersDbContext db,
+        IHostEnvironment env,
+        ILogger logger,
+        CancellationToken ct = default)
+    {
+        var directory = ResolveSeedDirectory(env);
+        if (directory is null)
+        {
+            logger.LogInformation(
+                "ThemeSeeder: no config/themes/global directory found; skipping seed.");
+            return 0;
+        }
+
+        var files = Directory.GetFiles(directory, "*.yaml", SearchOption.TopDirectoryOnly);
+        if (files.Length == 0)
+        {
+            logger.LogInformation(
+                "ThemeSeeder: {Directory} has no *.yaml files; nothing to seed.", directory);
+            return 0;
+        }
+
+        var changes = 0;
+        foreach (var path in files.OrderBy(p => p, StringComparer.Ordinal))
+        {
+            try
+            {
+                var yaml = await File.ReadAllTextAsync(path, ct);
+                var record = Yaml.Deserialize<SeedRecord>(yaml);
+                if (record is null)
+                {
+                    logger.LogWarning(
+                        "ThemeSeeder: {Path} parsed to null; skipping.", path);
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(record.Id) ||
+                    string.IsNullOrWhiteSpace(record.Name) ||
+                    string.IsNullOrWhiteSpace(record.DisplayName) ||
+                    string.IsNullOrWhiteSpace(record.Kind))
+                {
+                    logger.LogWarning(
+                        "ThemeSeeder: {Path} missing required field (id/name/display_name/kind); skipping.",
+                        path);
+                    continue;
+                }
+
+                if (record.Palette is null || record.Palette.Count == 0)
+                {
+                    logger.LogWarning(
+                        "ThemeSeeder: {Path} has empty palette; skipping.", path);
+                    continue;
+                }
+
+                // Serialise the palette dictionary as compact JSON
+                // for storage. The Conductor client deserialises
+                // back to its own typed Theme model — keeping the
+                // backend column dialect-portable (TEXT in SQLite,
+                // also TEXT in Postgres for ergonomic equality
+                // checks against the catalog row).
+                var paletteJson = JsonSerializer.Serialize(
+                    record.Palette,
+                    new JsonSerializerOptions { WriteIndented = false });
+
+                var existing = await db.Themes
+                    .FirstOrDefaultAsync(t => t.Id == record.Id, ct);
+
+                if (existing is null)
+                {
+                    db.Themes.Add(new Theme
+                    {
+                        Id = record.Id,
+                        Name = record.Name,
+                        DisplayName = record.DisplayName,
+                        Kind = record.Kind,
+                        PaletteJson = paletteJson,
+                        Version = record.Version <= 0 ? 1 : record.Version,
+                    });
+                    changes++;
+                    logger.LogInformation(
+                        "ThemeSeeder: seeded new theme '{Id}' from {Path}.",
+                        record.Id, path);
+                }
+                else
+                {
+                    var mutated = false;
+                    if (existing.Name != record.Name) { existing.Name = record.Name; mutated = true; }
+                    if (existing.DisplayName != record.DisplayName) { existing.DisplayName = record.DisplayName; mutated = true; }
+                    if (existing.Kind != record.Kind) { existing.Kind = record.Kind; mutated = true; }
+                    if (existing.PaletteJson != paletteJson) { existing.PaletteJson = paletteJson; mutated = true; }
+                    var newVersion = record.Version <= 0 ? 1 : record.Version;
+                    if (existing.Version != newVersion) { existing.Version = newVersion; mutated = true; }
+
+                    if (mutated)
+                    {
+                        changes++;
+                        logger.LogInformation(
+                            "ThemeSeeder: refreshed theme '{Id}' from {Path}.",
+                            record.Id, path);
+                    }
+                    else
+                    {
+                        logger.LogDebug(
+                            "ThemeSeeder: theme '{Id}' unchanged; leaving as-is.",
+                            record.Id);
+                    }
+                }
+            }
+            catch (YamlException ex)
+            {
+                logger.LogWarning(ex,
+                    "ThemeSeeder: malformed YAML in {Path}; skipping. {Message}",
+                    path, ex.Message);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "ThemeSeeder: failed to seed {Path}; skipping. {Message}",
+                    path, ex.Message);
+            }
+        }
+
+        if (changes > 0)
+        {
+            await db.SaveChangesAsync(ct);
+            logger.LogInformation(
+                "ThemeSeeder: persisted {Count} theme row(s).", changes);
+        }
+
+        return changes;
+    }
+
+    /// <summary>
+    /// Walk likely roots so the seeder works under <c>dotnet run</c>
+    /// from the project dir, from the repo root, or from a publish
+    /// output. Same shape as <see cref="EnvironmentProfileSeeder"/>;
+    /// duplicated deliberately so an extraction into a worker
+    /// process later is a single move.
+    /// </summary>
+    internal static string? ResolveSeedDirectory(IHostEnvironment env)
+    {
+        foreach (var candidate in EnumerateCandidates(env))
+        {
+            if (Directory.Exists(candidate)) return candidate;
+        }
+        return null;
+    }
+
+    private static IEnumerable<string> EnumerateCandidates(IHostEnvironment env)
+    {
+        // Project dir (../..) — matches `dotnet run` from src/Andy.Containers.Api.
+        yield return Path.GetFullPath(
+            Path.Combine(env.ContentRootPath, "..", "..", "config", "themes", "global"));
+        // Repo root.
+        yield return Path.Combine(env.ContentRootPath, "config", "themes", "global");
+        // Walk up to find it (handles publish output / docker /app).
+        var dir = env.ContentRootPath;
+        for (var i = 0; i < 5; i++)
+        {
+            var parent = Directory.GetParent(dir)?.FullName;
+            if (parent is null) yield break;
+            var candidate = Path.Combine(parent, "config", "themes", "global");
+            if (Directory.Exists(candidate))
+            {
+                yield return candidate;
+                yield break;
+            }
+            dir = parent;
+        }
+    }
+
+    /// <summary>
+    /// YAML wire shape — see config/themes/global/dracula.yaml for
+    /// the canonical example. Map names use snake_case so the
+    /// existing UnderscoredNamingConvention covers both this and
+    /// EnvironmentProfileSeeder without a separate deserialiser.
+    /// </summary>
+    internal sealed class SeedRecord
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
+        public string Kind { get; set; } = string.Empty;
+        public int Version { get; set; } = 1;
+        public Dictionary<string, string>? Palette { get; set; }
+    }
+}

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -326,6 +326,15 @@ try
             .GetRequiredService<ILoggerFactory>()
             .CreateLogger(typeof(EnvironmentProfileSeeder));
         await EnvironmentProfileSeeder.SeedAsync(db, app.Environment, seederLogger);
+
+        // Conductor #886. Theme catalog from config/themes/global/*.yaml.
+        // Unlike EnvironmentProfile, themes are read-only (no POST API
+        // in v1) so re-seeding always reconciles existing rows to
+        // whatever the YAML says.
+        var themeSeederLogger = scope.ServiceProvider
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger(typeof(ThemeSeeder));
+        await ThemeSeeder.SeedAsync(db, app.Environment, themeSeederLogger);
     }
 
     app.UseHttpsRedirection();

--- a/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
+++ b/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
@@ -26,6 +26,7 @@ public class ContainersDbContext : DbContext
     public DbSet<OutboxEntry> OutboxEntries => Set<OutboxEntry>();
     public DbSet<Run> Runs => Set<Run>();
     public DbSet<EnvironmentProfile> EnvironmentProfiles => Set<EnvironmentProfile>();
+    public DbSet<Theme> Themes => Set<Theme>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -305,5 +306,41 @@ public class ContainersDbContext : DbContext
                 c.Property(x => x.AuditMode).HasConversion<string>();
             });
         });
+
+        // Theme — predefined visual catalog (Conductor #886).
+        // String primary key matches the YAML-seeded slug ("dracula",
+        // "github-dark", …) so cross-deploy ids stay predictable. The
+        // palette is JSON-encoded as TEXT so the catalog is portable
+        // between Postgres and the embedded-SQLite host without
+        // dialect-aware schema. Deletion of a referenced theme falls
+        // through as ON DELETE SET NULL on the FK columns below — the
+        // container/template stays alive, picker just reverts to
+        // resolution fallback.
+        modelBuilder.Entity<Theme>(e =>
+        {
+            e.HasKey(t => t.Id);
+            e.Property(t => t.Id).IsRequired().HasMaxLength(64);
+            e.Property(t => t.Name).IsRequired().HasMaxLength(64);
+            e.Property(t => t.DisplayName).IsRequired().HasMaxLength(200);
+            e.Property(t => t.Kind).IsRequired().HasMaxLength(32);
+            e.Property(t => t.PaletteJson).IsRequired();
+            e.HasIndex(t => t.Name).IsUnique();
+            e.HasIndex(t => t.Kind);
+        });
+
+        // Container.ThemeId / ContainerTemplate.ThemeId → Theme.Id
+        // FK with ON DELETE SET NULL (the container is independent
+        // of the catalog row's lifetime).
+        modelBuilder.Entity<Container>()
+            .HasOne<Theme>()
+            .WithMany()
+            .HasForeignKey(c => c.ThemeId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder.Entity<ContainerTemplate>()
+            .HasOne<Theme>()
+            .WithMany()
+            .HasForeignKey(t => t.ThemeId)
+            .OnDelete(DeleteBehavior.SetNull);
     }
 }

--- a/src/Andy.Containers/Models/Container.cs
+++ b/src/Andy.Containers/Models/Container.cs
@@ -55,6 +55,17 @@ public class Container
     /// </summary>
     public string? OsLabel { get; set; }
 
+    /// <summary>
+    /// Optional reference to a <see cref="Theme"/> id. When set,
+    /// this container's terminal / IDE / VNC surfaces use the
+    /// referenced palette regardless of what the source template
+    /// or the user preference says. When null, resolution falls
+    /// through to <see cref="Template"/>.<see cref="ContainerTemplate.ThemeId"/>,
+    /// then to the Conductor user pref, then to the hardcoded
+    /// default. Conductor #886.
+    /// </summary>
+    public string? ThemeId { get; set; }
+
     public ICollection<ContainerSession> Sessions { get; set; } = new List<ContainerSession>();
     public ICollection<ContainerEvent> Events { get; set; } = new List<ContainerEvent>();
     public ICollection<ContainerGitRepository> GitRepositories { get; set; } = new List<ContainerGitRepository>();

--- a/src/Andy.Containers/Models/ContainerTemplate.cs
+++ b/src/Andy.Containers/Models/ContainerTemplate.cs
@@ -30,6 +30,16 @@ public class ContainerTemplate
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime? UpdatedAt { get; set; }
     public string? Metadata { get; set; }
+
+    /// <summary>
+    /// Optional reference to a <see cref="Theme"/> id. Containers
+    /// created from this template inherit this as their initial
+    /// theme. Operators can change it later via the template
+    /// detail editor; existing containers are NOT retroactively
+    /// updated (per-container theme overrides are sticky).
+    /// Conductor #886.
+    /// </summary>
+    public string? ThemeId { get; set; }
 }
 
 public enum CatalogScope

--- a/src/Andy.Containers/Models/Theme.cs
+++ b/src/Andy.Containers/Models/Theme.cs
@@ -1,0 +1,80 @@
+namespace Andy.Containers.Models;
+
+/// <summary>
+/// Predefined visual theme that can be attached to a container or
+/// a template. Conductor #886.
+///
+/// Themes are catalog records: seeded from
+/// <c>config/themes/global/*.yaml</c> at startup (mirroring the
+/// X2 EnvironmentProfile pattern), exposed via
+/// <c>GET /api/themes</c>, and referenced by
+/// <see cref="Container.ThemeId"/> /
+/// <see cref="ContainerTemplate.ThemeId"/>.
+///
+/// Catalog-vs-instance: this entity is read-only-by-default for
+/// API consumers (no <c>POST /api/themes</c> in v1). Operators
+/// add themes by adding YAML files; the seeder upserts them at
+/// next host start. User-defined themes are deliberately out of
+/// scope for v1 (story-level decision).
+///
+/// Resolution at session-attach time follows a fixed precedence:
+/// container > template > Conductor user preference > hardcoded
+/// default. Conductor's <c>ThemeResolver</c> implements the
+/// chain; this entity is just storage.
+/// </summary>
+public class Theme
+{
+    /// <summary>
+    /// Stable catalog id (e.g. "dracula", "github-dark"). Unique
+    /// across the catalog. Seeded entries use a slug derived from
+    /// the YAML filename so cross-deploy ids are predictable.
+    /// </summary>
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// Machine-readable name — typically equal to <see cref="Id"/>
+    /// but kept separate so a future rename can ship a stable id
+    /// + a refreshed name without invalidating containers that
+    /// already reference the old id.
+    /// </summary>
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// Human-readable display name shown in the picker UI
+    /// (e.g. "Dracula", "GitHub Dark").
+    /// </summary>
+    public required string DisplayName { get; set; }
+
+    /// <summary>
+    /// Surface this theme applies to: <c>terminal</c>, <c>ide</c>,
+    /// or <c>vnc</c>. The picker filters by kind so users only
+    /// see palette options that make sense for the surface
+    /// they're configuring.
+    /// </summary>
+    public required string Kind { get; set; }
+
+    /// <summary>
+    /// JSON-encoded palette. Schema is documented in
+    /// <c>docs/design/theme-persistence.md</c>; the consumer
+    /// (Conductor) parses it. Stored as a string column rather
+    /// than a relational JSON column so the catalog stays
+    /// portable across Postgres + SQLite without schema-per-
+    /// dialect handling.
+    /// </summary>
+    public required string PaletteJson { get; set; }
+
+    /// <summary>
+    /// Schema version for the palette JSON. Bumped when the
+    /// canonical key set changes (e.g. adding 256-color
+    /// extensions on top of the 16-color base). Lets clients
+    /// reject palettes they don't understand without crashing.
+    /// </summary>
+    public int Version { get; set; } = 1;
+
+    /// <summary>
+    /// When the seeder first inserted this row. Stable across
+    /// re-seeds — only the mutable fields (display name, palette,
+    /// version) get refreshed on subsequent runs.
+    /// </summary>
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerTests.cs
@@ -301,4 +301,100 @@ public class ContainersControllerTests : IDisposable
         type.GetProperty("message")!.GetValue(payload).Should().BeOfType<string>()
             .Which.Should().Contain("32 containers");
     }
+
+    // MARK: - SetTheme (#886)
+
+    [Fact]
+    public async Task SetTheme_ValidThemeId_PersistsAndReturnsContainer()
+    {
+        var containerId = Guid.NewGuid();
+        _db.Containers.Add(new Container
+        {
+            Id = containerId,
+            Name = "test",
+            OwnerId = "test-user",
+        });
+        _db.Themes.Add(new Theme
+        {
+            Id = "dracula",
+            Name = "dracula",
+            DisplayName = "Dracula",
+            Kind = "terminal",
+            PaletteJson = "{}",
+            Version = 1,
+        });
+        await _db.SaveChangesAsync();
+
+        var result = await _controller.SetTheme(
+            containerId,
+            new SetThemeRequest { ThemeId = "dracula" },
+            CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>();
+        var updated = await _db.Containers.FindAsync(containerId);
+        updated!.ThemeId.Should().Be("dracula",
+            "the per-container theme override is what makes the persistence story work — losing it here breaks the whole feature");
+    }
+
+    [Fact]
+    public async Task SetTheme_NullThemeId_ClearsOverride()
+    {
+        // Clearing the override falls through to template /
+        // user-pref / hardcoded resolution — explicitly setting
+        // null is how the picker says "go back to the default".
+        var containerId = Guid.NewGuid();
+        _db.Containers.Add(new Container
+        {
+            Id = containerId,
+            Name = "test",
+            OwnerId = "test-user",
+            ThemeId = "dracula",
+        });
+        await _db.SaveChangesAsync();
+
+        var result = await _controller.SetTheme(
+            containerId,
+            new SetThemeRequest { ThemeId = null },
+            CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>();
+        var updated = await _db.Containers.FindAsync(containerId);
+        updated!.ThemeId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SetTheme_UnknownThemeId_Returns422()
+    {
+        // The catalog is authoritative — accepting an unknown id
+        // would let stale clients write ghost references that the
+        // resolver would then silently drop on every attach.
+        var containerId = Guid.NewGuid();
+        _db.Containers.Add(new Container
+        {
+            Id = containerId,
+            Name = "test",
+            OwnerId = "test-user",
+        });
+        await _db.SaveChangesAsync();
+
+        var result = await _controller.SetTheme(
+            containerId,
+            new SetThemeRequest { ThemeId = "doesnotexist" },
+            CancellationToken.None);
+
+        var unprocessable = result.Should().BeOfType<UnprocessableEntityObjectResult>().Subject;
+        var payload = unprocessable.Value!;
+        payload.GetType().GetProperty("code")!.GetValue(payload).Should().Be("unknown_theme");
+    }
+
+    [Fact]
+    public async Task SetTheme_UnknownContainer_Returns404()
+    {
+        var result = await _controller.SetTheme(
+            Guid.NewGuid(),
+            new SetThemeRequest { ThemeId = "dracula" },
+            CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
 }

--- a/tests/Andy.Containers.Api.Tests/Controllers/ThemesControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ThemesControllerTests.cs
@@ -1,0 +1,145 @@
+using Andy.Containers.Api.Controllers;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Controllers;
+
+// Conductor #886. The catalog endpoint is read-only — most of the
+// controller's value is in the projection (palette JSON → Dict)
+// and the optional kind filter. These tests pin both.
+public class ThemesControllerTests : IDisposable
+{
+    private readonly ContainersDbContext _db;
+    private readonly ThemesController _controller;
+
+    public ThemesControllerTests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+        _controller = new ThemesController(_db, NullLogger<ThemesController>.Instance);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task List_ReturnsAllThemes_OrderedByDisplayName()
+    {
+        Seed("dracula", "Dracula", "terminal");
+        Seed("nord", "Nord", "terminal");
+        Seed("github-dark", "GitHub Dark", "terminal");
+        await _db.SaveChangesAsync();
+
+        var result = await _controller.List(kind: null, CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var payload = ok.Value!;
+        var items = (IEnumerable<ThemeDto>)payload.GetType().GetProperty("items")!.GetValue(payload)!;
+        items.Should().HaveCount(3);
+        items.Select(d => d.DisplayName).Should().BeEquivalentTo(
+            new[] { "Dracula", "GitHub Dark", "Nord" },
+            // Order is alphabetical-by-display-name to give the picker
+            // a stable presentation regardless of insert order.
+            options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public async Task List_KindFilter_ReturnsOnlyMatchingKind()
+    {
+        Seed("dracula", "Dracula", "terminal");
+        Seed("ide-light", "IDE Light", "ide");
+        await _db.SaveChangesAsync();
+
+        var result = await _controller.List(kind: "terminal", CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var items = (IEnumerable<ThemeDto>)ok.Value!.GetType().GetProperty("items")!.GetValue(ok.Value)!;
+        items.Should().HaveCount(1);
+        items.Single().Id.Should().Be("dracula");
+    }
+
+    [Fact]
+    public async Task List_UnknownKind_ReturnsEmptyList_Not400()
+    {
+        // The catalog is authoritative — an unknown filter just
+        // returns no rows. Returning 400 for "kind=foo" would
+        // mean the picker has to second-guess what's valid before
+        // querying, which the API contract explicitly avoids.
+        Seed("dracula", "Dracula", "terminal");
+        await _db.SaveChangesAsync();
+
+        var result = await _controller.List(kind: "fictional", CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var items = (IEnumerable<ThemeDto>)ok.Value!.GetType().GetProperty("items")!.GetValue(ok.Value)!;
+        items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task List_ParsesPaletteToDictionary()
+    {
+        // The wire shape promises a parsed palette dictionary, not
+        // a raw JSON string. A DTO regression here breaks every
+        // Conductor client that expects to read `theme.palette["background"]`.
+        _db.Themes.Add(new Theme
+        {
+            Id = "dracula",
+            Name = "dracula",
+            DisplayName = "Dracula",
+            Kind = "terminal",
+            PaletteJson = "{\"background\":\"#282a36\",\"foreground\":\"#f8f8f2\"}",
+            Version = 1,
+        });
+        await _db.SaveChangesAsync();
+
+        var result = await _controller.List(kind: null, CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var items = (IEnumerable<ThemeDto>)ok.Value!.GetType().GetProperty("items")!.GetValue(ok.Value)!;
+        var dto = items.Single();
+        dto.Palette["background"].Should().Be("#282a36");
+        dto.Palette["foreground"].Should().Be("#f8f8f2");
+    }
+
+    [Fact]
+    public async Task List_MalformedPaletteJson_ReturnsEmptyPaletteWithoutCrashing()
+    {
+        // Defensive: the seeder catches malformed YAML, but a row
+        // with broken JSON could still make it into the catalog
+        // through a manual DB edit. The endpoint must not crash —
+        // it returns the row with an empty palette and the picker
+        // shows a placeholder.
+        _db.Themes.Add(new Theme
+        {
+            Id = "broken",
+            Name = "broken",
+            DisplayName = "Broken",
+            Kind = "terminal",
+            PaletteJson = "this is not json",
+            Version = 1,
+        });
+        await _db.SaveChangesAsync();
+
+        var result = await _controller.List(kind: null, CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var items = (IEnumerable<ThemeDto>)ok.Value!.GetType().GetProperty("items")!.GetValue(ok.Value)!;
+        items.Single().Palette.Should().BeEmpty();
+    }
+
+    private void Seed(string id, string display, string kind)
+    {
+        _db.Themes.Add(new Theme
+        {
+            Id = id,
+            Name = id,
+            DisplayName = display,
+            Kind = kind,
+            PaletteJson = "{\"background\":\"#000\",\"foreground\":\"#fff\"}",
+            Version = 1,
+        });
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Data/ThemeSeederTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Data/ThemeSeederTests.cs
@@ -1,0 +1,196 @@
+using Andy.Containers.Api.Data;
+using Andy.Containers.Api.Tests.Helpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using System.Text.Json;
+
+namespace Andy.Containers.Api.Tests.Data;
+
+// Conductor #886. The seeder loads YAML at startup, upserts by
+// Theme.Id, and must never crash the host on a bad file. These
+// tests pin the contract: fresh insert / idempotent re-run /
+// upsert on YAML edits / invalid file skipped without aborting.
+public class ThemeSeederTests : IDisposable
+{
+    private readonly string _seedDir;
+    private readonly Mock<IHostEnvironment> _env = new();
+
+    public ThemeSeederTests()
+    {
+        _seedDir = Path.Combine(
+            Path.GetTempPath(),
+            $"theme-seeder-{Guid.NewGuid():N}",
+            "config", "themes", "global");
+        Directory.CreateDirectory(_seedDir);
+
+        var contentRoot = Path.GetFullPath(Path.Combine(_seedDir, "..", "..", "..", "src", "Andy.Containers.Api"));
+        Directory.CreateDirectory(contentRoot);
+        _env.Setup(e => e.ContentRootPath).Returns(contentRoot);
+    }
+
+    public void Dispose()
+    {
+        var root = Directory.GetParent(Directory.GetParent(_seedDir)!.FullName)!.FullName;
+        if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
+    public async Task SeedAsync_FreshDb_InsertsThemesWithParsedPalette()
+    {
+        WriteSeed("dracula.yaml", DraculaYaml);
+        WriteSeed("nord.yaml", NordYaml);
+
+        using var db = InMemoryDbHelper.CreateContext();
+        var changes = await ThemeSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+
+        changes.Should().Be(2);
+        var themes = await db.Themes.OrderBy(t => t.Id).ToListAsync();
+        themes.Should().HaveCount(2);
+        themes.Select(t => t.Id).Should().BeEquivalentTo(new[] { "dracula", "nord" });
+
+        var dracula = themes.Single(t => t.Id == "dracula");
+        dracula.DisplayName.Should().Be("Dracula");
+        dracula.Kind.Should().Be("terminal");
+        dracula.Version.Should().Be(1);
+
+        // Palette must round-trip cleanly through the JSON
+        // envelope — a malformed serialise would silently ship
+        // an empty palette downstream and break every theme that
+        // depends on this seeder.
+        var palette = JsonSerializer.Deserialize<Dictionary<string, string>>(dracula.PaletteJson)!;
+        palette["background"].Should().Be("#282a36");
+        palette["foreground"].Should().Be("#f8f8f2");
+        palette["ansi_4"].Should().Be("#bd93f9");
+    }
+
+    [Fact]
+    public async Task SeedAsync_RerunOnUnchangedYaml_ReportsZeroChanges()
+    {
+        // Idempotency: re-running the seeder with the same YAML
+        // must not produce phantom write traffic. A `changes > 0`
+        // here would mean every host start dirties the row even
+        // when nothing changed, which trips downstream
+        // notifications + breaks the "no-op startup" promise.
+        WriteSeed("dracula.yaml", DraculaYaml);
+
+        using var db = InMemoryDbHelper.CreateContext();
+        await ThemeSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+
+        var second = await ThemeSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+        second.Should().Be(0, "re-running on an unchanged YAML must produce zero updates");
+    }
+
+    [Fact]
+    public async Task SeedAsync_RerunAfterYamlEdit_RefreshesRowFields()
+    {
+        // The contract for theme seed (unlike EnvironmentProfile):
+        // YAML is the source of truth. An operator-edited YAML
+        // must reconcile to the DB on next start. This is what
+        // distinguishes our upsert from EnvironmentProfileSeeder's
+        // insert-only path.
+        WriteSeed("dracula.yaml", DraculaYaml);
+
+        using var db = InMemoryDbHelper.CreateContext();
+        await ThemeSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+
+        // Edit the YAML — bump display name + version.
+        WriteSeed("dracula.yaml", DraculaYaml.Replace("Dracula", "Dracula Pro").Replace("version: 1", "version: 2"));
+        var changes = await ThemeSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+
+        changes.Should().Be(1);
+        var dracula = await db.Themes.SingleAsync(t => t.Id == "dracula");
+        dracula.DisplayName.Should().Be("Dracula Pro");
+        dracula.Version.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task SeedAsync_MalformedYaml_SkipsWithoutAborting()
+    {
+        // Host startup must NEVER abort on a bad seed entry —
+        // operators iterate on YAML files locally and a missing
+        // colon shouldn't take the service offline. The other
+        // (well-formed) files in the directory still seed.
+        WriteSeed("dracula.yaml", DraculaYaml);
+        WriteSeed("broken.yaml", "this: : invalid: yaml");
+
+        using var db = InMemoryDbHelper.CreateContext();
+        var changes = await ThemeSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+
+        // Dracula seeded; the malformed file produced no row.
+        changes.Should().Be(1);
+        var themes = await db.Themes.ToListAsync();
+        themes.Should().HaveCount(1);
+        themes.Single().Id.Should().Be("dracula");
+    }
+
+    [Fact]
+    public async Task SeedAsync_FileMissingRequiredFields_SkipsWithWarning()
+    {
+        // No id, no name, no display_name → skip. The seed
+        // path has to be defensive against operator typos.
+        WriteSeed("missing-fields.yaml", "kind: terminal\nversion: 1\npalette:\n  background: '#000'");
+
+        using var db = InMemoryDbHelper.CreateContext();
+        var changes = await ThemeSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+
+        changes.Should().Be(0);
+        var themes = await db.Themes.ToListAsync();
+        themes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SeedAsync_FileWithEmptyPalette_Skipped()
+    {
+        // A theme with no palette is useless to consumers — we
+        // skip it so downstream code never has to handle the
+        // "valid theme, no colours" edge case.
+        WriteSeed("empty.yaml",
+            "id: empty\nname: empty\ndisplay_name: Empty\nkind: terminal\nversion: 1\npalette: {}\n");
+
+        using var db = InMemoryDbHelper.CreateContext();
+        var changes = await ThemeSeeder.SeedAsync(db, _env.Object, NullLogger.Instance);
+
+        changes.Should().Be(0);
+    }
+
+    // MARK: - Helpers
+
+    private void WriteSeed(string filename, string contents)
+    {
+        File.WriteAllText(Path.Combine(_seedDir, filename), contents);
+    }
+
+    private const string DraculaYaml = @"id: dracula
+name: dracula
+display_name: Dracula
+kind: terminal
+version: 1
+palette:
+  background: ""#282a36""
+  foreground: ""#f8f8f2""
+  cursor: ""#f8f8f2""
+  selection: ""#44475a""
+  ansi_0: ""#21222c""
+  ansi_1: ""#ff5555""
+  ansi_2: ""#50fa7b""
+  ansi_3: ""#f1fa8c""
+  ansi_4: ""#bd93f9""
+  ansi_5: ""#ff79c6""
+  ansi_6: ""#8be9fd""
+  ansi_7: ""#f8f8f2""
+";
+
+    private const string NordYaml = @"id: nord
+name: nord
+display_name: Nord
+kind: terminal
+version: 1
+palette:
+  background: ""#2e3440""
+  foreground: ""#d8dee9""
+";
+}


### PR DESCRIPTION
## Summary
- New \`Theme\` entity + \`Themes\` table with FK columns on Container / ContainerTemplate.
- \`GET /api/themes\` (?kind= filter) — read-only catalog seeded from \`config/themes/global/*.yaml\` at startup.
- \`PATCH /api/containers/{id}/theme\` — sets/clears the per-container override; unknown id → 422 \`code: "unknown_theme"\`.
- \`PUT /api/templates/{id}\` extended to copy \`themeId\`.
- 5 starter themes ship: Dracula, GitHub Dark, Solarized Dark, Nord, Monokai.

## Catalog
YAML is the source of truth — \`ThemeSeeder\` reconciles existing rows on every startup (unlike \`EnvironmentProfileSeeder\` which preserves operator hand-edits, themes have no edit API in v1). Idempotent on unchanged YAML.

## Persistence
- String PK on \`Themes\` matches the YAML slug — predictable across deploys.
- Palette JSON-encoded as TEXT for dialect portability (Postgres + embedded SQLite).
- FK with \`ON DELETE SET NULL\` so a deleted catalog row falls through resolution rather than orphaning the container.

## Test plan
- [x] 15 new tests across \`ThemeSeederTests\` (6), \`ThemesControllerTests\` (5), \`ContainersControllerTests.SetTheme\` (4). All pass.
- [x] Backend build clean.

Tracks rivoli-ai/conductor#886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)