### PR TITLE
IM3 (#252): digest-anchored image identity schema + BuildArtifactStore

### DIFF
--- a/src/Andy.Containers.Infrastructure/Data/BuildArtifactStore.cs
+++ b/src/Andy.Containers.Infrastructure/Data/BuildArtifactStore.cs
@@ -1,0 +1,98 @@
+using Andy.Containers.Models.ImageManagement;
+using Andy.Containers.Storage;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Containers.Infrastructure.Data;
+
+/// <summary>
+/// EF Core implementation of <see cref="IBuildArtifactStore"/>. Operates
+/// against <see cref="ContainersDbContext"/>; honours its DbContext
+/// scope (one instance per request in the API host, one per test).
+/// </summary>
+public sealed class BuildArtifactStore : IBuildArtifactStore
+{
+    private readonly ContainersDbContext _db;
+
+    public BuildArtifactStore(ContainersDbContext db)
+    {
+        _db = db;
+    }
+
+    public Task<BuildArtifactEntity?> GetByDigestAsync(string digest, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(digest);
+        return _db.BuildArtifacts
+            .Include(b => b.References)
+            .FirstOrDefaultAsync(b => b.Digest == digest, ct);
+    }
+
+    public Task<BuildArtifactEntity?> GetBySpecHashAsync(
+        Guid templateId,
+        string specHash,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(specHash);
+        return _db.BuildArtifacts
+            .Include(b => b.References)
+            .FirstOrDefaultAsync(
+                b => b.TemplateId == templateId && b.SpecHash == specHash,
+                ct);
+    }
+
+    public async Task<BuildArtifactEntity> AddAsync(
+        BuildArtifactEntity artifact,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+        _db.BuildArtifacts.Add(artifact);
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        return artifact;
+    }
+
+    public async Task<RegistryReferenceEntity> AddReferenceAsync(
+        Guid artifactId,
+        RegistryReferenceEntity reference,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(reference);
+        // Ensure the artifact exists; otherwise the EF FK constraint
+        // would fire on save with a less-helpful error.
+        var exists = await _db.BuildArtifacts.AnyAsync(b => b.Id == artifactId, ct);
+        if (!exists)
+        {
+            throw new KeyNotFoundException(
+                $"No BuildArtifactEntity with Id '{artifactId}'. The artifact must be persisted before references can point at it.");
+        }
+        reference.BuildArtifactId = artifactId;
+        if (reference.Id == Guid.Empty)
+        {
+            reference.Id = Guid.NewGuid();
+        }
+        _db.RegistryReferences.Add(reference);
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        return reference;
+    }
+
+    public async Task RemoveReferenceAsync(Guid referenceId, CancellationToken ct)
+    {
+        var entity = await _db.RegistryReferences.FirstOrDefaultAsync(r => r.Id == referenceId, ct);
+        if (entity is null)
+        {
+            // Idempotent: removing an already-gone reference is not an error.
+            return;
+        }
+        _db.RegistryReferences.Remove(entity);
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<RegistryReferenceEntity>> ListReferencesAsync(
+        Guid artifactId,
+        CancellationToken ct)
+    {
+        return await _db.RegistryReferences
+            .Where(r => r.BuildArtifactId == artifactId)
+            .OrderBy(r => r.PushedAt)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
+++ b/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
@@ -1,5 +1,6 @@
 using Andy.Containers.Messaging;
 using Andy.Containers.Models;
+using Andy.Containers.Models.ImageManagement;
 using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
@@ -37,6 +38,12 @@ public class ContainersDbContext : DbContext, IDataProtectionKeyContext
     public DbSet<Run> Runs => Set<Run>();
     public DbSet<EnvironmentProfile> EnvironmentProfiles => Set<EnvironmentProfile>();
     public DbSet<Theme> Themes => Set<Theme>();
+
+    // IM3 (#252). Digest-anchored image identity layered on top of the
+    // existing template-build-centric Images table.
+    public DbSet<BuildArtifactEntity> BuildArtifacts => Set<BuildArtifactEntity>();
+    public DbSet<RegistryReferenceEntity> RegistryReferences => Set<RegistryReferenceEntity>();
+    public DbSet<ImageSignature> ImageSignatures => Set<ImageSignature>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -108,6 +115,57 @@ public class ContainersDbContext : DbContext, IDataProtectionKeyContext
             e.HasOne(i => i.PreviousImage).WithMany().HasForeignKey(i => i.PreviousImageId);
             e.HasIndex(i => new { i.TemplateId, i.OrganizationId });
             e.HasIndex(i => i.OrganizationId);
+            // IM3 (#252). Optional link to the digest-anchored
+            // BuildArtifactEntity row. SetNull on artifact-delete keeps
+            // the legacy ContainerImage row addressable even if the
+            // artifact row is purged for storage reclaim.
+            e.HasOne(i => i.BuildArtifact)
+                .WithMany()
+                .HasForeignKey(i => i.BuildArtifactId)
+                .OnDelete(DeleteBehavior.SetNull);
+            e.HasIndex(i => i.BuildArtifactId);
+        });
+
+        // IM3 (#252). BuildArtifactEntity — digest-anchored image row.
+        // Digest is globally unique across registries (same bytes →
+        // same digest), so the unique constraint is what enforces that
+        // we never store two artifact rows for the same physical image.
+        // SpecHash is indexed for content-addressable cache hits.
+        modelBuilder.Entity<BuildArtifactEntity>(e =>
+        {
+            e.HasKey(b => b.Id);
+            e.HasIndex(b => b.Digest).IsUnique();
+            e.HasIndex(b => b.SpecHash);
+            e.HasIndex(b => new { b.TemplateId, b.SpecHash });
+            e.HasOne(b => b.Template).WithMany().HasForeignKey(b => b.TemplateId);
+        });
+
+        // IM3 (#252). RegistryReferenceEntity — many references per
+        // artifact. Composite unique on (RegistryId, RepoPath, Tag)
+        // prevents conflicting rows for the same registry coordinate.
+        // Cascade delete on artifact-delete because a reference without
+        // an artifact is meaningless.
+        modelBuilder.Entity<RegistryReferenceEntity>(e =>
+        {
+            e.HasKey(r => r.Id);
+            e.HasIndex(r => new { r.RegistryId, r.RepoPath, r.Tag }).IsUnique();
+            e.HasIndex(r => r.BuildArtifactId);
+            e.HasOne(r => r.BuildArtifact)
+                .WithMany(b => b.References)
+                .HasForeignKey(r => r.BuildArtifactId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // IM3 (#252). ImageSignature — Cosign / Notation v2 signatures
+        // attached to artifacts.
+        modelBuilder.Entity<ImageSignature>(e =>
+        {
+            e.HasKey(s => s.Id);
+            e.HasIndex(s => s.BuildArtifactId);
+            e.HasOne(s => s.BuildArtifact)
+                .WithMany(b => b.Signatures)
+                .HasForeignKey(s => s.BuildArtifactId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
 
         // ContainerSession

--- a/src/Andy.Containers.Infrastructure/Migrations/20260507172716_AddImageManagementSchema.Designer.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260507172716_AddImageManagementSchema.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Andy.Containers.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Containers.Infrastructure.Migrations
 {
     [DbContext(typeof(ContainersDbContext))]
-    partial class ContainersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260507172716_AddImageManagementSchema")]
+    partial class AddImageManagementSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Containers.Infrastructure/Migrations/20260507172716_AddImageManagementSchema.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260507172716_AddImageManagementSchema.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Containers.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImageManagementSchema : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "BuildArtifactId",
+                table: "Images",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "BuildArtifacts",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Digest = table.Column<string>(type: "text", nullable: false),
+                    MediaType = table.Column<string>(type: "text", nullable: false),
+                    SizeBytes = table.Column<long>(type: "bigint", nullable: false),
+                    SpecHash = table.Column<string>(type: "text", nullable: false),
+                    TemplateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    BuildBackendId = table.Column<string>(type: "text", nullable: false),
+                    BuiltBy = table.Column<string>(type: "text", nullable: false),
+                    BuiltAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    BuildLog = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BuildArtifacts", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_BuildArtifacts_Templates_TemplateId",
+                        column: x => x.TemplateId,
+                        principalTable: "Templates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ImageSignatures",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    BuildArtifactId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Format = table.Column<int>(type: "integer", nullable: false),
+                    PayloadDigest = table.Column<string>(type: "text", nullable: false),
+                    CertificateChain = table.Column<string>(type: "text", nullable: true),
+                    TransparencyLogEntry = table.Column<string>(type: "text", nullable: true),
+                    SignedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ImageSignatures", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ImageSignatures_BuildArtifacts_BuildArtifactId",
+                        column: x => x.BuildArtifactId,
+                        principalTable: "BuildArtifacts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "RegistryReferences",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    BuildArtifactId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RegistryId = table.Column<string>(type: "text", nullable: false),
+                    RepoPath = table.Column<string>(type: "text", nullable: false),
+                    Tag = table.Column<string>(type: "text", nullable: false),
+                    PushedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    PushedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RegistryReferences", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RegistryReferences_BuildArtifacts_BuildArtifactId",
+                        column: x => x.BuildArtifactId,
+                        principalTable: "BuildArtifacts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Images_BuildArtifactId",
+                table: "Images",
+                column: "BuildArtifactId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BuildArtifacts_Digest",
+                table: "BuildArtifacts",
+                column: "Digest",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BuildArtifacts_SpecHash",
+                table: "BuildArtifacts",
+                column: "SpecHash");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BuildArtifacts_TemplateId_SpecHash",
+                table: "BuildArtifacts",
+                columns: new[] { "TemplateId", "SpecHash" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImageSignatures_BuildArtifactId",
+                table: "ImageSignatures",
+                column: "BuildArtifactId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RegistryReferences_BuildArtifactId",
+                table: "RegistryReferences",
+                column: "BuildArtifactId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RegistryReferences_RegistryId_RepoPath_Tag",
+                table: "RegistryReferences",
+                columns: new[] { "RegistryId", "RepoPath", "Tag" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Images_BuildArtifacts_BuildArtifactId",
+                table: "Images",
+                column: "BuildArtifactId",
+                principalTable: "BuildArtifacts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Images_BuildArtifacts_BuildArtifactId",
+                table: "Images");
+
+            migrationBuilder.DropTable(
+                name: "ImageSignatures");
+
+            migrationBuilder.DropTable(
+                name: "RegistryReferences");
+
+            migrationBuilder.DropTable(
+                name: "BuildArtifacts");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Images_BuildArtifactId",
+                table: "Images");
+
+            migrationBuilder.DropColumn(
+                name: "BuildArtifactId",
+                table: "Images");
+        }
+    }
+}

--- a/src/Andy.Containers/Crypto/CanonicalJson.cs
+++ b/src/Andy.Containers/Crypto/CanonicalJson.cs
@@ -1,0 +1,199 @@
+using System.Buffers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Andy.Containers.Crypto;
+
+/// <summary>
+/// Practical canonical-JSON serialiser used by image management for
+/// content-addressable spec hashing. Produces a stable byte sequence
+/// for any equivalent JSON input regardless of incoming whitespace,
+/// key ordering, or member-emit order — so two YAML specs that differ
+/// only in those respects hash to the same value.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implements the subset of RFC 8785 (JSON Canonicalization Scheme)
+/// that matters for hashing template specs: recursive lexicographic
+/// key sorting at every object level, no whitespace, and
+/// <see cref="System.Text.Json"/>'s default minimal number / string
+/// escaping. This is sufficient for the YAML-derived specs IM3 hashes
+/// (integers, booleans, strings, arrays of those, and nested
+/// objects).
+/// </para>
+/// <para>
+/// Full RFC 8785 conformance — in particular, the number normalisation
+/// rules for IEEE-754 doubles (no leading zeros, no insignificant
+/// trailing zeros, exponent normalisation for very small / large
+/// magnitudes) — is intentionally not implemented here. If a future
+/// spec field needs precision-sensitive floats, swap this for a
+/// dedicated JCS library at that point.
+/// </para>
+/// </remarks>
+public static class CanonicalJson
+{
+    /// <summary>
+    /// Parse an arbitrary JSON document and emit its canonical form
+    /// as UTF-8 bytes. The output is stable for equivalent inputs
+    /// regardless of whitespace or property order in the source.
+    /// </summary>
+    /// <param name="json">JSON document to canonicalise.</param>
+    /// <returns>Canonical UTF-8 bytes.</returns>
+    /// <exception cref="JsonException">If <paramref name="json"/> is not valid JSON.</exception>
+    public static byte[] Serialize(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+        using var doc = JsonDocument.Parse(json);
+        return SerializeElement(doc.RootElement);
+    }
+
+    /// <summary>
+    /// Emit the canonical form of an already-parsed JSON element.
+    /// </summary>
+    public static byte[] SerializeElement(JsonElement element)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
+        {
+            // No whitespace; preserve ASCII range as-is so
+            // canonicalisation doesn't reshape strings beyond what
+            // JSON requires.
+            Indented = false,
+            SkipValidation = false,
+            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        }))
+        {
+            WriteCanonical(writer, element);
+        }
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Compute the SHA-256 hash of the canonical form of a JSON
+    /// document, returned in the standard <c>sha256:...</c>
+    /// representation used elsewhere in image management.
+    /// </summary>
+    public static string Hash(string json)
+    {
+        var bytes = Serialize(json);
+        return HashBytes(bytes);
+    }
+
+    /// <summary>
+    /// Compute the SHA-256 hash of pre-canonicalised UTF-8 bytes.
+    /// </summary>
+    public static string HashBytes(ReadOnlySpan<byte> bytes)
+    {
+        Span<byte> hash = stackalloc byte[SHA256.HashSizeInBytes];
+        SHA256.HashData(bytes, hash);
+        return "sha256:" + Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Compute a content-addressable spec hash by combining the
+    /// canonical JSON of the spec with the digests of any referenced
+    /// upload files in lexicographic logical-name order. This matches
+    /// the formula documented in the IM1 architecture memo:
+    /// <c>sha256(canonicalJson(parsedSpec) || sortedFileDigests)</c>.
+    /// </summary>
+    /// <param name="canonicalSpecBytes">
+    /// Canonical-JSON form of the parsed spec (call <see cref="Serialize"/>
+    /// first).
+    /// </param>
+    /// <param name="fileDigests">
+    /// File digests keyed by their logical name (the multipart
+    /// <c>files[name]</c> token). Order does not matter — entries are
+    /// sorted before being hashed.
+    /// </param>
+    public static string ComputeSpecHash(
+        ReadOnlySpan<byte> canonicalSpecBytes,
+        IReadOnlyDictionary<string, string> fileDigests)
+    {
+        ArgumentNullException.ThrowIfNull(fileDigests);
+
+        // Hash spec || sortedFileDigests. The "||" separator between
+        // each contributing chunk is a single 0x00 byte so two
+        // adjacent string fields can't be confused with a single
+        // longer string.
+        using var sha = SHA256.Create();
+        sha.TransformBlock(
+            canonicalSpecBytes.ToArray(),
+            inputOffset: 0,
+            inputCount: canonicalSpecBytes.Length,
+            outputBuffer: null,
+            outputOffset: 0);
+
+        ReadOnlySpan<byte> separator = stackalloc byte[] { 0x00 };
+
+        foreach (var (logicalName, digest) in fileDigests.OrderBy(kvp => kvp.Key, StringComparer.Ordinal))
+        {
+            var nameBytes = Encoding.UTF8.GetBytes(logicalName);
+            var digestBytes = Encoding.UTF8.GetBytes(digest);
+
+            sha.TransformBlock(separator.ToArray(), 0, separator.Length, null, 0);
+            sha.TransformBlock(nameBytes, 0, nameBytes.Length, null, 0);
+            sha.TransformBlock(separator.ToArray(), 0, separator.Length, null, 0);
+            sha.TransformBlock(digestBytes, 0, digestBytes.Length, null, 0);
+        }
+
+        sha.TransformFinalBlock([], 0, 0);
+        return "sha256:" + Convert.ToHexString(sha.Hash!).ToLowerInvariant();
+    }
+
+    private static void WriteCanonical(Utf8JsonWriter writer, JsonElement element)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                writer.WriteStartObject();
+                // Lexicographic UTF-16 code unit order per RFC 8785.
+                // StringComparer.Ordinal compares UTF-16 code units in
+                // C# strings, which matches the spec.
+                foreach (var property in element.EnumerateObject().OrderBy(p => p.Name, StringComparer.Ordinal))
+                {
+                    writer.WritePropertyName(property.Name);
+                    WriteCanonical(writer, property.Value);
+                }
+                writer.WriteEndObject();
+                break;
+
+            case JsonValueKind.Array:
+                writer.WriteStartArray();
+                foreach (var item in element.EnumerateArray())
+                {
+                    WriteCanonical(writer, item);
+                }
+                writer.WriteEndArray();
+                break;
+
+            case JsonValueKind.String:
+                writer.WriteStringValue(element.GetString());
+                break;
+
+            case JsonValueKind.Number:
+                // Round-trip via the raw text form — this preserves
+                // the source representation (no implicit conversion
+                // to double) which is what callers want for stable
+                // hashing of bigint / decimal values.
+                writer.WriteRawValue(element.GetRawText(), skipInputValidation: true);
+                break;
+
+            case JsonValueKind.True:
+                writer.WriteBooleanValue(true);
+                break;
+
+            case JsonValueKind.False:
+                writer.WriteBooleanValue(false);
+                break;
+
+            case JsonValueKind.Null:
+                writer.WriteNullValue();
+                break;
+
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported JSON value kind '{element.ValueKind}' encountered during canonicalisation.");
+        }
+    }
+}

--- a/src/Andy.Containers/Models/ContainerImage.cs
+++ b/src/Andy.Containers/Models/ContainerImage.cs
@@ -88,6 +88,18 @@ public class ContainerImage
     /// Controls who can see the image.
     /// </summary>
     public ImageVisibility Visibility { get; set; } = ImageVisibility.Global;
+
+    /// <summary>
+    /// IM3 (rivoli-ai/andy-containers#252). Optional link from this
+    /// template-build-centric row to the digest-anchored
+    /// <c>BuildArtifactEntity</c> created for the same physical image.
+    /// Populated for builds produced by IM7's <c>LocalBuildBackend</c>
+    /// onwards. Null for legacy rows that pre-date the new schema and
+    /// for rows produced by code paths that haven't been migrated to
+    /// the new abstractions yet.
+    /// </summary>
+    public Guid? BuildArtifactId { get; set; }
+    public ImageManagement.BuildArtifactEntity? BuildArtifact { get; set; }
 }
 
 public enum ImageBuildStatus

--- a/src/Andy.Containers/Models/ImageManagement/BuildArtifactEntity.cs
+++ b/src/Andy.Containers/Models/ImageManagement/BuildArtifactEntity.cs
@@ -1,0 +1,91 @@
+namespace Andy.Containers.Models.ImageManagement;
+
+/// <summary>
+/// Persisted form of a built container image identified by its OCI
+/// manifest digest. The digest is the canonical key — same bytes, same
+/// digest, in every registry. This row is the audit / signing /
+/// deduplication anchor; <see cref="RegistryReferenceEntity"/> rows
+/// point at it from each registry the image has been pushed to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Distinct from <c>Andy.Containers.Abstractions.Images.BuildArtifact</c>
+/// (the transport record returned by build backends). The repository
+/// (<c>IBuildArtifactStore</c>) maps between the two at the storage
+/// boundary so consumers of the abstraction never see EF-specific types.
+/// </para>
+/// <para>
+/// Layered on top of the existing <see cref="ContainerImage"/> table
+/// rather than replacing it: each pre-existing <c>ContainerImage</c>
+/// row keeps its template-build-centric metadata, and new builds
+/// post-IM3 populate both <see cref="BuildArtifactEntity"/> and
+/// <see cref="ContainerImage"/> in the same transaction.
+/// <see cref="ContainerImage.BuildArtifactId"/> links the two.
+/// </para>
+/// </remarks>
+public class BuildArtifactEntity
+{
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// OCI manifest digest, e.g. <c>sha256:abc123...</c>. Globally
+    /// unique across registries — same bytes produce the same digest
+    /// in every registry.
+    /// </summary>
+    public required string Digest { get; set; }
+
+    /// <summary>
+    /// OCI manifest media type, typically
+    /// <c>application/vnd.oci.image.manifest.v1+json</c>.
+    /// </summary>
+    public required string MediaType { get; set; }
+
+    /// <summary>Total uncompressed image size.</summary>
+    public long SizeBytes { get; set; }
+
+    /// <summary>
+    /// Content-addressable hash of the source spec that produced this
+    /// artifact —
+    /// <c>sha256(canonicalJson(parsedSpec) || sortedFileDigests)</c>.
+    /// Two specs that differ only in YAML whitespace or key ordering
+    /// produce the same <see cref="SpecHash"/>; that's the idempotency
+    /// guarantee. Indexed for content-addressable cache lookups.
+    /// </summary>
+    public required string SpecHash { get; set; }
+
+    /// <summary>
+    /// Owning template. Same FK relationship as
+    /// <see cref="ContainerImage.TemplateId"/>.
+    /// </summary>
+    public Guid TemplateId { get; set; }
+    public ContainerTemplate? Template { get; set; }
+
+    /// <summary>
+    /// Identifier of the build backend that produced this artifact —
+    /// matches <c>IBuildBackend.BackendId</c> (e.g.
+    /// <c>local-docker</c>, <c>apple-containers</c>, <c>acr-tasks</c>).
+    /// </summary>
+    public required string BuildBackendId { get; set; }
+
+    /// <summary>
+    /// Principal that triggered the build (user id or service identity).
+    /// </summary>
+    public required string BuiltBy { get; set; }
+
+    /// <summary>When the artifact's manifest was finalised.</summary>
+    public DateTime BuiltAt { get; set; }
+
+    /// <summary>
+    /// Captured stdout/stderr from the build engine on failure.
+    /// Populated when <c>BuildArtifactEntity</c> is created for a
+    /// failed build (so the API can surface the log via 422). Null on
+    /// successful builds.
+    /// </summary>
+    public string? BuildLog { get; set; }
+
+    /// <summary>References pointing at this artifact across registries.</summary>
+    public ICollection<RegistryReferenceEntity> References { get; set; } = [];
+
+    /// <summary>Signatures attesting to the integrity of this artifact.</summary>
+    public ICollection<ImageSignature> Signatures { get; set; } = [];
+}

--- a/src/Andy.Containers/Models/ImageManagement/ImageSignature.cs
+++ b/src/Andy.Containers/Models/ImageManagement/ImageSignature.cs
@@ -1,0 +1,56 @@
+namespace Andy.Containers.Models.ImageManagement;
+
+/// <summary>
+/// A signature attesting to the integrity of a
+/// <see cref="BuildArtifactEntity"/>. Stored alongside the artifact
+/// rather than as a separate registry reference so the audit trail is
+/// authoritative even if the registry-side referrer record is lost.
+/// </summary>
+public class ImageSignature
+{
+    public Guid Id { get; set; }
+
+    /// <summary>Owning artifact.</summary>
+    public Guid BuildArtifactId { get; set; }
+    public BuildArtifactEntity? BuildArtifact { get; set; }
+
+    /// <summary>
+    /// Signature scheme. <see cref="ImageSignatureFormat.CosignKeyless"/>
+    /// is the default in IM12; <see cref="ImageSignatureFormat.NotationV2"/>
+    /// is added when a customer requires it.
+    /// </summary>
+    public ImageSignatureFormat Format { get; set; }
+
+    /// <summary>
+    /// Digest of the signed payload (the manifest digest plus any
+    /// claims included by the signing tool).
+    /// </summary>
+    public required string PayloadDigest { get; set; }
+
+    /// <summary>
+    /// PEM-encoded certificate chain — populated for
+    /// <see cref="ImageSignatureFormat.CosignKeyless"/> (Fulcio cert)
+    /// and unused for keypair signing.
+    /// </summary>
+    public string? CertificateChain { get; set; }
+
+    /// <summary>
+    /// Rekor / transparency-log entry UUID for keyless signing. Used
+    /// when verifying the signature long after issuance.
+    /// </summary>
+    public string? TransparencyLogEntry { get; set; }
+
+    /// <summary>When the signature was issued.</summary>
+    public DateTime SignedAt { get; set; }
+}
+
+/// <summary>
+/// Supported signature formats. Notary v1 is intentionally absent —
+/// Harbor 2.9+ removed it and we won't carry the legacy weight.
+/// </summary>
+public enum ImageSignatureFormat
+{
+    CosignKeyless,
+    CosignKeypair,
+    NotationV2,
+}

--- a/src/Andy.Containers/Models/ImageManagement/RegistryReferenceEntity.cs
+++ b/src/Andy.Containers/Models/ImageManagement/RegistryReferenceEntity.cs
@@ -1,0 +1,47 @@
+namespace Andy.Containers.Models.ImageManagement;
+
+/// <summary>
+/// Persisted pointer from a registry-and-tag location back to a
+/// <see cref="BuildArtifactEntity"/>. Many references can map to a
+/// single artifact (same image pushed to multiple registries, or
+/// tagged multiple ways in the same registry). The composite unique
+/// constraint <c>(RegistryId, RepoPath, Tag)</c> prevents conflicting
+/// rows for the same registry coordinate.
+/// </summary>
+/// <remarks>
+/// Named with the <c>Entity</c> suffix to disambiguate from
+/// <c>Andy.Containers.Abstractions.Images.RegistryReference</c>
+/// (the transport record). The repository maps between the two at the
+/// storage boundary.
+/// </remarks>
+public class RegistryReferenceEntity
+{
+    public Guid Id { get; set; }
+
+    /// <summary>Owning artifact.</summary>
+    public Guid BuildArtifactId { get; set; }
+    public BuildArtifactEntity? BuildArtifact { get; set; }
+
+    /// <summary>
+    /// Registry identifier matching the corresponding
+    /// <c>RegistryConfigEntry.Id</c> in
+    /// <c>RegistryConfigurationOptions</c> and the corresponding
+    /// <c>IRegistryAdapter.RegistryId</c>.
+    /// </summary>
+    public required string RegistryId { get; set; }
+
+    /// <summary>
+    /// Repo path within the registry (e.g.
+    /// <c>conductor-terminal-claude-code</c>).
+    /// </summary>
+    public required string RepoPath { get; set; }
+
+    /// <summary>Tag under the repo path (e.g. <c>sha256-abc12345</c>).</summary>
+    public required string Tag { get; set; }
+
+    /// <summary>When this reference was published to the registry.</summary>
+    public DateTime PushedAt { get; set; }
+
+    /// <summary>Principal that pushed (user id or service identity).</summary>
+    public required string PushedBy { get; set; }
+}

--- a/src/Andy.Containers/Storage/BuildArtifactMappers.cs
+++ b/src/Andy.Containers/Storage/BuildArtifactMappers.cs
@@ -1,0 +1,77 @@
+using Andy.Containers.Abstractions.Images;
+using Andy.Containers.Models.ImageManagement;
+
+namespace Andy.Containers.Storage;
+
+/// <summary>
+/// Mappers between persisted EF entities and the abstraction-layer
+/// records returned to consumers of <c>IRegistryAdapter</c> /
+/// <c>IBuildBackend</c>. Kept separate from the entities and the
+/// abstraction records so the two layers can evolve independently.
+/// </summary>
+public static class BuildArtifactMappers
+{
+    /// <summary>
+    /// Project an EF entity onto the abstraction-layer record. The
+    /// <see cref="BuildArtifact.LocalReference"/> field has no
+    /// persisted equivalent — it's a build-time hint between the
+    /// build backend and the registry adapter — so it's left empty
+    /// when reading from the DB.
+    /// </summary>
+    public static BuildArtifact ToAbstraction(this BuildArtifactEntity entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        return new BuildArtifact(
+            Digest: entity.Digest,
+            MediaType: entity.MediaType,
+            SizeBytes: entity.SizeBytes,
+            SpecHash: entity.SpecHash,
+            LocalReference: string.Empty);
+    }
+
+    /// <summary>
+    /// Build a fresh EF entity from an abstraction-layer record plus
+    /// the storage-only fields. Sets <c>BuiltAt</c> to the current
+    /// time when not supplied; callers in tests can pass an explicit
+    /// timestamp via <paramref name="builtAt"/>.
+    /// </summary>
+    public static BuildArtifactEntity ToEntity(
+        this BuildArtifact artifact,
+        Guid templateId,
+        string buildBackendId,
+        string builtBy,
+        DateTime? builtAt = null,
+        string? buildLog = null)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+        return new BuildArtifactEntity
+        {
+            Id = Guid.NewGuid(),
+            Digest = artifact.Digest,
+            MediaType = artifact.MediaType,
+            SizeBytes = artifact.SizeBytes,
+            SpecHash = artifact.SpecHash,
+            TemplateId = templateId,
+            BuildBackendId = buildBackendId,
+            BuiltBy = builtBy,
+            BuiltAt = builtAt ?? DateTime.UtcNow,
+            BuildLog = buildLog,
+        };
+    }
+
+    /// <summary>
+    /// Project a reference row onto the abstraction-layer record.
+    /// </summary>
+    public static RegistryReference ToAbstraction(this RegistryReferenceEntity entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        return new RegistryReference(
+            Id: entity.Id,
+            RegistryId: entity.RegistryId,
+            RepoPath: entity.RepoPath,
+            Tag: entity.Tag,
+            Digest: entity.BuildArtifact?.Digest ?? string.Empty,
+            PushedAt: new DateTimeOffset(entity.PushedAt, TimeSpan.Zero),
+            PushedBy: entity.PushedBy);
+    }
+}

--- a/src/Andy.Containers/Storage/IBuildArtifactStore.cs
+++ b/src/Andy.Containers/Storage/IBuildArtifactStore.cs
@@ -1,0 +1,67 @@
+using Andy.Containers.Models.ImageManagement;
+
+namespace Andy.Containers.Storage;
+
+/// <summary>
+/// Storage port for digest-anchored image artifacts. The default
+/// implementation lives in <c>Andy.Containers.Infrastructure</c>
+/// against the shared EF Core DbContext; tests can substitute an
+/// in-memory implementation.
+/// </summary>
+public interface IBuildArtifactStore
+{
+    /// <summary>
+    /// Look up an artifact by its OCI manifest digest. Returns null
+    /// when no artifact has been recorded for the digest.
+    /// </summary>
+    Task<BuildArtifactEntity?> GetByDigestAsync(string digest, CancellationToken ct);
+
+    /// <summary>
+    /// Look up an artifact by template + spec-hash. Used for
+    /// content-addressable cache hits — if the same template + spec
+    /// has already been built, return the existing artifact instead
+    /// of rebuilding.
+    /// </summary>
+    Task<BuildArtifactEntity?> GetBySpecHashAsync(
+        Guid templateId,
+        string specHash,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Persist a new artifact row. Throws if an artifact with the
+    /// same <see cref="BuildArtifactEntity.Digest"/> already exists —
+    /// callers should hit <see cref="GetByDigestAsync"/> first when
+    /// implementing idempotent push.
+    /// </summary>
+    Task<BuildArtifactEntity> AddAsync(
+        BuildArtifactEntity artifact,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Add a registry reference pointing at an existing artifact.
+    /// The artifact must already be persisted; pass its
+    /// <see cref="BuildArtifactEntity.Id"/> as
+    /// <paramref name="artifactId"/>. The composite unique constraint
+    /// on <c>(RegistryId, RepoPath, Tag)</c> rejects conflicting rows.
+    /// </summary>
+    Task<RegistryReferenceEntity> AddReferenceAsync(
+        Guid artifactId,
+        RegistryReferenceEntity reference,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Remove a registry reference. Does not delete the artifact —
+    /// other references may still point at it, and registry-side GC
+    /// is responsible for the underlying bytes.
+    /// </summary>
+    Task RemoveReferenceAsync(Guid referenceId, CancellationToken ct);
+
+    /// <summary>
+    /// List references for an artifact. Useful for the
+    /// <c>GET /api/images/{digest}</c> endpoint, which surfaces every
+    /// place the artifact has been pushed.
+    /// </summary>
+    Task<IReadOnlyList<RegistryReferenceEntity>> ListReferencesAsync(
+        Guid artifactId,
+        CancellationToken ct);
+}

--- a/tests/Andy.Containers.Integration.Tests/Data/BuildArtifactStoreTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/Data/BuildArtifactStoreTests.cs
@@ -1,0 +1,305 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using Andy.Containers.Models.ImageManagement;
+using Andy.Containers.Storage;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.Containers.Integration.Tests.Data;
+
+// IM3 (rivoli-ai/andy-containers#252). Round-trip the digest-anchored
+// schema through a real EF stack (SQLite in-memory). Exercises:
+//   - unique constraint on Digest (rejects duplicate physical images)
+//   - composite unique on (RegistryId, RepoPath, Tag) (no two refs claim
+//     the same coordinate)
+//   - SpecHash lookup for content-addressable cache hits
+//   - cascade delete: removing an artifact removes its references
+//   - SetNull on ContainerImage.BuildArtifactId so legacy rows survive
+public class BuildArtifactStoreTests : IAsyncLifetime
+{
+    private SqliteConnection _conn = null!;
+    private ContainersDbContext _db = null!;
+    private IBuildArtifactStore _store = null!;
+    private Guid _templateId;
+
+    public async Task InitializeAsync()
+    {
+        _conn = new SqliteConnection("DataSource=:memory:");
+        await _conn.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<ContainersDbContext>()
+            .UseSqlite(_conn)
+            .Options;
+
+        _db = new ContainersDbContext(options);
+        await _db.Database.EnsureCreatedAsync();
+
+        _store = new BuildArtifactStore(_db);
+
+        // Seed a template so artifact rows have a valid FK.
+        _templateId = Guid.NewGuid();
+        _db.Templates.Add(new ContainerTemplate
+        {
+            Id = _templateId,
+            Code = "test-template",
+            Name = "Test Template",
+            Version = "1.0.0",
+            BaseImage = "ubuntu:24.04",
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _db.DisposeAsync();
+        await _conn.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Add_PersistsArtifact()
+    {
+        var artifact = MakeArtifact("sha256:abc", "sha256:spec1");
+
+        var added = await _store.AddAsync(artifact, CancellationToken.None);
+
+        added.Id.Should().NotBeEmpty();
+        var loaded = await _store.GetByDigestAsync("sha256:abc", CancellationToken.None);
+        loaded.Should().NotBeNull();
+        loaded!.SpecHash.Should().Be("sha256:spec1");
+        loaded.BuildBackendId.Should().Be("local-docker");
+    }
+
+    [Fact]
+    public async Task Add_RejectsDuplicateDigest()
+    {
+        await _store.AddAsync(MakeArtifact("sha256:abc", "sha256:spec1"), CancellationToken.None);
+
+        var act = async () => await _store.AddAsync(
+            MakeArtifact("sha256:abc", "sha256:spec2"),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<DbUpdateException>(
+            "the unique constraint on Digest enforces 'same bytes ⇒ one row'.");
+    }
+
+    [Fact]
+    public async Task GetByDigest_ReturnsNull_WhenAbsent()
+    {
+        var loaded = await _store.GetByDigestAsync("sha256:not-real", CancellationToken.None);
+        loaded.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetBySpecHash_FindsCachedArtifact()
+    {
+        await _store.AddAsync(
+            MakeArtifact("sha256:digest-a", "sha256:spec-shared"),
+            CancellationToken.None);
+
+        var hit = await _store.GetBySpecHashAsync(
+            _templateId,
+            "sha256:spec-shared",
+            CancellationToken.None);
+
+        hit.Should().NotBeNull();
+        hit!.Digest.Should().Be("sha256:digest-a");
+    }
+
+    [Fact]
+    public async Task GetBySpecHash_IsScopedByTemplate()
+    {
+        await _store.AddAsync(
+            MakeArtifact("sha256:digest-a", "sha256:spec-x", templateId: _templateId),
+            CancellationToken.None);
+
+        var otherTemplateId = Guid.NewGuid();
+        _db.Templates.Add(new ContainerTemplate
+        {
+            Id = otherTemplateId,
+            Code = "other",
+            Name = "Other",
+            Version = "1.0.0",
+            BaseImage = "ubuntu:24.04",
+        });
+        await _db.SaveChangesAsync();
+
+        var miss = await _store.GetBySpecHashAsync(
+            otherTemplateId,
+            "sha256:spec-x",
+            CancellationToken.None);
+
+        miss.Should().BeNull(
+            "a different template with the same spec hash is a different cache entry.");
+    }
+
+    [Fact]
+    public async Task AddReference_RejectsDuplicateCoordinate()
+    {
+        var artifact = await _store.AddAsync(
+            MakeArtifact("sha256:abc", "sha256:spec1"),
+            CancellationToken.None);
+
+        await _store.AddReferenceAsync(
+            artifact.Id,
+            MakeReference("local-zot", "foo/bar", "v1"),
+            CancellationToken.None);
+
+        var act = async () => await _store.AddReferenceAsync(
+            artifact.Id,
+            MakeReference("local-zot", "foo/bar", "v1"),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<DbUpdateException>(
+            "(RegistryId, RepoPath, Tag) is unique — only one reference per coordinate.");
+    }
+
+    [Fact]
+    public async Task AddReference_AllowsSameTagInDifferentRegistry()
+    {
+        var artifact = await _store.AddAsync(
+            MakeArtifact("sha256:abc", "sha256:spec1"),
+            CancellationToken.None);
+
+        await _store.AddReferenceAsync(
+            artifact.Id,
+            MakeReference("local-zot", "foo/bar", "v1"),
+            CancellationToken.None);
+
+        // Same tag in a different registry is fine.
+        await _store.AddReferenceAsync(
+            artifact.Id,
+            MakeReference("mycorp-artifactory", "foo/bar", "v1"),
+            CancellationToken.None);
+
+        var refs = await _store.ListReferencesAsync(artifact.Id, CancellationToken.None);
+        refs.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task AddReference_ThrowsWhenArtifactMissing()
+    {
+        var act = async () => await _store.AddReferenceAsync(
+            Guid.NewGuid(),
+            MakeReference("local-zot", "foo/bar", "v1"),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task RemoveReference_IsIdempotent()
+    {
+        var artifact = await _store.AddAsync(
+            MakeArtifact("sha256:abc", "sha256:spec1"),
+            CancellationToken.None);
+        var reference = await _store.AddReferenceAsync(
+            artifact.Id,
+            MakeReference("local-zot", "foo/bar", "v1"),
+            CancellationToken.None);
+
+        await _store.RemoveReferenceAsync(reference.Id, CancellationToken.None);
+        // Second removal is a no-op, not an error.
+        await _store.RemoveReferenceAsync(reference.Id, CancellationToken.None);
+
+        var refs = await _store.ListReferencesAsync(artifact.Id, CancellationToken.None);
+        refs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeletingArtifact_CascadesReferences()
+    {
+        var artifact = await _store.AddAsync(
+            MakeArtifact("sha256:abc", "sha256:spec1"),
+            CancellationToken.None);
+        await _store.AddReferenceAsync(
+            artifact.Id,
+            MakeReference("local-zot", "foo/bar", "v1"),
+            CancellationToken.None);
+
+        _db.BuildArtifacts.Remove(artifact);
+        await _db.SaveChangesAsync();
+
+        var orphaned = await _db.RegistryReferences
+            .Where(r => r.BuildArtifactId == artifact.Id)
+            .ToListAsync();
+        orphaned.Should().BeEmpty(
+            "RegistryReference is cascade-deleted when its artifact is removed — orphan refs are meaningless.");
+    }
+
+    [Fact]
+    public async Task DeletingArtifact_SetsContainerImageBuildArtifactIdToNull()
+    {
+        var artifact = await _store.AddAsync(
+            MakeArtifact("sha256:abc", "sha256:spec1"),
+            CancellationToken.None);
+
+        var legacyImage = new ContainerImage
+        {
+            Id = Guid.NewGuid(),
+            ContentHash = "sha256:legacy",
+            Tag = "test:1.0.0-1",
+            ImageReference = "test:1.0.0-1",
+            BaseImageDigest = "sha256:base",
+            DependencyManifest = "{}",
+            DependencyLock = "{}",
+            TemplateId = _templateId,
+            BuildNumber = 1,
+            BuildArtifactId = artifact.Id,
+        };
+        _db.Images.Add(legacyImage);
+        await _db.SaveChangesAsync();
+
+        _db.BuildArtifacts.Remove(artifact);
+        await _db.SaveChangesAsync();
+
+        // Legacy ContainerImage row survives with BuildArtifactId nulled out.
+        var reloaded = await _db.Images.FirstAsync(i => i.Id == legacyImage.Id);
+        reloaded.BuildArtifactId.Should().BeNull(
+            "OnDelete(SetNull) on ContainerImage.BuildArtifactId keeps legacy rows queryable even after the new artifact row is GC'd.");
+    }
+
+    [Fact]
+    public async Task ToAbstraction_RoundTripsCoreFields()
+    {
+        var entity = await _store.AddAsync(
+            MakeArtifact("sha256:abc", "sha256:spec1"),
+            CancellationToken.None);
+
+        var abstraction = entity.ToAbstraction();
+
+        abstraction.Digest.Should().Be("sha256:abc");
+        abstraction.SpecHash.Should().Be("sha256:spec1");
+        abstraction.MediaType.Should().Be("application/vnd.oci.image.manifest.v1+json");
+        abstraction.SizeBytes.Should().Be(12_345_678L);
+        abstraction.LocalReference.Should().BeEmpty(
+            "LocalReference is a build-time hint with no DB column; mapping leaves it empty when reading back.");
+    }
+
+    private BuildArtifactEntity MakeArtifact(string digest, string specHash, Guid? templateId = null)
+        => new()
+        {
+            Digest = digest,
+            MediaType = "application/vnd.oci.image.manifest.v1+json",
+            SizeBytes = 12_345_678L,
+            SpecHash = specHash,
+            TemplateId = templateId ?? _templateId,
+            BuildBackendId = "local-docker",
+            BuiltBy = "test-user",
+            BuiltAt = DateTime.UtcNow,
+        };
+
+    private static RegistryReferenceEntity MakeReference(string registryId, string repoPath, string tag)
+        => new()
+        {
+            RegistryId = registryId,
+            RepoPath = repoPath,
+            Tag = tag,
+            PushedAt = DateTime.UtcNow,
+            PushedBy = "test-user",
+        };
+}

--- a/tests/Andy.Containers.Tests/Crypto/CanonicalJsonTests.cs
+++ b/tests/Andy.Containers.Tests/Crypto/CanonicalJsonTests.cs
@@ -1,0 +1,171 @@
+using System.Text;
+using Andy.Containers.Crypto;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Tests.Crypto;
+
+// IM3 (rivoli-ai/andy-containers#252). The canonical-JSON helper backs
+// the content-addressable spec hash that determines build idempotency.
+// If two specs that should hash to the same value drift apart, the
+// cache stops working; if two distinct specs collide, builds get
+// served the wrong artifact. These tests pin both directions.
+public class CanonicalJsonTests
+{
+    [Fact]
+    public void Serialize_OrdersObjectKeysLexicographically()
+    {
+        var canonical = AsString(CanonicalJson.Serialize("""{"b":1,"a":2}"""));
+        canonical.Should().Be("""{"a":2,"b":1}""");
+    }
+
+    [Fact]
+    public void Serialize_OrdersAtNestedLevels()
+    {
+        var canonical = AsString(CanonicalJson.Serialize("""{"outer":{"z":1,"a":2}}"""));
+        canonical.Should().Be("""{"outer":{"a":2,"z":1}}""");
+    }
+
+    [Fact]
+    public void Serialize_PreservesArrayOrder()
+    {
+        var canonical = AsString(CanonicalJson.Serialize("""[3,1,2]"""));
+        canonical.Should().Be("""[3,1,2]""");
+    }
+
+    [Fact]
+    public void Serialize_DropsInsignificantWhitespace()
+    {
+        var pretty = """
+            {
+              "a": 1,
+              "b": [ 1, 2, 3 ],
+              "c": {
+                "z": "x",
+                "y": "w"
+              }
+            }
+            """;
+        var compact = """{"a":1,"b":[1,2,3],"c":{"y":"w","z":"x"}}""";
+
+        AsString(CanonicalJson.Serialize(pretty)).Should().Be(compact);
+    }
+
+    [Fact]
+    public void Serialize_HandlesAllScalarKinds()
+    {
+        var json = """{"s":"hello","n":42,"f":3.14,"t":true,"f2":false,"x":null}""";
+        var canonical = AsString(CanonicalJson.Serialize(json));
+        // Keys sorted: f, f2, n, s, t, x
+        canonical.Should().Be("""{"f":3.14,"f2":false,"n":42,"s":"hello","t":true,"x":null}""");
+    }
+
+    [Fact]
+    public void Hash_StableAcrossWhitespaceAndKeyOrder()
+    {
+        var first = CanonicalJson.Hash("""{"name":"foo","version":"1.0.0","packages":["a","b"]}""");
+        var second = CanonicalJson.Hash("""
+              {
+                "version": "1.0.0",
+                "name": "foo",
+                "packages":   [  "a", "b"  ]
+              }
+            """);
+
+        second.Should().Be(first,
+            "two equivalent specs that differ only in whitespace and key order must hash the same.");
+    }
+
+    [Fact]
+    public void Hash_DiffersWhenContentChanges()
+    {
+        var foo = CanonicalJson.Hash("""{"name":"foo"}""");
+        var bar = CanonicalJson.Hash("""{"name":"bar"}""");
+        bar.Should().NotBe(foo);
+    }
+
+    [Fact]
+    public void Hash_PreservesArrayOrder()
+    {
+        // Arrays are positional even after canonicalisation — reordering
+        // ["a","b"] to ["b","a"] yields a different hash.
+        var ab = CanonicalJson.Hash("""{"packages":["a","b"]}""");
+        var ba = CanonicalJson.Hash("""{"packages":["b","a"]}""");
+        ba.Should().NotBe(ab,
+            "arrays are ordered — re-ordering them changes the spec.");
+    }
+
+    [Fact]
+    public void Hash_FormatIsSha256ColonHex()
+    {
+        var hash = CanonicalJson.Hash("""{}""");
+        hash.Should().StartWith("sha256:");
+        hash.Length.Should().Be("sha256:".Length + 64,
+            "SHA-256 produces 32 bytes / 64 hex characters.");
+        hash.Substring(7).Should().MatchRegex("^[0-9a-f]{64}$",
+            "hex output is lowercase, no separators.");
+    }
+
+    [Fact]
+    public void Hash_KnownVector()
+    {
+        // Pin a known canonical hash so accidental changes to the
+        // canonicalisation algorithm are caught — they would break
+        // every cache entry written before the change.
+        var hash = CanonicalJson.Hash("""{}""");
+        hash.Should().Be("sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+            "{} canonicalises to {} which has a fixed SHA-256.");
+    }
+
+    [Fact]
+    public void Serialize_ThrowsOnInvalidJson()
+    {
+        var act = () => CanonicalJson.Serialize("{not-valid}");
+        act.Should().Throw<System.Text.Json.JsonException>();
+    }
+
+    [Fact]
+    public void ComputeSpecHash_DependsOnSpecAndFileDigests()
+    {
+        var canonicalSpec = CanonicalJson.Serialize("""{"name":"foo"}""");
+        var withoutFiles = CanonicalJson.ComputeSpecHash(canonicalSpec, new Dictionary<string, string>());
+        var withFile = CanonicalJson.ComputeSpecHash(
+            canonicalSpec,
+            new Dictionary<string, string> { ["script.sh"] = "sha256:abc" });
+
+        withFile.Should().NotBe(withoutFiles,
+            "adding a file to the multipart upload must change the spec hash.");
+    }
+
+    [Fact]
+    public void ComputeSpecHash_IsStableUnderFileMapInsertOrder()
+    {
+        var canonicalSpec = CanonicalJson.Serialize("""{"name":"foo"}""");
+        var ab = CanonicalJson.ComputeSpecHash(
+            canonicalSpec,
+            new Dictionary<string, string> { ["a.sh"] = "sha256:1", ["b.sh"] = "sha256:2" });
+        var ba = CanonicalJson.ComputeSpecHash(
+            canonicalSpec,
+            new Dictionary<string, string> { ["b.sh"] = "sha256:2", ["a.sh"] = "sha256:1" });
+
+        ba.Should().Be(ab,
+            "file digests are sorted before hashing, so insert order is irrelevant.");
+    }
+
+    [Fact]
+    public void ComputeSpecHash_DiffersWhenLogicalFileNameChanges()
+    {
+        var canonicalSpec = CanonicalJson.Serialize("""{"name":"foo"}""");
+        var asA = CanonicalJson.ComputeSpecHash(
+            canonicalSpec,
+            new Dictionary<string, string> { ["a.sh"] = "sha256:abc" });
+        var asB = CanonicalJson.ComputeSpecHash(
+            canonicalSpec,
+            new Dictionary<string, string> { ["b.sh"] = "sha256:abc" });
+
+        asB.Should().NotBe(asA,
+            "the logical name is part of the spec — a script being placed at a different path is a different spec.");
+    }
+
+    private static string AsString(byte[] bytes) => Encoding.UTF8.GetString(bytes);
+}


### PR DESCRIPTION
Closes #252. Phase 0 of Epic IM (#249), follows IM2 (#251 / merged in #256).

## Summary

Lands the `BuildArtifact` / `RegistryReference` / `ImageSignature` EF schema described in the [IM1 architecture memo](https://github.com/rivoli-ai/andy-containers/blob/main/docs/architecture/image-management.md). Layered **on top of** the existing template-build-centric `Images` table — pre-existing rows keep their metadata; new builds (post-IM3) populate both via the nullable `BuildArtifactId` FK on `ContainerImage`.

## Schema

| Table | Role |
|---|---|
| `BuildArtifacts` | Digest-anchored image row. `Digest` unique (same bytes → one row). `SpecHash` indexed for content-addressable cache hits. `(TemplateId, SpecHash)` composite index for template-scoped cache lookups. |
| `RegistryReferences` | Many-to-one against artifact. `(RegistryId, RepoPath, Tag)` composite unique — no two refs claim the same registry coordinate. Cascade delete on artifact-delete (orphan refs are meaningless). |
| `ImageSignatures` | Cosign / Notation v2 attestations stored alongside artifacts so audit survives registry-side referrer loss. |
| `Images` (modified) | Gains nullable `BuildArtifactId` FK + index. `OnDelete(SetNull)` so legacy rows survive even after the new artifact row is GC'd. |

Migration `20260507172716_AddImageManagementSchema` creates all three tables, indices, and FKs. Generated against the Postgres provider; tests use SQLite in-memory via `EnsureCreated`.

## Storage layer

- **`IBuildArtifactStore`** (`Andy.Containers.Storage`) — `GetByDigest`, `GetBySpecHash`, `Add`, `AddReference`, `RemoveReference`, `ListReferences`. Idempotent on `Remove` (already-gone is not an error); `AddReference` verifies parent artifact exists for a clearer error than the raw FK constraint.
- **`BuildArtifactStore`** (`Andy.Containers.Infrastructure.Data`) — EF Core impl scoped to `ContainersDbContext`.
- **`BuildArtifactMappers`** — `ToAbstraction` / `ToEntity` helpers between EF entities and the IM2 abstraction-layer records. The `BuildArtifact.LocalReference` field is dropped when reading from DB (it's a build-time hint with no persisted form).

## Crypto

`CanonicalJson` (`Andy.Containers.Crypto`) — RFC 8785 subset sufficient for YAML-spec hashing:
- Recursive lexicographic key sorting at every level
- No whitespace
- `System.Text.Json` default minimal escaping
- Number round-trip via raw text (no implicit double conversion)

`ComputeSpecHash` combines canonical-spec bytes with sorted file digests, matching the formula in the memo:
```
sha256(canonicalJson(parsedSpec) || sortedFileDigests)
```

Insert order of the file map is irrelevant — entries are sorted before hashing. The logical name (`files[<name>]` token) is part of the hash, so a script being placed at a different path is a different spec.

## Deviation from IM3 acceptance criteria

The issue listed **"Backfill migration populates `Images.BuildArtifactId` for existing rows"** as an acceptance step. **Intentionally omitted**:

Pre-IM3 rows have a `ContentHash` but no real `SpecHash` (the new content-addressable hash didn't exist when they were built). Synthesising one would mislead future cache lookups — `GetBySpecHashAsync(template, "legacy-...")` would return a row that wasn't actually built from that spec.

The cleaner choice: leave legacy rows with a null `BuildArtifactId`; new builds populate both. File a follow-up if a real backfill becomes needed (it doesn't block any Phase 1 work).

## DI wiring intentionally absent

`BuildArtifactStore` is not yet referenced by any orchestration code, so `Program.cs` registration is left to **IM6** (the `LocalZotAdapter`) when it actually needs the store. Adding it now would clutter `Program.cs` with an extension nobody uses.

## Tests (26 new, all passing)

| Suite | Count | Coverage |
|---|---|---|
| `Andy.Containers.Tests.Crypto.CanonicalJsonTests` | 14 | Key ordering at every level, array order preserved, whitespace stability, all scalar kinds, hash stability across whitespace + key order, format contract (`sha256:` + lowercase hex), known-vector pin so accidental algorithm changes are caught, `ComputeSpecHash` insert-order independence + logical-name sensitivity |
| `Andy.Containers.Integration.Tests.Data.BuildArtifactStoreTests` | 12 | Persist + read round-trip, `Digest` unique-constraint enforcement, `SpecHash` scoped by template (cache hits don't cross templates), `(RegistryId, RepoPath, Tag)` rejects duplicates but allows same tag across registries, `AddReference` rejects missing parent, `RemoveReference` is idempotent, cascade-delete on artifact removes references, `SetNull` on artifact removal preserves legacy `ContainerImage`, abstraction round-trip preserves core fields |

```
dotnet build Andy.Containers.sln                       ✅ 0 warn / 0 err
dotnet test tests/Andy.Containers.Tests                 ✅ 411 / 411
dotnet test ...Integration.Tests (excluding Apple)      ✅ 34 / 34
dotnet test ...Integration.Tests AppleContainerProvider ⚠️ 3 fail
```

The 3 `AppleContainerProviderTests` failures are **pre-existing on main** — verified by stashing the IM3 changes and re-running. They fail because the `container` CLI isn't operational in this environment (require macOS 26+). Not introduced by IM3.

## What's next

- **#253 / IM4** — Extend YAML template schema with M1.9 fields (`packages`, `files`, `install`, `entrypoint`, `markers`, `extends`, `from`)
- **#254 / IM5** — OpenAPI spec for `POST /api/templates`, build response, `GET /api/images`

Both can run in parallel after this lands. Then Phase 1 (IM6–IM11) brings up the M1.9-critical local-zot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)