### PR TITLE
RC2 (#200): Data Protection keys → Postgres row store

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <!-- Entity Framework Core -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,10 @@ services:
       - ./certs:/usr/local/share/ca-certificates/custom:ro
       - ./images:/app/images:ro
       - ./scripts/container:/app/scripts/container:ro
-      - dataprotection_keys:/root/.aspnet/DataProtection-Keys
+      # Note: prior `dataprotection_keys:/root/.aspnet/DataProtection-Keys`
+      # mount removed in RC2 (#200) — Data Protection keys now live in
+      # the `DataProtectionKeys` Postgres table so multiple replicas
+      # share the key ring. See docs/operations/data-protection.md.
     depends_on:
       postgres:
         condition: service_healthy
@@ -123,5 +126,4 @@ services:
 
 volumes:
   postgres_data:
-  dataprotection_keys:
   nats_data:

--- a/docs/operations/data-protection.md
+++ b/docs/operations/data-protection.md
@@ -1,0 +1,73 @@
+# Data Protection keys
+
+ASP.NET Core's [Data Protection](https://learn.microsoft.com/aspnet/core/security/data-protection/introduction) subsystem encrypts every payload that needs at-rest protection inside the API: cookies, anti-forgery tokens, OAuth state parameters, etc. The key ring rotates every 90 days by default; if the key ring is lost, every previously-issued payload becomes unreadable and users get logged out.
+
+## Where the keys live
+
+**Postgres `DataProtectionKeys` table.** Schema added by EF migration `20260506045845_AddDataProtectionKeys`. One row per active key; XML payload is the key material. Wired in `Program.cs` via:
+
+```csharp
+builder.Services.AddDataProtection()
+    .SetApplicationName("andy-containers")
+    .PersistKeysToDbContext<ContainersDbContext>();
+```
+
+`SetApplicationName` is **load-bearing** — two providers that share a key store but disagree on the application name will not decrypt each other's payloads. Don't change this string without a planned mass-logout event.
+
+### Why not the filesystem?
+
+Older deploys (pre-RC2 #200) mounted `/root/.aspnet/DataProtection-Keys` from a Docker volume. That works for a single API container but breaks the moment you scale to N replicas behind a Service: an RWO PVC can't be shared, RWX isn't universally available, and per-pod ephemeral volumes mean every pod issues payloads only it can decrypt. The DB-backed store side-steps the problem — every replica reads the same `DataProtectionKeys` table.
+
+The legacy `dataprotection_keys` Docker volume was removed from `docker-compose.yml` in RC2.
+
+### Encryption at rest
+
+The `Xml` column ships unwrapped — the key material is at-rest-protected by **whatever protects Postgres**:
+
+- Hosted Postgres: rely on the provider's at-rest encryption (RDS/Cloud SQL/Aiven all encrypt by default).
+- Self-hosted: encrypted volume (LUKS / dm-crypt) or Postgres TDE.
+- Local dev: not encrypted; not a concern because dev data isn't sensitive.
+
+If your security review requires explicit KEK wrapping (envelope encryption with an external KMS), see RC16 (#214) — out of scope for RC2.
+
+## Rotation
+
+The framework rotates automatically every 90 days. There's nothing to schedule — the runtime walks the key ring on each operation and creates a new key when the active one is approaching expiry. A new row appears in `DataProtectionKeys`; old rows are kept around to decrypt still-valid payloads issued under previous keys.
+
+## Recovery from key loss
+
+If the entire `DataProtectionKeys` table is lost (e.g., a botched migration, a bad backup restore):
+
+1. **Every existing cookie / anti-forgery token becomes invalid.** Users get logged out and must sign in again. This is the same recovery posture as losing the disk-based key ring.
+2. The framework auto-generates a fresh key on next startup. No operator action required.
+3. If multiple replicas are running during the loss window, expect brief 401/403s while pods catch up.
+
+For deliberate mass logout (e.g., compromised key suspected, post-incident reset), `TRUNCATE DataProtectionKeys` then restart the API pods.
+
+## Migration from disk-based keys
+
+If you have an existing single-process deploy with keys on `/root/.aspnet/DataProtection-Keys`, two paths:
+
+### Option A — accept a logout
+
+Deploy the new version. The framework generates a fresh key on first request. Every cached cookie issued by the old version becomes invalid. Users sign in again.
+
+This is the right choice for low-traffic deploys or planned-maintenance windows.
+
+### Option B — preserve key ring (no script yet)
+
+Spec'd in RC2 (#200) but not implemented in v1. The intended subcommand is `dotnet Andy.Containers.Api.dll migrate-data-protection-keys --from <path>`, which would parse the XML files under the volume and INSERT them into the `DataProtectionKeys` table. Punted to a follow-up because:
+
+- The two-stage rollout pattern (run both stores side-by-side for one rotation cycle, then drop the disk store) is cleaner and avoids a one-shot script that has to handle every edge case.
+- Most existing deploys are single-process compose where a logout is acceptable.
+
+If the migration script becomes blocking, file a follow-up issue against #200 and link this section.
+
+## Reference
+
+- `src/Andy.Containers.Api/Program.cs` — `AddDataProtection().PersistKeysToDbContext<>()` registration.
+- `src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs` — implements `IDataProtectionKeyContext`.
+- `src/Andy.Containers.Infrastructure/Migrations/20260506045845_AddDataProtectionKeys.cs` — table migration.
+- `tests/Andy.Containers.Api.Tests/DataProtection/DataProtectionKeyStoreTests.cs` — cross-replica + persistence contracts.
+- Issue [#200](https://github.com/rivoli-ai/andy-containers/issues/200) — RC2 story.
+- Issue [#202](https://github.com/rivoli-ai/andy-containers/issues/202) — RC4 (Helm chart skeleton) — first consumer.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,8 @@ nav:
     - Run configurator: run-configurator.md
   - Operations:
     - Registry credentials: operations/registry-credentials.md
+    - Data Protection keys: operations/data-protection.md
+    - Migrations: operations/migrations.md
   - ADRs:
     - ADR 0001 — Messaging: adr/0001-messaging.md
     - ADR 0002 — Environment profiles: adr/0002-environment-profiles.md

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -5,6 +5,7 @@ using Andy.Containers.Api.Services;
 using Andy.Containers.Configurator;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Infrastructure.Messaging;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using Andy.Containers.Api.Telemetry;
 using Andy.Rbac.Client;
@@ -112,7 +113,17 @@ try
     builder.Services.AddHostedService<ImageBuildWorker>();
 
     // Git credential + clone services
-    builder.Services.AddDataProtection();
+    //
+    // RC2 (#200). Persist the Data Protection key ring in the DB
+    // (`DataProtectionKeys` table) rather than the previous on-disk
+    // volume mount. Two API replicas behind a Service must decrypt
+    // each other's cookies / anti-forgery tokens; an RWO PVC can't
+    // guarantee that, so the DB row store is the multi-replica path.
+    // SetApplicationName isolates this app's keys from any other DP
+    // user on the same DB (defensive — there isn't one today).
+    builder.Services.AddDataProtection()
+        .SetApplicationName("andy-containers")
+        .PersistKeysToDbContext<ContainersDbContext>();
     builder.Services.AddScoped<IGitCredentialService, GitCredentialService>();
     builder.Services.AddScoped<IGitCloneService, GitCloneService>();
     builder.Services.AddScoped<IGitRepositoryProbeService, GitRepositoryProbeService>();

--- a/src/Andy.Containers.Infrastructure/Andy.Containers.Infrastructure.csproj
+++ b/src/Andy.Containers.Infrastructure/Andy.Containers.Infrastructure.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
+++ b/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
@@ -1,12 +1,22 @@
 using Andy.Containers.Messaging;
 using Andy.Containers.Models;
+using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Andy.Containers.Infrastructure.Data;
 
-public class ContainersDbContext : DbContext
+// IDataProtectionKeyContext lets ASP.NET Core's Data Protection store
+// its key ring in our schema (RC2 #200). The interface only requires
+// the DataProtectionKeys DbSet — the framework owns the row contract
+// (id, friendly name, XML payload). Persisting in the DB instead of a
+// filesystem volume removes the multi-replica blocker for Helm rollouts:
+// cookies / anti-forgery tokens issued by one pod must decrypt in any
+// other pod, which a per-pod RWO PVC can't guarantee.
+public class ContainersDbContext : DbContext, IDataProtectionKeyContext
 {
     public ContainersDbContext(DbContextOptions<ContainersDbContext> options) : base(options) { }
+
+    public DbSet<DataProtectionKey> DataProtectionKeys => Set<DataProtectionKey>();
 
     public DbSet<Container> Containers => Set<Container>();
     public DbSet<ContainerTemplate> Templates => Set<ContainerTemplate>();

--- a/src/Andy.Containers.Infrastructure/Migrations/20260506045845_AddDataProtectionKeys.Designer.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260506045845_AddDataProtectionKeys.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Andy.Containers.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Containers.Infrastructure.Migrations
 {
     [DbContext(typeof(ContainersDbContext))]
-    partial class ContainersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260506045845_AddDataProtectionKeys")]
+    partial class AddDataProtectionKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Containers.Infrastructure/Migrations/20260506045845_AddDataProtectionKeys.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260506045845_AddDataProtectionKeys.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Andy.Containers.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDataProtectionKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DataProtectionKeys",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    FriendlyName = table.Column<string>(type: "text", nullable: true),
+                    Xml = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataProtectionKeys", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DataProtectionKeys");
+        }
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/DataProtection/DataProtectionKeyStoreTests.cs
+++ b/tests/Andy.Containers.Api.Tests/DataProtection/DataProtectionKeyStoreTests.cs
@@ -1,0 +1,175 @@
+using Andy.Containers.Infrastructure.Data;
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.DataProtection;
+
+/// <summary>
+/// RC2 (#200). Pins the multi-replica contract: Data Protection keys
+/// persisted in <see cref="ContainersDbContext"/> must be readable from
+/// every replica that shares the database, so cookies / anti-forgery
+/// tokens issued by one pod decrypt cleanly on every other.
+/// </summary>
+/// <remarks>
+/// <para>
+/// We exercise the contract against SQLite-shared-:memory:: a single
+/// <see cref="SqliteConnection"/> backs two independent DI containers
+/// (≈ two API replicas) so the test reproduces the cross-pod scenario
+/// without needing Testcontainers / a real Postgres for the unit
+/// suite. The Postgres path is the same code (EF Core + the same
+/// <c>DataProtectionKeys</c> table); the integration smoke against a
+/// real cluster lands in RC4's chart smoke after the chart exists.
+/// </para>
+/// <para>
+/// <b>Why <c>SetApplicationName</c> matters here:</b> Data Protection
+/// derives a per-app key. Two providers that share a key store but
+/// disagree on application name will not decrypt each other's
+/// payloads. Production pins it via <c>SetApplicationName("andy-containers")</c>
+/// in <c>Program.cs</c>; tests must match.
+/// </para>
+/// </remarks>
+public sealed class DataProtectionKeyStoreTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+
+    public DataProtectionKeyStoreTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        // Materialise the schema once on the shared connection so both
+        // "replicas" see the DataProtectionKeys table.
+        using var seedCtx = NewContext();
+        seedCtx.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private ContainersDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<ContainersDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+        return new ContainersDbContext(options);
+    }
+
+    /// <summary>
+    /// Build a Data Protection provider whose key ring is persisted to
+    /// a fresh <see cref="ContainersDbContext"/> over the shared SQLite
+    /// connection. Each call models a separate replica's DI container.
+    /// </summary>
+    private ServiceProvider BuildReplica()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<ContainersDbContext>(opts => opts.UseSqlite(_connection));
+        services.AddDataProtection()
+            .SetApplicationName("andy-containers")
+            .PersistKeysToDbContext<ContainersDbContext>();
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void ContainersDbContext_ImplementsIDataProtectionKeyContext()
+    {
+        // Defensive: if a future refactor drops the interface, the
+        // PersistKeysToDbContext<> registration call would still type-
+        // check (the constraint is satisfied by the cast at call time)
+        // — but the framework would fail at runtime when it tries to
+        // resolve IDataProtectionKeyContext from DI. Pin the interface
+        // here so the failure surfaces at compile time.
+        typeof(IDataProtectionKeyContext).IsAssignableFrom(typeof(ContainersDbContext))
+            .Should().BeTrue();
+        using var ctx = NewContext();
+        ctx.DataProtectionKeys.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Protect_OnReplicaA_Unprotect_OnReplicaB_RoundTripsPayload()
+    {
+        // The headline invariant: two API pods sharing one database
+        // must decrypt each other's payloads. Without DB-backed keys
+        // (RC2's predecessor: per-pod filesystem volume) this fails —
+        // each pod generates its own ephemeral key.
+        const string purpose = "andy.tests.dp.cross-replica";
+        const string secret = "csrf-token-payload-123";
+
+        using var replicaA = BuildReplica();
+        using var replicaB = BuildReplica();
+
+        var protectorA = replicaA.GetRequiredService<IDataProtectionProvider>()
+            .CreateProtector(purpose);
+        var protectorB = replicaB.GetRequiredService<IDataProtectionProvider>()
+            .CreateProtector(purpose);
+
+        var ciphertext = protectorA.Protect(secret);
+        var roundTripped = protectorB.Unprotect(ciphertext);
+
+        roundTripped.Should().Be(
+            secret,
+            "any cookie / anti-forgery token issued by one replica must " +
+            "decrypt cleanly on every other replica that shares the DB");
+    }
+
+    [Fact]
+    public void KeyRing_PersistsAcrossReplicaRestart()
+    {
+        // Models the rolling-restart scenario: replica A protects, then
+        // gets recycled (DI rebuild). A new replica A' inherits the key
+        // ring from the DB and decrypts the original payload. Without
+        // DB persistence the new pod would generate a fresh key and the
+        // old payload would be unreadable.
+        const string purpose = "andy.tests.dp.restart";
+        const string secret = "long-lived-cookie";
+
+        byte[] ciphertext;
+        using (var beforeRestart = BuildReplica())
+        {
+            ciphertext = beforeRestart
+                .GetRequiredService<IDataProtectionProvider>()
+                .CreateProtector(purpose)
+                .Protect(System.Text.Encoding.UTF8.GetBytes(secret));
+        }
+
+        using var afterRestart = BuildReplica();
+        var roundTripped = afterRestart
+            .GetRequiredService<IDataProtectionProvider>()
+            .CreateProtector(purpose)
+            .Unprotect(ciphertext);
+
+        System.Text.Encoding.UTF8.GetString(roundTripped).Should().Be(secret);
+    }
+
+    [Fact]
+    public void KeyRing_IsWrittenToDataProtectionKeysTable()
+    {
+        // Defends against silent fallback to the in-memory key ring —
+        // if PersistKeysToDbContext<> is mis-wired or the DbContext
+        // doesn't expose IDataProtectionKeyContext, the framework
+        // will quietly fall back without breaking the round-trip
+        // tests above. Asserting an actual row is the canary.
+        const string purpose = "andy.tests.dp.persistence-canary";
+
+        using (var replica = BuildReplica())
+        {
+            replica.GetRequiredService<IDataProtectionProvider>()
+                .CreateProtector(purpose)
+                .Protect("forces-key-generation");
+        }
+
+        using var ctx = NewContext();
+        ctx.DataProtectionKeys.Count().Should().BeGreaterThan(
+            0,
+            "the act of protecting a payload must materialise at least " +
+            "one key row in the shared store; otherwise the framework " +
+            "is silently using an ephemeral in-memory key ring");
+    }
+}


### PR DESCRIPTION
Closes #200. Part of #198 (Epic RC). Unblocks #202 (RC4 — Helm chart skeleton).

## Summary

Wires the API's Data Protection key ring into `ContainersDbContext` so two API replicas behind a Service can decrypt each other's cookies / anti-forgery tokens. The previous filesystem-volume mount worked for single-process compose but blocked any Helm multi-replica rollout (RWO PVC can't be shared, RWX isn't universal).

- `ContainersDbContext` now implements `IDataProtectionKeyContext` and exposes `DbSet<DataProtectionKey>`.
- `Program.cs` calls `.SetApplicationName("andy-containers").PersistKeysToDbContext<ContainersDbContext>()`. `SetApplicationName` is **load-bearing** — providers that share a key store but disagree on app name don't decrypt each other's payloads.
- EF migration `AddDataProtectionKeys` (additive table → zero-downtime).
- `dataprotection_keys` Docker volume removed from `docker-compose.yml` with a pointer comment.
- New ops doc covers where keys live, why DB-backed beats filesystem, rotation cadence, recovery from key loss, and migration paths.

## Acceptance criteria (from #200)

- [x] `Program.cs` calls `.PersistKeysToDbContext<ContainersDbContext>()`
- [x] EF migration adds `DataProtectionKeys` table
- [x] Two API replicas can decrypt cookies / anti-forgery tokens issued by the other (integration test)
- [x] `dataprotection_keys` Docker volume removed from `docker-compose.yml`
- [x] Import path documented for any keys already on disk
- [x] `docs/operations/data-protection.md` exists

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] New `DataProtectionKeyStoreTests` (4):
  - `ContainersDbContext_ImplementsIDataProtectionKeyContext` — compile-time + runtime DbSet check
  - `Protect_OnReplicaA_Unprotect_OnReplicaB_RoundTripsPayload` — headline cross-replica invariant via shared SQLite `:memory:` backing two independent DI containers
  - `KeyRing_PersistsAcrossReplicaRestart` — rolling-restart scenario
  - `KeyRing_IsWrittenToDataProtectionKeysTable` — canary against silent fallback to ephemeral in-memory keys
- [x] Full `Andy.Containers.Api.Tests`: 889/891 pass; the 1 failure (`TerminalControllerTests.ShellCommand_TmuxInvocationCreatesTheProbedSession`) is the same pre-existing failure as RC3, unrelated to DP

## Migration note for existing single-process deploys

The disk → DB cutover gives users two paths (covered in the new ops doc):

- **Accept a logout** — fresh key generated on first request, every old cookie invalidated. Right for low-traffic deploys / planned maintenance.
- **Preserve key ring** — spec'd as `dotnet Andy.Containers.Api.dll migrate-data-protection-keys --from <path>` but punted to a follow-up. The two-stage rollout (both stores side-by-side for one rotation cycle, then drop the volume) is cleaner than a one-shot import script.

Most existing deploys are single-process compose where the logout is acceptable. If migration becomes blocking, file a follow-up linked to #200.

## Out of scope

- Custom KEK (envelope encryption with external KMS) — defer to RC16 (#214) if customer security review requires it.
- The `migrate-data-protection-keys` console subcommand — see migration note above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)