### PR TITLE
RC3 (#201): extract EF migrations into 'andy-containers-api migrate' console entry

### DIFF
--- a/docs/operations/migrations.md
+++ b/docs/operations/migrations.md
@@ -1,0 +1,87 @@
+# Database migrations
+
+Andy Containers can apply EF Core migrations two ways: in-process at API
+startup, or out-of-band via the `andy-containers-api migrate` console
+entry. Pick the mode that matches your deployment shape.
+
+## When to use each
+
+| Deployment shape | Mode | Why |
+|---|---|---|
+| `docker compose` (single API container) | Startup migration | One process, no race. Default — no extra wiring needed. |
+| `dotnet run` (developer machine) | Startup migration | Same. |
+| Kubernetes / Helm (multi-replica rollout) | Migrate Job | N replicas booting in parallel would race on `MigrateAsync`. The Job runs once before the rollout. |
+| CI integration test | Either | Tests typically use the startup path with SQLite. |
+
+## Startup migration (default)
+
+`Database:MigrateOnStartup` is `true` in `appsettings.json`. On startup,
+the API:
+
+1. Resolves the configured provider (`Database:Provider`).
+2. Calls `MigrationEntryPoint.ApplyMigrationsAsync`, which dispatches to
+   `SqliteMigrationBootstrap.EnsureSchemaAsync` for SQLite (handles the
+   legacy-schema-without-migration-history case from #883) or
+   `MigrateAsync` for Postgres.
+3. Continues the normal startup flow (data seeders, Kestrel bind, etc.).
+
+To opt out — for instance in Kubernetes where the Helm chart provides a
+pre-upgrade Job — set:
+
+```yaml
+env:
+  - name: Database__MigrateOnStartup
+    value: "false"
+```
+
+The API then skips the migration block but still runs the data seeders
+(`DataSeeder`, `EnvironmentProfileSeeder`, `ThemeSeeder`) — those are
+idempotent and safe on every pod start.
+
+## `migrate` console entry
+
+```bash
+dotnet Andy.Containers.Api.dll migrate
+```
+
+(or, in a built container image, `andy-containers-api migrate`).
+
+Builds a minimal host (no Kestrel, no workers, no seeders), applies
+pending migrations, exits.
+
+- Exit `0` on success.
+- Exit non-zero on any migration failure. A single JSON line is written
+  to stderr with `{ "event": "migration_failed", "provider": "...",
+  "error": "...", "message": "..." }` so Helm hook log consumers can
+  branch on it without regex.
+
+The CLI inherits the same configuration chain as the API: `appsettings.*`,
+environment variables (`Database__Provider`,
+`ConnectionStrings__DefaultConnection`), and `--Key=Value` command-line
+overrides. A Helm Job typically passes the connection string via env vars
+sourced from a Secret.
+
+## Helm Job pattern (RC6)
+
+The chart in `charts/andy-containers/` (RC4–RC6) installs a
+`pre-install,pre-upgrade` hook Job that runs `andy-containers-api migrate`
+against the same Postgres the API pods will connect to. The API
+Deployment sets `Database__MigrateOnStartup=false`, so pods boot without
+touching the schema.
+
+Out of scope here:
+
+- `migrate --rollback <name>` — rolling back a migration is an out-of-band
+  ops task, not a CLI subcommand.
+- Online schema changes (zero-downtime DDL) — orthogonal concern.
+
+## Reference
+
+- `src/Andy.Containers.Api/MigrationEntryPoint.cs` — the entry point.
+- `src/Andy.Containers.Api/Services/SqliteMigrationBootstrap.cs` — legacy
+  SQLite history bootstrap (#883).
+- `tests/Andy.Containers.Api.Tests/MigrationEntryPointTests.cs` — exit
+  code + stderr envelope contracts.
+- Issue [#201](https://github.com/rivoli-ai/andy-containers/issues/201) — RC3 story.
+- Issue [#204](https://github.com/rivoli-ai/andy-containers/issues/204) — RC6 (Helm
+  Job) consumer.

--- a/src/Andy.Containers.Api/MigrationEntryPoint.cs
+++ b/src/Andy.Containers.Api/MigrationEntryPoint.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using Andy.Containers.Api.Data;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Containers.Api;
+
+/// <summary>
+/// Console entry point for `dotnet andy-containers-api migrate` (RC3, #201).
+/// Builds a minimal host (no Kestrel, no workers, no seeding), applies
+/// pending EF migrations, and exits. Sized to slot into a Helm
+/// pre-install / pre-upgrade Job (RC6, #204) so the rollout is decoupled
+/// from per-pod startup migration races.
+/// </summary>
+public static class MigrationEntryPoint
+{
+    /// <summary>
+    /// Runs migrations against the configured provider and returns a
+    /// process exit code. <c>0</c> on success, non-zero on any failure.
+    /// On failure a single JSON line is written to stderr so a Helm
+    /// hook log line can be parsed without scraping plain text.
+    /// </summary>
+    public static async Task<int> RunAsync(string[] args)
+    {
+        var builder = Host.CreateApplicationBuilder(args);
+
+        // Configuration mirrors Program.cs: appsettings → environment-
+        // specific → environment variables → command-line. Keeping the
+        // chain identical means a deployed Helm Job sees the same
+        // ConnectionStrings__DefaultConnection / Database__Provider env
+        // vars as the API pods.
+
+        var dbProvider = DatabaseProviderExtensions.GetDatabaseProvider(builder.Configuration);
+        var dbConnectionString = DatabaseProviderExtensions.ResolveConnectionString(
+            builder.Configuration, dbProvider);
+        builder.Services.AddDbContext<ContainersDbContext>(options =>
+        {
+            DatabaseProviderExtensions.ConfigureDbContext(options, dbProvider, dbConnectionString);
+        });
+
+        using var host = builder.Build();
+        using var scope = host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ContainersDbContext>();
+        var loggerFactory = scope.ServiceProvider.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger("MigrationEntryPoint");
+
+        try
+        {
+            await ApplyMigrationsAsync(db, loggerFactory);
+            logger.LogInformation("Migrations applied successfully (provider={Provider})", dbProvider);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            // Single-line JSON to stderr — Helm hook logs concatenate
+            // pod stderr verbatim, so a structured shape lets ops
+            // pipelines branch on `error` / `provider` without regex.
+            var payload = new
+            {
+                @event = "migration_failed",
+                provider = dbProvider.ToString(),
+                error = ex.GetType().FullName,
+                message = ex.Message,
+            };
+            await Console.Error.WriteLineAsync(JsonSerializer.Serialize(payload));
+            logger.LogError(ex, "Migration failed");
+            return 1;
+        }
+    }
+
+    /// <summary>
+    /// Applies pending migrations to <paramref name="db"/>, taking the
+    /// SQLite legacy-bootstrap path when the provider is SQLite. Shared
+    /// between this entry point and the Program.cs startup branch so
+    /// both surfaces stay in lock-step.
+    /// </summary>
+    public static async Task ApplyMigrationsAsync(
+        ContainersDbContext db,
+        ILoggerFactory loggerFactory)
+    {
+        if (db.Database.IsSqlite())
+        {
+            var bootstrapLogger = loggerFactory.CreateLogger("SqliteMigrationBootstrap");
+            await SqliteMigrationBootstrap.EnsureSchemaAsync(db, bootstrapLogger);
+        }
+        else
+        {
+            await db.Database.MigrateAsync();
+        }
+    }
+}

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -15,6 +15,24 @@ Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
     .CreateBootstrapLogger();
 
+// RC3 (#201). `dotnet Andy.Containers.Api migrate` short-circuits
+// the host build and runs EF migrations only — the path Helm's
+// pre-install / pre-upgrade Job (RC6) takes so the rollout is
+// decoupled from per-pod startup migration races. Default behaviour
+// (no args) is unchanged: the API boots and applies migrations
+// in-process unless `Database:MigrateOnStartup` is `false`.
+if (args.Length > 0 && args[0] == "migrate")
+{
+    try
+    {
+        return await Andy.Containers.Api.MigrationEntryPoint.RunAsync(args[1..]);
+    }
+    finally
+    {
+        Log.CloseAndFlush();
+    }
+}
+
 try
 {
     var builder = WebApplication.CreateBuilder(args);
@@ -305,16 +323,19 @@ try
     using (var scope = app.Services.CreateScope())
     {
         var db = scope.ServiceProvider.GetRequiredService<ContainersDbContext>();
-        if (db.Database.IsSqlite())
+
+        // RC3 (#201). `Database:MigrateOnStartup` defaults to true so
+        // existing single-process compose deploys are unchanged. Helm
+        // (RC6) sets it false and runs the dedicated `migrate` Job
+        // before the rollout — avoiding the multi-replica race where
+        // every pod tries to apply schema changes on startup.
+        var migrateOnStartup = builder.Configuration
+            .GetValue<bool?>("Database:MigrateOnStartup") ?? true;
+        if (migrateOnStartup)
         {
             var loggerFactory = scope.ServiceProvider.GetRequiredService<ILoggerFactory>();
-            var migrationLogger = loggerFactory.CreateLogger("SqliteMigrationBootstrap");
-            await Andy.Containers.Api.Services.SqliteMigrationBootstrap.EnsureSchemaAsync(
-                db, migrationLogger);
-        }
-        else
-        {
-            await db.Database.MigrateAsync();
+            await Andy.Containers.Api.MigrationEntryPoint
+                .ApplyMigrationsAsync(db, loggerFactory);
         }
         await DataSeeder.SeedAsync(db);
 
@@ -409,10 +430,12 @@ try
     Log.Information("Health: https://localhost:5200/health");
 
     app.Run();
+    return 0;
 }
 catch (Exception ex)
 {
     Log.Fatal(ex, "Andy Containers API terminated unexpectedly");
+    return 1;
 }
 finally
 {

--- a/src/Andy.Containers.Api/appsettings.json
+++ b/src/Andy.Containers.Api/appsettings.json
@@ -4,8 +4,9 @@
     "DefaultConnection": "Host=localhost;Port=5434;Database=andy_containers;Username=postgres;Password="
   },
   "Database": {
-    "_comment": "PostgreSQL is the hosted/Docker default. Conductor's embedded launcher overrides this with Database__Provider=Sqlite via environment variables.",
-    "Provider": "PostgreSql"
+    "_comment": "PostgreSQL is the hosted/Docker default. Conductor's embedded launcher overrides this with Database__Provider=Sqlite via environment variables. MigrateOnStartup gates the in-process startup migration; the Helm chart sets it false and runs `andy-containers-api migrate` as a pre-upgrade Job (RC3 #201).",
+    "Provider": "PostgreSql",
+    "MigrateOnStartup": true
   },
   "AndyAuth": {
     "Authority": "",

--- a/tests/Andy.Containers.Api.Tests/MigrationEntryPointTests.cs
+++ b/tests/Andy.Containers.Api.Tests/MigrationEntryPointTests.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using Andy.Containers.Api;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests;
+
+/// <summary>
+/// RC3 (#201). Exercises the <c>andy-containers-api migrate</c> CLI
+/// entry. The two contracts under test are the ones a Helm hook
+/// pipeline depends on:
+/// <list type="number">
+///   <item>Exit code 0 on success, non-zero on failure.</item>
+///   <item>On failure, a single JSON line goes to stderr — Helm hook
+///         logs concatenate stderr verbatim, so consumers can branch on
+///         <c>error</c> / <c>provider</c> without scraping plain text.</item>
+/// </list>
+/// SQLite is used here because the migration-history bootstrap path
+/// is the more interesting branch (see <c>SqliteMigrationBootstrap</c>);
+/// the Postgres path is a thin <c>MigrateAsync</c> wrapper covered
+/// implicitly when the integration suite runs against the real DB.
+/// </summary>
+public class MigrationEntryPointTests : IDisposable
+{
+    private readonly string _tempDbPath;
+
+    public MigrationEntryPointTests()
+    {
+        _tempDbPath = Path.Combine(
+            Path.GetTempPath(),
+            $"rc3-migrate-{Guid.NewGuid():N}.sqlite");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (File.Exists(_tempDbPath)) File.Delete(_tempDbPath);
+        }
+        catch (IOException) { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task RunAsync_OnFreshSqliteDb_AppliesMigrations_ReturnsZero()
+    {
+        var args = ConfigArgs(
+            ("Database:Provider", "Sqlite"),
+            ("ConnectionStrings:Sqlite", $"Data Source={_tempDbPath}"));
+
+        var exitCode = await MigrationEntryPoint.RunAsync(args);
+
+        exitCode.Should().Be(0, "successful migration must surface as exit 0 for the Helm hook");
+        File.Exists(_tempDbPath).Should().BeTrue("migration must create the SQLite file");
+    }
+
+    [Fact]
+    public async Task RunAsync_OnExistingSqliteDb_IsIdempotent_ReturnsZero()
+    {
+        // Re-running the migrate command must be a no-op exit-0 — Helm
+        // hooks may re-run if a release rolls back and forward.
+        var args = ConfigArgs(
+            ("Database:Provider", "Sqlite"),
+            ("ConnectionStrings:Sqlite", $"Data Source={_tempDbPath}"));
+
+        var first = await MigrationEntryPoint.RunAsync(args);
+        var second = await MigrationEntryPoint.RunAsync(args);
+
+        first.Should().Be(0);
+        second.Should().Be(0, "re-running migrate must be idempotent");
+    }
+
+    [Fact]
+    public async Task RunAsync_OnUnreachablePostgres_ReturnsOne_AndWritesStructuredStderr()
+    {
+        // Capture stderr so we can assert the JSON envelope shape. The
+        // rest of the pipeline (Helm hook log parser) treats this as
+        // the structured failure signal.
+        var originalErr = Console.Error;
+        using var capturedErr = new StringWriter();
+        Console.SetError(capturedErr);
+
+        try
+        {
+            var args = ConfigArgs(
+                ("Database:Provider", "PostgreSql"),
+                // Port deliberately closed; libpq fails fast.
+                ("ConnectionStrings:DefaultConnection",
+                 "Host=127.0.0.1;Port=1;Database=nope;Username=nope;Password=nope;Timeout=2"));
+
+            var exitCode = await MigrationEntryPoint.RunAsync(args);
+
+            exitCode.Should().NotBe(0, "an unreachable database must surface as a non-zero exit");
+            var stderr = capturedErr.ToString();
+            stderr.Should().NotBeEmpty("stderr must carry the failure envelope");
+
+            var jsonLine = stderr
+                .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+                .First(l => l.TrimStart().StartsWith("{"));
+            using var doc = JsonDocument.Parse(jsonLine);
+            doc.RootElement.GetProperty("event").GetString().Should().Be("migration_failed");
+            doc.RootElement.GetProperty("provider").GetString().Should().Be("PostgreSql");
+            doc.RootElement.GetProperty("error").GetString().Should().NotBeNullOrEmpty();
+            doc.RootElement.GetProperty("message").GetString().Should().NotBeNullOrEmpty();
+        }
+        finally
+        {
+            Console.SetError(originalErr);
+        }
+    }
+
+    /// <summary>
+    /// Build CLI args of the form <c>--Key=Value</c> that
+    /// <c>HostApplicationBuilder</c> picks up via the default command-
+    /// line configuration provider.
+    /// </summary>
+    private static string[] ConfigArgs(params (string Key, string Value)[] kvps)
+        => kvps.Select(kv => $"--{kv.Key}={kv.Value}").ToArray();
+}


### PR DESCRIPTION
Closes #201. Part of #198 (Epic RC).

## Summary

Splits the in-process startup migration into a dedicated CLI entry so Helm (RC6 #204) can run a pre-install / pre-upgrade `Job` once before the rollout, instead of every replica racing on `MigrateAsync` at pod startup.

- `MigrationEntryPoint.RunAsync(args)` builds a minimal `Host` (no Kestrel, no workers, no seeders), applies migrations, exits **0** on success or **1** with a single-line JSON envelope on stderr otherwise. Helm hook log consumers can branch on the `event` / `provider` / `error` / `message` fields without scraping plain text.
- `Program.cs` short-circuits on `args[0] == "migrate"` and returns the CLI exit code. Top-level Main returns int now (was implicit void).
- `Database:MigrateOnStartup` (default `true`) gates the in-process startup migration. Compose / `dotnet run` keep the default and are unchanged. Helm sets it `false`.
- Shared `MigrationEntryPoint.ApplyMigrationsAsync` keeps SQLite legacy-history bootstrap (#883) and Postgres `MigrateAsync` in lock-step across both surfaces.

## Acceptance criteria (from #201)

- [x] `dotnet Andy.Containers.Api migrate` applies pending migrations and exits 0 on success, non-zero on failure
- [x] `Database__MigrateOnStartup=false` skips the startup migration
- [x] Existing single-process compose deploy still works (default behaviour unchanged)
- [x] `docs/operations/migrations.md` exists

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] New `MigrationEntryPointTests` (3): fresh SQLite → exit 0; idempotent re-run → exit 0; unreachable Postgres → non-zero + structured JSON stderr
- [x] Smoke: `dotnet run --project src/Andy.Containers.Api -- migrate --Database:Provider=Sqlite --ConnectionStrings:Sqlite=...` → exit 0, DB file created, "Migrations applied successfully (provider=Sqlite)" log line
- [x] Full `Andy.Containers.Api.Tests` suite: 885/887 pass; the 1 failure (`TerminalControllerTests.ShellCommand_TmuxInvocationCreatesTheProbedSession`) is pre-existing on main and unrelated to migrations

## Out of scope

- `migrate --rollback <name>` — out-of-band ops task.
- Online schema changes (zero-downtime DDL) — orthogonal concern.
- Helm Job wiring — that lands in RC6 (#204) which this PR unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)