### PR TITLE
chore(deps): bump OpenTelemetry.Exporter.OpenTelemetryProtocol 1.11.2 → 1.15.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -63,7 +63,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.11.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.11.2" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1" />
     <!-- Messaging (ADR 0001) — version-aligned with andy-tasks -->


### PR DESCRIPTION
## Summary

Bumps `OpenTelemetry.Exporter.OpenTelemetryProtocol` from 1.11.2 to 1.15.3 in `Directory.Packages.props`. Pulls in OpenTelemetry SDK 1.15.3 transitively.

Other OTel packages (Instrumentation.*, Exporter.Console, Extensions.Hosting) stay on 1.11.x — 1.x instrumentations are forward-compatible with a newer SDK within the same major.

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] `dotnet list package --include-transitive` confirms OTel SDK resolves to 1.15.3 with no conflicts
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)