### PR TITLE
IM2 (#251): image management abstractions

### DIFF
--- a/src/Andy.Containers/Abstractions/Images/BuildArtifact.cs
+++ b/src/Andy.Containers/Abstractions/Images/BuildArtifact.cs
@@ -1,0 +1,35 @@
+namespace Andy.Containers.Abstractions.Images;
+
+/// <summary>
+/// A built container image, identified by its OCI manifest digest.
+/// The digest is the canonical key — the same bytes produce the same
+/// digest in every registry. References (where the artifact is tagged)
+/// are tracked separately via <see cref="RegistryReference"/>.
+/// </summary>
+/// <param name="Digest">
+/// OCI manifest digest, e.g. <c>sha256:abc123...</c>. Globally unique.
+/// </param>
+/// <param name="MediaType">
+/// OCI manifest media type, typically
+/// <c>application/vnd.oci.image.manifest.v1+json</c>.
+/// </param>
+/// <param name="SizeBytes">Total uncompressed image size.</param>
+/// <param name="SpecHash">
+/// Content-addressable hash of the source <see cref="TemplateSpec"/> that
+/// produced this artifact. Used as the idempotency key — the same spec
+/// hashed to the same value should resolve to the same artifact, skipping
+/// rebuild.
+/// </param>
+/// <param name="LocalReference">
+/// Build-engine-local hint for where the bytes live before the registry
+/// adapter pushes them. For <c>LocalBuildBackend</c> this is a Docker /
+/// Apple Containers image ref the daemon just produced; for cloud build
+/// backends it's a backend-specific identifier the matching registry
+/// adapter understands.
+/// </param>
+public sealed record BuildArtifact(
+    string Digest,
+    string MediaType,
+    long SizeBytes,
+    string SpecHash,
+    string LocalReference);

--- a/src/Andy.Containers/Abstractions/Images/BuildBackendCapabilities.cs
+++ b/src/Andy.Containers/Abstractions/Images/BuildBackendCapabilities.cs
@@ -1,0 +1,33 @@
+namespace Andy.Containers.Abstractions.Images;
+
+/// <summary>
+/// Self-describing capability set for an <see cref="IBuildBackend"/>.
+/// Lets the orchestrator pick a compatible backend for a given spec.
+/// </summary>
+/// <param name="SupportsMultiArch">
+/// True if the backend can produce a multi-architecture manifest list
+/// in one build (e.g. Docker BuildKit with QEMU, ACR Tasks
+/// <c>--platform</c>, Cloud Build with multiple steps).
+/// </param>
+/// <param name="SupportedArchitectures">
+/// Architecture identifiers the backend can target, in OCI format
+/// (<c>amd64</c>, <c>arm64</c>, etc.). Empty list means "host only".
+/// </param>
+/// <param name="SupportsCacheImport">
+/// True if the backend honours <c>--cache-from</c> / equivalent to
+/// reuse layers from a prior build.
+/// </param>
+/// <param name="SupportsRemoteContext">
+/// True if the backend can fetch a build context from a remote URL
+/// (e.g. git repo) instead of requiring all files to be uploaded.
+/// </param>
+/// <param name="SupportsSecrets">
+/// True if the backend can mount build-time secrets that don't end up
+/// in the resulting image (e.g. <c>--secret</c> in BuildKit).
+/// </param>
+public sealed record BuildBackendCapabilities(
+    bool SupportsMultiArch,
+    IReadOnlyList<string> SupportedArchitectures,
+    bool SupportsCacheImport,
+    bool SupportsRemoteContext,
+    bool SupportsSecrets);

--- a/src/Andy.Containers/Abstractions/Images/BuildProgressEvent.cs
+++ b/src/Andy.Containers/Abstractions/Images/BuildProgressEvent.cs
@@ -1,0 +1,49 @@
+namespace Andy.Containers.Abstractions.Images;
+
+/// <summary>
+/// Base type for events surfaced through
+/// <see cref="IProgress{T}"/> during a build. Concrete subtypes are
+/// pattern-matched by the API layer to map onto the SSE event stream
+/// served at <c>GET /api/images/build/{id}/events</c>.
+/// </summary>
+public abstract record BuildProgressEvent
+{
+    public required DateTimeOffset Timestamp { get; init; }
+}
+
+/// <summary>A new build step started.</summary>
+public sealed record BuildStepStartedEvent : BuildProgressEvent
+{
+    public required string StepName { get; init; }
+    public required int StepIndex { get; init; }
+    public required int TotalSteps { get; init; }
+}
+
+/// <summary>One line of build output captured from the engine.</summary>
+public sealed record BuildStepStdoutEvent : BuildProgressEvent
+{
+    public required string StepName { get; init; }
+    public required string Line { get; init; }
+}
+
+/// <summary>An error within a build step (does not necessarily fail the build).</summary>
+public sealed record BuildStepErrorEvent : BuildProgressEvent
+{
+    public required string StepName { get; init; }
+    public required string Message { get; init; }
+}
+
+/// <summary>The build reached a terminal state.</summary>
+public sealed record BuildCompletedEvent : BuildProgressEvent
+{
+    public required BuildOutcome Outcome { get; init; }
+    public string? Digest { get; init; }
+    public string? FailureReason { get; init; }
+}
+
+public enum BuildOutcome
+{
+    Succeeded,
+    Failed,
+    Cancelled,
+}

--- a/src/Andy.Containers/Abstractions/Images/IBuildBackend.cs
+++ b/src/Andy.Containers/Abstractions/Images/IBuildBackend.cs
@@ -1,0 +1,40 @@
+namespace Andy.Containers.Abstractions.Images;
+
+/// <summary>
+/// Per-engine image-building. Concrete implementations cover the local
+/// Docker daemon, Apple Containers, ACR Tasks, Cloud Build, CodeBuild,
+/// or BuildKit-on-cluster. Each backend converts a parsed
+/// <see cref="TemplateSpec"/> into a <see cref="BuildArtifact"/>; the
+/// registry adapter then pushes the artifact to its configured registry.
+/// </summary>
+public interface IBuildBackend
+{
+    /// <summary>
+    /// Stable identifier matching the build backend selected at startup
+    /// (e.g. <c>local-docker</c>, <c>apple-containers</c>,
+    /// <c>acr-tasks</c>).
+    /// </summary>
+    string BackendId { get; }
+
+    /// <summary>
+    /// Self-described capabilities. Lets the orchestrator pick a
+    /// compatible backend for a given spec (e.g. multi-arch builds need
+    /// a backend with <see cref="BuildBackendCapabilities.SupportsMultiArch"/>).
+    /// </summary>
+    BuildBackendCapabilities Capabilities { get; }
+
+    /// <summary>
+    /// Build an image from the parsed spec, surfacing progress through
+    /// <paramref name="progress"/>. Returns the resulting artifact on
+    /// success.
+    /// </summary>
+    /// <exception cref="ImageBuildFailedException">
+    /// Thrown when the build engine reports a non-zero exit. The
+    /// exception carries captured logs for the API to surface as a 422.
+    /// </exception>
+    Task<BuildArtifact> BuildAsync(
+        TemplateSpec spec,
+        IBuildContext context,
+        IProgress<BuildProgressEvent> progress,
+        CancellationToken ct);
+}

--- a/src/Andy.Containers/Abstractions/Images/IBuildContext.cs
+++ b/src/Andy.Containers/Abstractions/Images/IBuildContext.cs
@@ -1,0 +1,39 @@
+namespace Andy.Containers.Abstractions.Images;
+
+/// <summary>
+/// Inputs to a build — the directory the build engine operates against
+/// plus metadata about uploaded files referenced by the spec's
+/// <c>files:</c> entries.
+/// </summary>
+public interface IBuildContext
+{
+    /// <summary>
+    /// Absolute path on the host where the build context has been
+    /// staged. Backends pass this to the build engine as the build
+    /// context root.
+    /// </summary>
+    string ContextDirectoryPath { get; }
+
+    /// <summary>
+    /// Files uploaded with the template registration request, indexed
+    /// by their <c>files[name]</c> multipart name. Backends use this to
+    /// resolve <c>files:</c> entries in the spec.
+    /// </summary>
+    IReadOnlyList<UploadedFile> Files { get; }
+}
+
+/// <summary>
+/// One file uploaded alongside a template spec.
+/// </summary>
+/// <param name="LogicalName">
+/// The <c>files[<em>name</em>]</c> part name in the multipart request.
+/// </param>
+/// <param name="AbsolutePath">
+/// Absolute path on disk where the file is staged (within
+/// <see cref="IBuildContext.ContextDirectoryPath"/>).
+/// </param>
+/// <param name="SizeBytes">File size on disk.</param>
+public sealed record UploadedFile(
+    string LogicalName,
+    string AbsolutePath,
+    long SizeBytes);

--- a/src/Andy.Containers/Abstractions/Images/IIdentityBridge.cs
+++ b/src/Andy.Containers/Abstractions/Images/IIdentityBridge.cs
@@ -1,0 +1,48 @@
+using System.Security.Claims;
+
+namespace Andy.Containers.Abstractions.Images;
+
+/// <summary>
+/// Translates an <c>andy-auth</c> identity into the credential form a
+/// specific registry expects. Implementations cover token exchange
+/// (Artifactory scoped tokens), STS assumption (ECR), AAD token
+/// passthrough (ACR), workload-identity-federation (GAR), or no-op
+/// passthrough (zot).
+/// </summary>
+public interface IIdentityBridge
+{
+    /// <summary>
+    /// Mint a credential the caller can use to authenticate against
+    /// the named registry. The credential's <see cref="RegistryCredential.ExpiresAt"/>
+    /// is non-null when the underlying scheme returns one (ECR's 12 h
+    /// STS token, Artifactory access tokens with expiry); null means
+    /// the credential does not auto-expire.
+    /// </summary>
+    Task<RegistryCredential> GetCredentialAsync(
+        string registryId,
+        ClaimsPrincipal principal,
+        CancellationToken ct);
+}
+
+/// <summary>
+/// A short-lived credential authenticating a request to a registry.
+/// </summary>
+/// <param name="RegistryId">Registry the credential is valid for.</param>
+/// <param name="Scheme">
+/// HTTP auth scheme — typically <c>Bearer</c> for OIDC-style or
+/// token-exchange registries, <c>Basic</c> for username+password
+/// schemes.
+/// </param>
+/// <param name="Token">
+/// Opaque token string. For <c>Basic</c>, callers must base64-encode
+/// <c>username:password</c> themselves before constructing the header.
+/// </param>
+/// <param name="ExpiresAt">
+/// When the credential stops working, or null if the credential does not
+/// auto-expire.
+/// </param>
+public sealed record RegistryCredential(
+    string RegistryId,
+    string Scheme,
+    string Token,
+    DateTimeOffset? ExpiresAt);

--- a/src/Andy.Containers/Abstractions/Images/IPullCredentialBroker.cs
+++ b/src/Andy.Containers/Abstractions/Images/IPullCredentialBroker.cs
@@ -1,0 +1,41 @@
+namespace Andy.Containers.Abstractions.Images;
+
+/// <summary>
+/// Mints short-lived pull credentials for workspace launches. The
+/// orchestrator (DockerProvider / AppleContainersProvider /
+/// KubernetesInfrastructureProvider) calls this when starting a
+/// workspace so the runtime can pull the workspace's image without
+/// long-lived shared registry credentials being baked into the host.
+/// </summary>
+public interface IPullCredentialBroker
+{
+    /// <summary>
+    /// Mint a pull credential scoped to a single repo path on a single
+    /// registry. Callers should request only the TTL they actually need;
+    /// implementations may cap to lower than the requested TTL based on
+    /// registry policy (e.g. ECR's 12 h maximum, Artifactory's project
+    /// token expiry).
+    /// </summary>
+    Task<WorkspacePullCredential> MintAsync(
+        string registryId,
+        string repoPath,
+        TimeSpan ttl,
+        CancellationToken ct);
+}
+
+/// <summary>
+/// A pull credential ready to be handed to a container runtime.
+/// </summary>
+/// <param name="RegistryId">Registry id from <see cref="IRegistryConfiguration"/>.</param>
+/// <param name="RepoPath">Repo path the credential authorises pulling from.</param>
+/// <param name="DockerConfigJson">
+/// The credential serialised in <c>~/.docker/config.json</c> format —
+/// the form Docker, containerd, and Apple Containers all accept. The
+/// orchestrator writes this directly into the runtime's auth store.
+/// </param>
+/// <param name="ExpiresAt">When the credential stops working.</param>
+public sealed record WorkspacePullCredential(
+    string RegistryId,
+    string RepoPath,
+    string DockerConfigJson,
+    DateTimeOffset ExpiresAt);

--- a/src/Andy.Containers/Abstractions/Images/IRegistryAdapter.cs
+++ b/src/Andy.Containers/Abstractions/Images/IRegistryAdapter.cs
@@ -1,0 +1,51 @@
+namespace Andy.Containers.Abstractions.Images;
+
+/// <summary>
+/// Per-registry I/O. Concrete implementations cover an OCI-conformant
+/// registry (zot, Artifactory, ACR, ECR, Harbor, GAR). The default OCI
+/// Distribution v1.1 surface lives here; vendor-specific extensions
+/// (lifecycle, scanning, signing-policy) live on subinterfaces and are
+/// added as needed.
+/// </summary>
+public interface IRegistryAdapter
+{
+    /// <summary>
+    /// Stable identifier matching the <see cref="RegistryConfigEntry.Id"/>
+    /// this adapter handles.
+    /// </summary>
+    string RegistryId { get; }
+
+    /// <summary>
+    /// Push a built artifact into this registry under the given repo path
+    /// and tag. Implementations transfer the bytes referenced by
+    /// <see cref="BuildArtifact.LocalReference"/> to the remote registry
+    /// and return the resulting <see cref="RegistryReference"/>.
+    /// </summary>
+    Task<RegistryReference> PushAsync(
+        BuildArtifact artifact,
+        string repoPath,
+        string tag,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Check whether a manifest with the given digest already exists
+    /// under the given repo path. Used for content-addressable cache
+    /// hits — if the spec hash already resolved to a digest in this
+    /// registry, the build can be skipped.
+    /// </summary>
+    Task<bool> ExistsAsync(string repoPath, string digest, CancellationToken ct);
+
+    /// <summary>
+    /// List all references currently stored under a repo path.
+    /// </summary>
+    Task<IReadOnlyList<RegistryReference>> ListReferencesAsync(
+        string repoPath,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Untag a reference. Does not delete the underlying artifact bytes —
+    /// registry-side garbage collection reclaims those when no reference
+    /// points at the digest.
+    /// </summary>
+    Task DeleteAsync(RegistryReference reference, CancellationToken ct);
+}

--- a/src/Andy.Containers/Abstractions/Images/IRegistryConfiguration.cs
+++ b/src/Andy.Containers/Abstractions/Images/IRegistryConfiguration.cs
@@ -1,0 +1,84 @@
+namespace Andy.Containers.Abstractions.Images;
+
+/// <summary>
+/// The ordered set of registries this <c>andy-containers</c> instance is
+/// configured to push to. In solo mode this is one entry (managed local
+/// zot); in single-tenant cloud mode it's the customer-mandated registry;
+/// in multi-tenant Rivoli Cloud it's the scale-out cluster plus optional
+/// pull-through caches.
+/// </summary>
+public interface IRegistryConfiguration
+{
+    /// <summary>
+    /// All configured registries, in the order they were declared. The
+    /// first entry is conventionally the primary push target unless
+    /// <see cref="PrimaryRegistryId"/> overrides.
+    /// </summary>
+    IReadOnlyList<RegistryConfigEntry> Registries { get; }
+
+    /// <summary>
+    /// Id of the primary push target. Resolution order:
+    /// (1) explicit <c>PrimaryRegistryId</c> in options;
+    /// (2) the entry with <c>IsPrimary=true</c>;
+    /// (3) the first entry in <see cref="Registries"/>.
+    /// Throws if no registries are configured.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if <see cref="Registries"/> is empty.
+    /// </exception>
+    string PrimaryRegistryId { get; }
+
+    /// <summary>
+    /// Look up a registry config by id. Throws if no entry matches.
+    /// </summary>
+    /// <exception cref="KeyNotFoundException">
+    /// Thrown if no registry is configured with this id.
+    /// </exception>
+    RegistryConfigEntry GetByIdOrThrow(string registryId);
+}
+
+/// <summary>
+/// Configuration metadata for one registry. The actual I/O is owned by
+/// an <see cref="IRegistryAdapter"/> registered separately in DI; the
+/// link between a config entry and its adapter is by <c>Id</c>.
+/// </summary>
+/// <remarks>
+/// Defined as a non-positional record with init-only properties so the
+/// default <see cref="Microsoft.Extensions.Configuration.ConfigurationBinder"/>
+/// can populate it from the <c>ImageManagement:Registries</c> section
+/// without a custom binder. Construct in code using object-initializer
+/// syntax: <c>new RegistryConfigEntry { Id = "...", Kind = "..." }</c>.
+/// </remarks>
+public sealed record RegistryConfigEntry
+{
+    /// <summary>
+    /// Stable id used by the rest of the system to refer to this registry,
+    /// matching the corresponding adapter's
+    /// <see cref="IRegistryAdapter.RegistryId"/>.
+    /// </summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Discriminator naming the registry technology — <c>zot</c>,
+    /// <c>artifactory</c>, <c>acr</c>, <c>ecr</c>, <c>harbor</c>, <c>gar</c>.
+    /// </summary>
+    public string Kind { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Base URL where the registry serves its OCI Distribution API.
+    /// </summary>
+    public string Url { get; init; } = string.Empty;
+
+    /// <summary>
+    /// True if this entry is the primary push target. At most one entry
+    /// should be primary; if multiple are flagged the first wins.
+    /// </summary>
+    public bool IsPrimary { get; init; }
+
+    /// <summary>
+    /// Adapter-specific configuration (auth-mode hints, repo-path-prefix,
+    /// scan-policy id, etc.). Kept open-ended so adding a new adapter
+    /// doesn't require changing this record.
+    /// </summary>
+    public Dictionary<string, string> Properties { get; init; } = new();
+}

--- a/src/Andy.Containers/Abstractions/Images/ImageBuildFailedException.cs
+++ b/src/Andy.Containers/Abstractions/Images/ImageBuildFailedException.cs
@@ -1,0 +1,52 @@
+namespace Andy.Containers.Abstractions.Images;
+
+/// <summary>
+/// Thrown by an <see cref="IBuildBackend"/> when the underlying engine
+/// reports a non-zero exit (or any other non-recoverable failure).
+/// The exception carries captured logs so the API layer can surface
+/// them as a structured 422 response per IM10.
+/// </summary>
+public sealed class ImageBuildFailedException : Exception
+{
+    /// <summary>
+    /// The build backend's id at the time of failure.
+    /// </summary>
+    public string BackendId { get; }
+
+    /// <summary>
+    /// The spec hash that was being built. Populated when known.
+    /// </summary>
+    public string? SpecHash { get; }
+
+    /// <summary>
+    /// The failing step's name, if the failure can be attributed to a
+    /// specific step.
+    /// </summary>
+    public string? FailingStepName { get; }
+
+    /// <summary>
+    /// Captured stdout/stderr from the build engine, intended for
+    /// inclusion in the API's error response.
+    /// </summary>
+    public string CapturedLogs { get; }
+
+    public ImageBuildFailedException(
+        string backendId,
+        string capturedLogs,
+        string? specHash = null,
+        string? failingStepName = null,
+        string? message = null,
+        Exception? innerException = null)
+        : base(message ?? BuildDefaultMessage(backendId, failingStepName), innerException)
+    {
+        BackendId = backendId;
+        SpecHash = specHash;
+        FailingStepName = failingStepName;
+        CapturedLogs = capturedLogs;
+    }
+
+    private static string BuildDefaultMessage(string backendId, string? failingStepName)
+        => failingStepName is null
+            ? $"Build failed on backend '{backendId}'."
+            : $"Build failed on backend '{backendId}' at step '{failingStepName}'.";
+}

--- a/src/Andy.Containers/Abstractions/Images/OptionsBackedRegistryConfiguration.cs
+++ b/src/Andy.Containers/Abstractions/Images/OptionsBackedRegistryConfiguration.cs
@@ -1,0 +1,71 @@
+using Andy.Containers.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Andy.Containers.Abstractions.Images;
+
+/// <summary>
+/// Default <see cref="IRegistryConfiguration"/> implementation that
+/// reads from <see cref="RegistryConfigurationOptions"/>. Singleton —
+/// safe to capture <see cref="IOptions{TOptions}"/> because changes to
+/// the registry list at runtime are not supported in IM2 (later stories
+/// can swap in <see cref="IOptionsMonitor{TOptions}"/> if needed).
+/// </summary>
+internal sealed class OptionsBackedRegistryConfiguration : IRegistryConfiguration
+{
+    private readonly IOptions<RegistryConfigurationOptions> _options;
+
+    public OptionsBackedRegistryConfiguration(IOptions<RegistryConfigurationOptions> options)
+    {
+        _options = options;
+    }
+
+    public IReadOnlyList<RegistryConfigEntry> Registries => _options.Value.Registries;
+
+    public string PrimaryRegistryId
+    {
+        get
+        {
+            var explicitPrimary = _options.Value.PrimaryRegistryId;
+            if (!string.IsNullOrWhiteSpace(explicitPrimary))
+            {
+                // Validate the explicit id resolves to a real entry; otherwise
+                // a typo in config would silently shadow the IsPrimary fallback.
+                if (_options.Value.Registries.All(r => r.Id != explicitPrimary))
+                {
+                    throw new InvalidOperationException(
+                        $"PrimaryRegistryId '{explicitPrimary}' does not match any configured registry id.");
+                }
+                return explicitPrimary;
+            }
+
+            var primaryFlagged = _options.Value.Registries.FirstOrDefault(r => r.IsPrimary);
+            if (primaryFlagged is not null)
+            {
+                return primaryFlagged.Id;
+            }
+
+            var first = _options.Value.Registries.FirstOrDefault();
+            if (first is not null)
+            {
+                return first.Id;
+            }
+
+            throw new InvalidOperationException(
+                "No registries configured. Populate RegistryConfigurationOptions.Registries via " +
+                "the 'ImageManagement:Registries' configuration section, or register a registry " +
+                "adapter through one of the per-vendor extension methods (AddZotRegistry, etc.).");
+        }
+    }
+
+    public RegistryConfigEntry GetByIdOrThrow(string registryId)
+    {
+        var entry = _options.Value.Registries.FirstOrDefault(r => r.Id == registryId);
+        if (entry is null)
+        {
+            throw new KeyNotFoundException(
+                $"No registry configured with id '{registryId}'. " +
+                $"Configured ids: [{string.Join(", ", _options.Value.Registries.Select(r => $"'{r.Id}'"))}].");
+        }
+        return entry;
+    }
+}

--- a/src/Andy.Containers/Abstractions/Images/RegistryReference.cs
+++ b/src/Andy.Containers/Abstractions/Images/RegistryReference.cs
@@ -1,0 +1,37 @@
+namespace Andy.Containers.Abstractions.Images;
+
+/// <summary>
+/// A pointer to a built artifact in a specific registry under a specific
+/// repo path and tag. Many <see cref="RegistryReference"/>s can map to a
+/// single <see cref="BuildArtifact"/> (same image pushed to multiple
+/// registries, or tagged multiple ways in the same registry).
+/// </summary>
+/// <param name="Id">Stable identifier for this reference row.</param>
+/// <param name="RegistryId">
+/// The id of the registry in <see cref="IRegistryConfiguration"/> this
+/// reference was pushed to.
+/// </param>
+/// <param name="RepoPath">
+/// Repo path within the registry, e.g.
+/// <c>conductor-terminal-claude-code</c>.
+/// </param>
+/// <param name="Tag">
+/// Tag under the repo path, e.g. <c>sha256-abc12345</c> or <c>v1.2.3</c>.
+/// </param>
+/// <param name="Digest">
+/// OCI manifest digest the tag currently resolves to. Same as
+/// <see cref="BuildArtifact.Digest"/> at push time. Tags are mutable;
+/// the digest is authoritative.
+/// </param>
+/// <param name="PushedAt">When this reference was published to the registry.</param>
+/// <param name="PushedBy">
+/// Identifier of the principal that pushed (user id or service identity).
+/// </param>
+public sealed record RegistryReference(
+    Guid Id,
+    string RegistryId,
+    string RepoPath,
+    string Tag,
+    string Digest,
+    DateTimeOffset PushedAt,
+    string PushedBy);

--- a/src/Andy.Containers/Abstractions/Images/TemplateSpec.cs
+++ b/src/Andy.Containers/Abstractions/Images/TemplateSpec.cs
@@ -1,0 +1,36 @@
+namespace Andy.Containers.Abstractions.Images;
+
+/// <summary>
+/// Parsed and canonicalised template specification ready to be built.
+/// </summary>
+/// <remarks>
+/// <para>
+/// IM2 ships a minimal placeholder so the abstraction interfaces compile
+/// against a stable type. IM4 (#253) extends this with the M1.9
+/// imperative fields (<c>packages</c>, <c>files</c>, <c>install</c>,
+/// <c>entrypoint</c>, <c>markers</c>, <c>extends</c>, <c>from</c>)
+/// alongside the existing declarative <c>dependencies</c> model.
+/// </para>
+/// <para>
+/// <see cref="SpecHash"/> is the content-addressable identity:
+/// <c>sha256(canonicalJson(parsedSpec) || sortedFileDigests)</c>.
+/// Two specs that differ only in YAML whitespace or key ordering produce
+/// the same <see cref="SpecHash"/>.
+/// </para>
+/// </remarks>
+/// <param name="Code">Template code (e.g. <c>conductor-terminal-claude-code</c>).</param>
+/// <param name="Version">Template version string.</param>
+/// <param name="SpecHash">
+/// SHA-256 hash of the canonical JSON serialisation of this spec plus the
+/// digests of any uploaded files. Used as the build idempotency key.
+/// </param>
+/// <param name="CanonicalJson">
+/// Canonical-JSON (RFC 8785 / JCS) serialisation of the parsed spec, used
+/// for hashing and for storage. Stored as a string so the hash is
+/// reproducible without re-parsing.
+/// </param>
+public sealed record TemplateSpec(
+    string Code,
+    string Version,
+    string SpecHash,
+    string CanonicalJson);

--- a/src/Andy.Containers/Configuration/RegistryConfigurationOptions.cs
+++ b/src/Andy.Containers/Configuration/RegistryConfigurationOptions.cs
@@ -1,0 +1,32 @@
+using Andy.Containers.Abstractions.Images;
+
+namespace Andy.Containers.Configuration;
+
+/// <summary>
+/// Options binding for the set of image registries this
+/// <c>andy-containers</c> instance is configured to push to. Bound from
+/// the <c>ImageManagement:Registries</c> configuration section by
+/// <see cref="DependencyInjection.ServiceCollectionExtensions.AddImageManagement"/>.
+/// </summary>
+/// <remarks>
+/// IM2 introduces this options class with no default registry entries.
+/// IM6 (the local zot adapter) wires a default <c>local-zot</c> entry
+/// when no registries are configured at all, so embedded mode works out
+/// of the box.
+/// </remarks>
+public sealed class RegistryConfigurationOptions
+{
+    public const string SectionName = "ImageManagement";
+
+    /// <summary>
+    /// All configured registries, in declaration order.
+    /// </summary>
+    public List<RegistryConfigEntry> Registries { get; set; } = [];
+
+    /// <summary>
+    /// Optional explicit primary id. When unset, primary resolution
+    /// falls back to the entry with <see cref="RegistryConfigEntry.IsPrimary"/>
+    /// true, then to the first entry in <see cref="Registries"/>.
+    /// </summary>
+    public string? PrimaryRegistryId { get; set; }
+}

--- a/src/Andy.Containers/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Andy.Containers/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
+using Andy.Containers.Abstractions.Images;
 using Andy.Containers.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Andy.Containers.DependencyInjection;
 
@@ -12,6 +14,37 @@ public static class ServiceCollectionExtensions
     {
         services.Configure<ContainersOptions>(
             configuration.GetSection(ContainersOptions.SectionName));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the image management abstraction layer (IM2). Wires
+    /// the default <see cref="IRegistryConfiguration"/> backed by
+    /// <see cref="RegistryConfigurationOptions"/>. Concrete adapters
+    /// and build backends are registered separately by per-vendor
+    /// extensions (<c>AddZotRegistry</c>, <c>AddLocalBuildBackend</c>,
+    /// etc.) introduced in IM6+.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">
+    /// Optional configuration root. When supplied, the
+    /// <c>ImageManagement</c> section is bound to
+    /// <see cref="RegistryConfigurationOptions"/>. When null, callers are
+    /// expected to invoke <see cref="OptionsServiceCollectionExtensions.Configure{TOptions}(IServiceCollection, Action{TOptions})"/>
+    /// themselves (typical in unit tests).
+    /// </param>
+    public static IServiceCollection AddImageManagement(
+        this IServiceCollection services,
+        IConfiguration? configuration = null)
+    {
+        if (configuration is not null)
+        {
+            services.Configure<RegistryConfigurationOptions>(
+                configuration.GetSection(RegistryConfigurationOptions.SectionName));
+        }
+
+        services.TryAddSingleton<IRegistryConfiguration, OptionsBackedRegistryConfiguration>();
 
         return services;
     }

--- a/tests/Andy.Containers.Tests/Abstractions/Images/AbstractionContractTests.cs
+++ b/tests/Andy.Containers.Tests/Abstractions/Images/AbstractionContractTests.cs
@@ -1,0 +1,203 @@
+using System.Security.Claims;
+using Andy.Containers.Abstractions.Images;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Tests.Abstractions.Images;
+
+// IM2 (rivoli-ai/andy-containers#251). The abstractions are intended
+// to be implementable by stub/no-op classes for tests and by per-vendor
+// adapters in IM6+. These tests exercise the contracts via stubs so a
+// later refactor that breaks an interface signature surfaces here as
+// a compile error rather than at adapter-implementation time.
+public class AbstractionContractTests
+{
+    [Fact]
+    public async Task IRegistryAdapter_PushAsync_ReturnsReferenceWithMatchingDigest()
+    {
+        var adapter = new StubRegistryAdapter("local-zot");
+        var artifact = MakeArtifact("sha256:abc");
+
+        var reference = await adapter.PushAsync(artifact, "foo/bar", "v1", CancellationToken.None);
+
+        reference.RegistryId.Should().Be("local-zot");
+        reference.RepoPath.Should().Be("foo/bar");
+        reference.Tag.Should().Be("v1");
+        reference.Digest.Should().Be(artifact.Digest);
+    }
+
+    [Fact]
+    public async Task IBuildBackend_BuildAsync_SurfacesProgressEvents()
+    {
+        var backend = new StubBuildBackend();
+        var spec = new TemplateSpec("conductor-terminal", "1.0.0", "sha256:def", "{}");
+        var context = new StubBuildContext("/tmp/build-xyz");
+        var events = new List<BuildProgressEvent>();
+        var progress = new Progress<BuildProgressEvent>(events.Add);
+
+        var artifact = await backend.BuildAsync(spec, context, progress, CancellationToken.None);
+
+        artifact.SpecHash.Should().Be("sha256:def");
+
+        // Allow the Progress<T> SynchronizationContext callback to flush.
+        await Task.Delay(50);
+
+        events.Should().NotBeEmpty();
+        events.OfType<BuildStepStartedEvent>().Should().HaveCount(1);
+        events.OfType<BuildCompletedEvent>().Should().ContainSingle()
+            .Which.Outcome.Should().Be(BuildOutcome.Succeeded);
+    }
+
+    [Fact]
+    public async Task IIdentityBridge_GetCredentialAsync_ReturnsCredentialForRegistry()
+    {
+        var bridge = new StubIdentityBridge();
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.NameIdentifier, "user-123"),
+        ]));
+
+        var credential = await bridge.GetCredentialAsync("local-zot", principal, CancellationToken.None);
+
+        credential.RegistryId.Should().Be("local-zot");
+        credential.Scheme.Should().Be("Bearer");
+        credential.Token.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task IPullCredentialBroker_MintAsync_RespectsTtl()
+    {
+        var broker = new StubPullCredentialBroker();
+        var ttl = TimeSpan.FromMinutes(15);
+
+        var credential = await broker.MintAsync("local-zot", "foo/bar", ttl, CancellationToken.None);
+
+        credential.RegistryId.Should().Be("local-zot");
+        credential.RepoPath.Should().Be("foo/bar");
+        credential.ExpiresAt.Should().BeCloseTo(DateTimeOffset.UtcNow + ttl, TimeSpan.FromSeconds(5));
+        credential.DockerConfigJson.Should().Contain("auths");
+    }
+
+    [Fact]
+    public void ImageBuildFailedException_CarriesCapturedLogs()
+    {
+        var exception = new ImageBuildFailedException(
+            backendId: "local-docker",
+            capturedLogs: "Step 5/12 : RUN apt-get install -y bogus\n  E: Unable to locate package bogus",
+            specHash: "sha256:bad",
+            failingStepName: "packages-install");
+
+        exception.BackendId.Should().Be("local-docker");
+        exception.SpecHash.Should().Be("sha256:bad");
+        exception.FailingStepName.Should().Be("packages-install");
+        exception.CapturedLogs.Should().Contain("Unable to locate package");
+        exception.Message.Should().Contain("packages-install");
+    }
+
+    private static BuildArtifact MakeArtifact(string digest)
+        => new(
+            Digest: digest,
+            MediaType: "application/vnd.oci.image.manifest.v1+json",
+            SizeBytes: 12_345_678,
+            SpecHash: "sha256:def",
+            LocalReference: "andy-containers-build-tmp:abc");
+
+    private sealed class StubRegistryAdapter : IRegistryAdapter
+    {
+        public StubRegistryAdapter(string id) { RegistryId = id; }
+        public string RegistryId { get; }
+
+        public Task<RegistryReference> PushAsync(BuildArtifact artifact, string repoPath, string tag, CancellationToken ct)
+            => Task.FromResult(new RegistryReference(
+                Id: Guid.NewGuid(),
+                RegistryId: RegistryId,
+                RepoPath: repoPath,
+                Tag: tag,
+                Digest: artifact.Digest,
+                PushedAt: DateTimeOffset.UtcNow,
+                PushedBy: "stub"));
+
+        public Task<bool> ExistsAsync(string repoPath, string digest, CancellationToken ct)
+            => Task.FromResult(false);
+
+        public Task<IReadOnlyList<RegistryReference>> ListReferencesAsync(string repoPath, CancellationToken ct)
+            => Task.FromResult<IReadOnlyList<RegistryReference>>(Array.Empty<RegistryReference>());
+
+        public Task DeleteAsync(RegistryReference reference, CancellationToken ct)
+            => Task.CompletedTask;
+    }
+
+    private sealed class StubBuildBackend : IBuildBackend
+    {
+        public string BackendId => "stub-backend";
+
+        public BuildBackendCapabilities Capabilities => new(
+            SupportsMultiArch: false,
+            SupportedArchitectures: ["amd64"],
+            SupportsCacheImport: false,
+            SupportsRemoteContext: false,
+            SupportsSecrets: false);
+
+        public Task<BuildArtifact> BuildAsync(
+            TemplateSpec spec,
+            IBuildContext context,
+            IProgress<BuildProgressEvent> progress,
+            CancellationToken ct)
+        {
+            var now = DateTimeOffset.UtcNow;
+            progress.Report(new BuildStepStartedEvent
+            {
+                Timestamp = now,
+                StepName = "stub-step",
+                StepIndex = 1,
+                TotalSteps = 1,
+            });
+            progress.Report(new BuildCompletedEvent
+            {
+                Timestamp = now,
+                Outcome = BuildOutcome.Succeeded,
+                Digest = "sha256:stub",
+            });
+            return Task.FromResult(new BuildArtifact(
+                Digest: "sha256:stub",
+                MediaType: "application/vnd.oci.image.manifest.v1+json",
+                SizeBytes: 0,
+                SpecHash: spec.SpecHash,
+                LocalReference: "stub:" + spec.SpecHash));
+        }
+    }
+
+    private sealed class StubBuildContext : IBuildContext
+    {
+        public StubBuildContext(string path) { ContextDirectoryPath = path; }
+        public string ContextDirectoryPath { get; }
+        public IReadOnlyList<UploadedFile> Files => Array.Empty<UploadedFile>();
+    }
+
+    private sealed class StubIdentityBridge : IIdentityBridge
+    {
+        public Task<RegistryCredential> GetCredentialAsync(
+            string registryId,
+            ClaimsPrincipal principal,
+            CancellationToken ct)
+            => Task.FromResult(new RegistryCredential(
+                RegistryId: registryId,
+                Scheme: "Bearer",
+                Token: "stub-token-for-" + (principal.FindFirstValue(ClaimTypes.NameIdentifier) ?? "anon"),
+                ExpiresAt: DateTimeOffset.UtcNow.AddHours(1)));
+    }
+
+    private sealed class StubPullCredentialBroker : IPullCredentialBroker
+    {
+        public Task<WorkspacePullCredential> MintAsync(
+            string registryId,
+            string repoPath,
+            TimeSpan ttl,
+            CancellationToken ct)
+            => Task.FromResult(new WorkspacePullCredential(
+                RegistryId: registryId,
+                RepoPath: repoPath,
+                DockerConfigJson: "{\"auths\":{\"" + registryId + "\":{\"auth\":\"stub\"}}}",
+                ExpiresAt: DateTimeOffset.UtcNow + ttl));
+    }
+}

--- a/tests/Andy.Containers.Tests/Abstractions/Images/RegistryConfigurationTests.cs
+++ b/tests/Andy.Containers.Tests/Abstractions/Images/RegistryConfigurationTests.cs
@@ -1,0 +1,204 @@
+using Andy.Containers.Abstractions.Images;
+using Andy.Containers.Configuration;
+using Andy.Containers.DependencyInjection;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Containers.Tests.Abstractions.Images;
+
+// IM2 (rivoli-ai/andy-containers#251). The abstractions are pure
+// contracts plus one default IRegistryConfiguration implementation
+// reading from RegistryConfigurationOptions. These tests pin the
+// behaviour callers depend on:
+//   - AddImageManagement composes a working DI graph
+//   - Primary resolution prefers explicit > IsPrimary > first
+//   - GetByIdOrThrow surfaces the configured-ids list to help debugging
+//   - Empty config is an explicit InvalidOperationException, not silent null
+public class RegistryConfigurationTests
+{
+    [Fact]
+    public void AddImageManagement_RegistersIRegistryConfigurationAsSingleton()
+    {
+        var services = new ServiceCollection();
+
+        services.AddImageManagement();
+
+        // Resolution requires options to be configured even if empty.
+        services.Configure<RegistryConfigurationOptions>(_ => { });
+
+        using var provider = services.BuildServiceProvider();
+
+        var first = provider.GetRequiredService<IRegistryConfiguration>();
+        var second = provider.GetRequiredService<IRegistryConfiguration>();
+
+        first.Should().BeSameAs(second);
+    }
+
+    [Fact]
+    public void AddImageManagement_BindsImageManagementSection_WhenConfigurationProvided()
+    {
+        var configValues = new Dictionary<string, string?>
+        {
+            ["ImageManagement:PrimaryRegistryId"] = "registry-from-config",
+            ["ImageManagement:Registries:0:Id"] = "registry-from-config",
+            ["ImageManagement:Registries:0:Kind"] = "zot",
+            ["ImageManagement:Registries:0:Url"] = "http://localhost:5050",
+            ["ImageManagement:Registries:0:IsPrimary"] = "true",
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configValues)
+            .Build();
+        var services = new ServiceCollection();
+
+        services.AddImageManagement(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var config = provider.GetRequiredService<IRegistryConfiguration>();
+
+        config.Registries.Should().HaveCount(1);
+        config.Registries[0].Id.Should().Be("registry-from-config");
+        config.Registries[0].Kind.Should().Be("zot");
+        config.PrimaryRegistryId.Should().Be("registry-from-config");
+    }
+
+    [Fact]
+    public void AddImageManagement_DoesNotOverrideExistingRegistration()
+    {
+        var services = new ServiceCollection();
+        var customConfig = new StubRegistryConfiguration();
+        services.AddSingleton<IRegistryConfiguration>(customConfig);
+
+        services.AddImageManagement();
+        services.Configure<RegistryConfigurationOptions>(_ => { });
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IRegistryConfiguration>()
+            .Should().BeSameAs(customConfig,
+                "AddImageManagement uses TryAddSingleton so callers can override the default impl.");
+    }
+
+    [Fact]
+    public void Registries_IsEmpty_WhenNoneConfigured()
+    {
+        var config = BuildConfig(_ => { });
+        config.Registries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetByIdOrThrow_Throws_WhenIdUnknown()
+    {
+        var config = BuildConfig(opts =>
+        {
+            opts.Registries.Add(KnownEntry("local-zot"));
+        });
+
+        var act = () => config.GetByIdOrThrow("not-configured");
+
+        act.Should().Throw<KeyNotFoundException>()
+            .WithMessage("*not-configured*")
+            .Which.Message.Should().Contain("'local-zot'",
+                "the error includes the list of configured ids so a typo is obvious.");
+    }
+
+    [Fact]
+    public void GetByIdOrThrow_ReturnsEntry_WhenMatch()
+    {
+        var entry = KnownEntry("local-zot");
+        var config = BuildConfig(opts => opts.Registries.Add(entry));
+
+        config.GetByIdOrThrow("local-zot").Should().Be(entry);
+    }
+
+    [Fact]
+    public void PrimaryRegistryId_Throws_WhenNoRegistriesConfigured()
+    {
+        var config = BuildConfig(_ => { });
+
+        var act = () => config.PrimaryRegistryId;
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*No registries configured*");
+    }
+
+    [Fact]
+    public void PrimaryRegistryId_PrefersExplicitOption()
+    {
+        var config = BuildConfig(opts =>
+        {
+            opts.Registries.Add(KnownEntry("alpha", isPrimary: true));
+            opts.Registries.Add(KnownEntry("beta"));
+            opts.PrimaryRegistryId = "beta";
+        });
+
+        config.PrimaryRegistryId.Should().Be("beta",
+            "explicit PrimaryRegistryId beats the IsPrimary flag.");
+    }
+
+    [Fact]
+    public void PrimaryRegistryId_ThrowsWhenExplicitOptionDoesNotMatchAnyEntry()
+    {
+        var config = BuildConfig(opts =>
+        {
+            opts.Registries.Add(KnownEntry("alpha"));
+            opts.PrimaryRegistryId = "typo";
+        });
+
+        var act = () => config.PrimaryRegistryId;
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*'typo'*does not match*");
+    }
+
+    [Fact]
+    public void PrimaryRegistryId_FallsBackToIsPrimaryFlag()
+    {
+        var config = BuildConfig(opts =>
+        {
+            opts.Registries.Add(KnownEntry("alpha"));
+            opts.Registries.Add(KnownEntry("beta", isPrimary: true));
+            opts.Registries.Add(KnownEntry("gamma"));
+        });
+
+        config.PrimaryRegistryId.Should().Be("beta");
+    }
+
+    [Fact]
+    public void PrimaryRegistryId_FallsBackToFirstEntry_WhenNothingFlagged()
+    {
+        var config = BuildConfig(opts =>
+        {
+            opts.Registries.Add(KnownEntry("alpha"));
+            opts.Registries.Add(KnownEntry("beta"));
+        });
+
+        config.PrimaryRegistryId.Should().Be("alpha");
+    }
+
+    private static IRegistryConfiguration BuildConfig(Action<RegistryConfigurationOptions> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddImageManagement();
+        services.Configure(configure);
+
+        var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<IRegistryConfiguration>();
+    }
+
+    private static RegistryConfigEntry KnownEntry(string id, bool isPrimary = false)
+        => new()
+        {
+            Id = id,
+            Kind = "zot",
+            Url = $"http://localhost:5050/{id}",
+            IsPrimary = isPrimary,
+        };
+
+    private sealed class StubRegistryConfiguration : IRegistryConfiguration
+    {
+        public IReadOnlyList<RegistryConfigEntry> Registries => Array.Empty<RegistryConfigEntry>();
+        public string PrimaryRegistryId => "stub";
+        public RegistryConfigEntry GetByIdOrThrow(string registryId) => throw new KeyNotFoundException();
+    }
+}


### PR DESCRIPTION
Closes #251. Phase 0 of Epic IM (#249) — abstraction layer that subsequent stories implement against. Builds on IM1 memo (#250 / PR #255).

## Summary

Lands the five abstraction interfaces and supporting records described in the architecture memo. **Pure contracts plus one default `IRegistryConfiguration` implementation** — no concrete adapters or build backends. Those land in IM6+ (Phase 1) and Phase 3 (external registries).

## What's in

| Type | Role |
|---|---|
| `IRegistryAdapter` | Per-registry I/O (push / exists / list / delete) over OCI Distribution v1.1. Vendor-specific extensions land on subinterfaces in Phase 3. |
| `IBuildBackend` | Per-engine image construction, surfacing progress through `IProgress<BuildProgressEvent>`. |
| `IRegistryConfiguration` | Ordered list of configured registries with primary-resolution preference (explicit > `IsPrimary` > first). |
| `IIdentityBridge` | Translates `andy-auth` claims into per-registry credentials (token exchange / STS / AAD / workload-identity). |
| `IPullCredentialBroker` | Mints short-lived `~/.docker/config.json` creds for workspace launches. |
| `BuildArtifact` | Digest-anchored record carrying `SpecHash` (idempotency key) and `LocalReference` (source pointer for the registry adapter). |
| `RegistryReference` | Pointer in `(RegistryId, RepoPath, Tag)` space; many-to-one against `BuildArtifact.Digest`. |
| `RegistryConfigEntry` | Non-positional record so the default `ConfigurationBinder` populates it from `ImageManagement:Registries`. |
| `BuildBackendCapabilities` | Self-describing capability set so the orchestrator can pick a compatible backend for a given spec. |
| `BuildProgressEvent` (+ `BuildStepStartedEvent` / `BuildStepStdoutEvent` / `BuildStepErrorEvent` / `BuildCompletedEvent`) | Drive the SSE stream that `GET /api/images/build/{id}/events` will serve in IM9. |
| `ImageBuildFailedException` | Carries `BackendId`, `SpecHash`, `FailingStepName`, `CapturedLogs` — fed into IM10's structured 422 response mapping. |
| `IBuildContext` + `UploadedFile` | Where uploaded files live on disk during a build. |
| `TemplateSpec` (placeholder) | Minimal stub so the interfaces compile against a stable type; IM4 (#253) extends with M1.9 fields. |

## DI wiring

`services.AddImageManagement(IConfiguration? configuration = null)` extension. Binds `RegistryConfigurationOptions` from the `ImageManagement` section when configuration is supplied; otherwise leaves callers to `Configure<RegistryConfigurationOptions>(...)` manually (typical in tests). Uses `TryAddSingleton` so callers can register a different `IRegistryConfiguration` implementation if they need to.

The API project (`Andy.Containers.Api`) does **not** call `AddImageManagement()` yet — that wiring lands when the first concrete adapter ships in IM6, so the API doesn't crash at startup with "no registries configured."

## Open by design

- `RegistryConfigEntry.Properties` is a `Dictionary<string, string>` rather than `IReadOnlyDictionary<...>` so the default config binder can populate it. Callers should treat it as immutable after construction.
- Positional records were considered for the data types but rejected for `RegistryConfigEntry` because the binder needs a parameterless constructor. Other records (`BuildArtifact`, `RegistryReference`, `BuildArtifact`) stay positional since they're only constructed in code.
- No `IImageBuildService` overlap: the existing `IImageBuildService` (template-build-centric) stays untouched; the new abstractions live underneath it. Phase 1 (IM6+) introduces a thin `IImageManagementOrchestrator` that delegates to both.

## Test plan

- **16 new tests** in `tests/Andy.Containers.Tests/Abstractions/Images/`:
  - `RegistryConfigurationTests` (10) — DI graph composition, primary-resolution preference, `GetByIdOrThrow` error message includes configured ids, configuration binding, `TryAdd`-respect.
  - `AbstractionContractTests` (5) — stub `IRegistryAdapter` / `IBuildBackend` / `IIdentityBridge` / `IPullCredentialBroker` exercise the interface signatures so contract drift surfaces as a compile error in tests.
  - `ImageBuildFailedException` carries logs.
- **Full `Andy.Containers.Tests` suite (397 tests) green.**
- **Whole solution builds with 0 warnings, 0 errors** under `TreatWarningsAsErrors`.

```
dotnet build Andy.Containers.sln                              ✅ 0 warn / 0 err
dotnet test tests/Andy.Containers.Tests                        ✅ 397 / 397
```

## What's next

- **#252 / IM3** — `BuildArtifact` / `RegistryReference` EF entities + migration. Layer on top of existing `Images` table.
- **#253 / IM4** — extend YAML template schema with M1.9 fields.
- **#254 / IM5** — OpenAPI spec for the new endpoints.

Then Phase 1 (IM6–IM11) implements `LocalZotAdapter`, `LocalBuildBackend`, content-addressable cache, build progress SSE, structured errors, and the embedded round-trip integration test — the M1.9 critical path for `rivoli-ai/conductor#1008`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)