### PR TITLE
fix(terminal): detach stale tmux clients on each attach (-A -D)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/TerminalController.cs
+++ b/src/Andy.Containers.Api/Controllers/TerminalController.cs
@@ -1082,7 +1082,22 @@ public class TerminalController : ControllerBase
                     $"fi; " +
                $"fi; " +
                $"if command -v tmux >/dev/null 2>&1; then " +
-                    $"exec tmux -f \"$TMUX_CONF\" new-session -A -s {TmuxSessionName} bash -i; " +
+                    // -A: attach if session exists, otherwise create.
+                    // -D: when -A attaches, detach all OTHER clients
+                    //     first. Without -D, every reconnect spawned
+                    //     a fresh tmux client without ever sending
+                    //     SIGHUP to the prior one — clients piled up
+                    //     (one per attach) because the docker-exec
+                    //     PTY chain doesn't reliably propagate SIGHUP
+                    //     into the container when the WebSocket
+                    //     drops. -D makes tmux itself evict the
+                    //     stale client, which it does cleanly via
+                    //     its own client-detach path. Conductor
+                    //     enforces a single-attach invariant per
+                    //     container (embedded XOR detached, see
+                    //     #830), so detach-others is the right
+                    //     semantic.
+                    $"exec tmux -f \"$TMUX_CONF\" new-session -A -D -s {TmuxSessionName} bash -i; " +
                $"else " +
                     $"exec bash -i; " +
                $"fi";

--- a/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
@@ -413,14 +413,21 @@ public class TerminalControllerTests : IDisposable
     }
 
     [Fact]
-    public void BuildContainerShellCommand_ExecsTmuxNewSessionAttachOrCreate()
+    public void BuildContainerShellCommand_ExecsTmuxNewSessionAttachOrCreateAndDetachOthers()
     {
         // The end of the command must launch tmux in attach-if-exists,
-        // create-if-not mode. `-A` is the flag; `-s web` is the fixed
-        // session name shared with the probe. Conductor #875 PR 2.
+        // create-if-not mode AND detach any prior client. -A gives
+        // attach-or-create (persistence across reconnects); -D, when
+        // combined with -A, makes attach evict any client already on
+        // the session — without that we leak one tmux client per
+        // attach because the docker-exec PTY chain doesn't
+        // propagate SIGHUP into the container reliably when the
+        // WebSocket drops. Single-attach is the design invariant
+        // (embedded XOR detached, see Conductor #830). Conductor
+        // #875 PR 2 + tmux-leak fix.
         var cmd = TerminalController.BuildContainerShellCommand(rows: 40, cols: 120);
-        cmd.Should().Contain($"new-session -A -s {TerminalController.TmuxSessionName} bash -i",
-            "tmux must use -A for attach-or-create — that gives us persistence across reconnects");
+        cmd.Should().Contain($"new-session -A -D -s {TerminalController.TmuxSessionName} bash -i",
+            "tmux must use -A -D so each attach replaces the prior client instead of stacking on top");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Each terminal WebSocket attach was spawning a fresh `tmux new-session -A` client. When the WS dropped, SIGHUP did not propagate reliably through the docker-exec PTY chain into the container, so the prior tmux client survived and the next attach stacked another one on top. Result: dozens of orphaned tmux clients per session over time (observed `pts/3..pts/16` in a single live container).

Add `-D` to the tmux invocation so each attach forces tmux to detach all OTHER clients before attaching the new one. tmux handles the eviction via its own client-detach path, which reliably terminates the prior process.

The Conductor client enforces a single-attach invariant per container (embedded XOR detached, Conductor #830), so detach-others is the right semantic.

## Test plan
- [x] `BuildContainerShellCommand_ExecsTmuxNewSessionAttachOrCreateAndDetachOthers` updated to pin `-A -D` so future changes can't silently regress it
- [x] All 10 `BuildContainerShellCommand_*` unit tests pass
- [ ] Manual smoke after deploy: open + close + reopen a workspace's terminal a few times, confirm only one tmux client process remains in the container