### PR TITLE
IM5 (#254): OpenAPI spec for digest-anchored image management API

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -82,16 +82,44 @@ All endpoints require authentication (JWT Bearer token) and RBAC permissions via
 
 ## Images
 
+### Legacy (template-build-centric)
+
 | Method | Endpoint | Permission | Description |
 |--------|----------|------------|-------------|
 | GET | `/images/{templateId}` | template:read | List built images |
-| POST | `/images/{templateId}/build` | template:write | Trigger build |
+| POST | `/images/{templateId}/build` | template:write | Trigger build (returns `BuildHandle` since IM5) |
 | GET | `/images/{templateId}/latest` | template:read | Get latest image |
 | GET | `/images/diff` | template:read | Compare two images |
 | GET | `/images/{imageId}/manifest` | template:read | Get introspection manifest |
 | GET | `/images/{imageId}/tools` | template:read | List installed tools |
 | GET | `/images/{imageId}/packages` | template:read | List OS packages |
 | POST | `/images/{imageId}/introspect` | template:write | Re-run introspection |
+
+### Image Management (Epic IM — digest-anchored)
+
+The endpoints below ship the digest-anchored image identity model introduced in IM3 (`#252`). Same physical bytes produce the same `digest` in every registry; the `references` array on each `BuildArtifact` records every place the bytes have been pushed.
+
+| Method | Endpoint | Permission | Description |
+|--------|----------|------------|-------------|
+| POST | `/templates/from-yaml` | template:write | Register a YAML template (multipart for spec + files; JSON for spec-only). Idempotent on `specHash`. |
+| GET | `/images` | template:read | List `BuildArtifact`s with their references. Filters: `templateId`, `registryId`, `marker`. |
+| GET | `/images/by-digest/{digest}` | template:read | Get a single artifact by OCI digest. |
+| DELETE | `/images/by-digest/{digest}/references/{referenceId}` | image:admin | Untag one registry coordinate. Idempotent. |
+| GET | `/images/build/{buildId}` | template:read | Build status snapshot (`BuildStatus`). |
+| GET | `/images/build/{buildId}/events` | template:read | SSE stream of `BuildEvent`s (build progress). |
+
+#### Error mapping
+
+| Status | Code prefix | Meaning |
+|---|---|---|
+| 400 | `template.spec.invalid` | YAML schema validation failed. |
+| 401 | (auth) | Missing or expired JWT. |
+| 403 | (rbac) | Caller lacks `template:write` / `image:admin`. |
+| 404 | (resource) | Unknown templateId / digest / buildId / referenceId. |
+| 409 | `template.code.in-use` | Template `code` is already registered with a different `specHash`. |
+| 422 | `template.extends.cycle`, `build.failed` | Cycle in `extends:`, or build engine reported a non-zero exit (logs in `buildLog`). |
+| 503 | `build.engine.unavailable` | No build engine on the host (no Docker daemon, no Apple Containers CLI). |
+| 507 | `registry.quota.exceeded` | Registry storage quota exhausted. |
 
 ## Other Endpoints
 

--- a/openapi/containers-api.yaml
+++ b/openapi/containers-api.yaml
@@ -564,10 +564,88 @@ paths:
           description: No run with that id
 
   # --- Images ---
+  # --- IM5 (#254) — Template registration via YAML --------------
+  # Multipart variant lands the spec + any uploaded files in one
+  # request and is idempotent on the content-addressable spec hash.
+  # JSON variant accepts a string-bodied YAML for callers that don't
+  # need file uploads (admin UIs, the CLI's `templates import`).
+  /api/templates/from-yaml:
+    post:
+      tags: [Templates]
+      summary: Register a template from a YAML spec
+      description: |
+        Idempotent on `specHash` — submitting the same spec twice
+        returns the existing template id with `created: false`. The
+        multipart variant uploads any files referenced by the spec's
+        `files:` entries; the `source` field of each entry must match
+        the multipart part name.
+
+        On `409 Conflict` the body carries an
+        [`ImageManagementError`](#components/schemas/ImageManagementError)
+        with `code: "template.code.in-use"` when the template `code` is
+        already registered against a different `specHash`.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [spec]
+              properties:
+                spec:
+                  type: string
+                  format: binary
+                  description: YAML or JSON spec body.
+                files:
+                  type: array
+                  description: Files referenced by the spec's `files:` entries; the multipart part name must match the spec entry's `source`.
+                  items:
+                    type: string
+                    format: binary
+            encoding:
+              spec: { contentType: 'application/yaml, application/json' }
+              files: { contentType: 'application/octet-stream' }
+          application/json:
+            schema:
+              type: object
+              required: [content]
+              properties:
+                content:
+                  type: string
+                  description: YAML spec text.
+      responses:
+        '200':
+          description: Template registered (or returned an existing match).
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/RegisteredTemplate' }
+        '400':
+          description: Spec validation failure.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ImageManagementError' }
+        '409':
+          description: Template code already registered with a different specHash.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ImageManagementError' }
+        '422':
+          description: Spec is structurally valid but contains a cycle in `extends:`.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ImageManagementError' }
+
+  # --- IM5 (#254) — Legacy template-build-centric image endpoints
+  # The endpoints under /api/images/{templateId}/* are the original
+  # template-build-centric API. They remain for back-compat; new
+  # callers should use /api/images/by-digest/* and the SSE / list /
+  # untag endpoints below, which expose the digest-anchored
+  # BuildArtifact identity introduced in IM3 (#252).
+
   /api/images/{templateId}:
     get:
       tags: [Images]
-      summary: List built images for a template
+      summary: List built images for a template (legacy)
       parameters:
         - name: templateId
           in: path
@@ -585,7 +663,17 @@ paths:
   /api/images/{templateId}/build:
     post:
       tags: [Images]
-      summary: Trigger image build for a template
+      summary: Trigger an image build for a template
+      description: |
+        Async — returns a `BuildHandle` immediately. Poll the build
+        status via `GET /api/images/build/{buildId}` or stream
+        progress events via
+        `GET /api/images/build/{buildId}/events` (SSE).
+
+        If the template's `specHash` already resolves to a digest in
+        the targeted registry, the response status is `cached` and
+        `digest` / `references` are populated immediately — no actual
+        build runs.
       parameters:
         - name: templateId
           in: path
@@ -597,19 +685,45 @@ paths:
             schema:
               type: object
               properties:
+                registryId:
+                  type: string
+                  description: Override the primary push registry. Defaults to `RegistryConfiguration.PrimaryRegistryId`.
                 offline: { type: boolean, default: false }
-                force: { type: boolean, default: false }
+                force:
+                  type: boolean
+                  default: false
+                  description: Bypass the content-addressable cache hit (`cached` short-circuit) and rebuild from scratch.
       responses:
         '202':
-          description: Build started
+          description: Build queued.
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/ContainerImage' }
+              schema: { $ref: '#/components/schemas/BuildHandle' }
+        '200':
+          description: Cache hit — existing artifact returned without rebuilding.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/BuildHandle' }
+        '422':
+          description: Spec validation failure or build failure with captured logs.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ImageManagementError' }
+        '503':
+          description: No build engine available on the host (no Docker daemon, no Apple Containers CLI).
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ImageManagementError' }
+        '507':
+          description: Registry storage quota exceeded.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ImageManagementError' }
 
   /api/images/{templateId}/latest:
     get:
       tags: [Images]
-      summary: Get the latest built image for a template
+      summary: Get the latest built image for a template (legacy)
       parameters:
         - name: templateId
           in: path
@@ -625,7 +739,7 @@ paths:
   /api/images/diff:
     get:
       tags: [Images]
-      summary: Diff two images
+      summary: Diff two images (legacy)
       parameters:
         - name: fromImageId
           in: query
@@ -641,6 +755,141 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ImageDiff' }
+
+  # --- IM5 (#254) — Digest-anchored image management ------------
+  # New endpoints introduced by Epic IM. Contract is registry-agnostic
+  # — the `references` array on each artifact records every place the
+  # bytes have been pushed.
+
+  /api/images:
+    get:
+      tags: [Images]
+      summary: List build artifacts (digest-anchored)
+      description: |
+        Lists `BuildArtifact` rows. Each entry carries the references
+        array showing every registry the digest has been pushed to.
+      parameters:
+        - name: templateId
+          in: query
+          schema: { type: string, format: uuid }
+        - name: registryId
+          in: query
+          schema: { type: string }
+        - name: marker
+          in: query
+          description: Filter by markers — `marker=baked-assistants:claude-code` matches artifacts whose `markers["baked-assistants"]` includes `claude-code`.
+          schema: { type: string }
+        - name: skip
+          in: query
+          schema: { type: integer, default: 0 }
+        - name: take
+          in: query
+          schema: { type: integer, default: 20 }
+      responses:
+        '200':
+          description: Paged list of build artifacts.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/BuildArtifactList' }
+
+  /api/images/by-digest/{digest}:
+    get:
+      tags: [Images]
+      summary: Get a build artifact by digest
+      parameters:
+        - name: digest
+          in: path
+          required: true
+          description: OCI manifest digest, e.g. `sha256:abc123...`.
+          schema: { type: string }
+      responses:
+        '200':
+          description: Build artifact.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/BuildArtifact' }
+        '404':
+          description: No artifact found for this digest.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ImageManagementError' }
+
+  /api/images/by-digest/{digest}/references/{referenceId}:
+    delete:
+      tags: [Images]
+      summary: Untag a registry reference
+      description: |
+        Removes one `(registryId, repoPath, tag)` reference from the
+        artifact. Does not delete the underlying artifact bytes —
+        registry-side garbage collection reclaims those when no
+        reference points at the digest. Admin-only.
+      parameters:
+        - name: digest
+          in: path
+          required: true
+          schema: { type: string }
+        - name: referenceId
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '204':
+          description: Reference removed (idempotent — already-gone is not an error).
+        '403':
+          description: Caller lacks admin permission.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ImageManagementError' }
+
+  /api/images/build/{buildId}:
+    get:
+      tags: [Images]
+      summary: Build status snapshot
+      parameters:
+        - name: buildId
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: Current state of the build.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/BuildStatus' }
+        '404':
+          description: Unknown buildId.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ImageManagementError' }
+
+  /api/images/build/{buildId}/events:
+    get:
+      tags: [Images]
+      summary: Build progress event stream (SSE)
+      description: |
+        Server-Sent Events stream of build progress. The stream is
+        backed by `BuildEvent` payloads serialised one-per-event in
+        `data:` lines. The stream closes when the build reaches a
+        terminal state — clients may also drop the connection at
+        any time and reconnect via `Last-Event-ID`. For builds that
+        have already completed when the request arrives, the server
+        replays the `complete` event and closes immediately.
+      parameters:
+        - name: buildId
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: text/event-stream of `BuildEvent` payloads.
+          content:
+            text/event-stream:
+              schema: { $ref: '#/components/schemas/BuildEvent' }
+        '404':
+          description: Unknown buildId.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ImageManagementError' }
 
   # --- Providers ---
   /api/providers:
@@ -940,6 +1189,192 @@ components:
               newVersion: { type: string }
               changeType: { type: string, enum: [Added, Removed, VersionChanged, Unchanged] }
         baseImageChanged: { type: string }
+
+    # --- IM5 (#254) — Image Management API schemas -----------------
+    # Digest-anchored image identity introduced in Epic IM. The
+    # canonical key is the OCI manifest digest; references map a
+    # registry coordinate (registryId, repoPath, tag) to a digest.
+
+    RegisteredTemplate:
+      type: object
+      description: |
+        Result of registering a template via `POST /api/templates/from-yaml`.
+        Idempotent on `specHash` — re-registering an identical spec
+        returns the existing template id with `created: false`.
+      required: [templateId, specHash, created, code, name, version]
+      properties:
+        templateId: { type: string, format: uuid }
+        specHash:
+          type: string
+          description: Content-addressable hash of the parsed spec + uploaded files. Format `sha256:...`.
+        created:
+          type: boolean
+          description: True when the registration produced a new row; false when the existing row was returned.
+        code: { type: string }
+        name: { type: string }
+        version: { type: string }
+
+    BuildArtifact:
+      type: object
+      description: |
+        A built container image identified by its OCI manifest digest.
+        Same physical bytes produce the same digest in every registry;
+        push events are tracked via the `references` array.
+      required: [digest, mediaType, sizeBytes, specHash, templateId, builtAt, references]
+      properties:
+        digest:
+          type: string
+          description: OCI manifest digest, e.g. `sha256:abc123...`. Globally unique.
+        mediaType:
+          type: string
+          description: OCI media type, typically `application/vnd.oci.image.manifest.v1+json`.
+        sizeBytes:
+          type: integer
+          format: int64
+          description: Total uncompressed image size.
+        specHash:
+          type: string
+          description: Idempotency key for the source spec — `sha256:...`.
+        templateId: { type: string, format: uuid }
+        buildBackendId:
+          type: string
+          description: Identifier of the build backend that produced this artifact (`local-docker`, `apple-containers`, `acr-tasks`, ...).
+        builtBy:
+          type: string
+          description: Principal that triggered the build (user id or service identity).
+        builtAt: { type: string, format: date-time }
+        references:
+          type: array
+          items: { $ref: '#/components/schemas/BuildArtifactReference' }
+        markers:
+          type: object
+          additionalProperties: true
+          description: |
+            Free-form metadata about what's baked into the image — for example
+            `{ "baked-assistants": ["claude-code"] }`.
+
+    BuildArtifactReference:
+      type: object
+      description: Pointer from a registry coordinate back to a `BuildArtifact`. Many references can map to one artifact.
+      required: [id, registryId, repoPath, tag, pushedAt, pushedBy]
+      properties:
+        id: { type: string, format: uuid }
+        registryId:
+          type: string
+          description: Identifier of the registry from `RegistryConfigEntry`.
+        repoPath:
+          type: string
+          description: Repo path within the registry (e.g. `conductor-terminal-claude-code`).
+        tag:
+          type: string
+          description: Tag under the repo path (e.g. `sha256-abc12345`).
+        digest:
+          type: string
+          description: OCI digest the tag resolves to at push time. Tags are mutable; the digest is authoritative.
+        pushedAt: { type: string, format: date-time }
+        pushedBy: { type: string }
+
+    BuildHandle:
+      type: object
+      description: |
+        Async build acknowledgement returned by `POST /api/images/{templateId}/build`.
+        When `status` is `cached`, `digest` and `references` are populated immediately
+        — no actual build runs.
+      required: [buildId, status]
+      properties:
+        buildId: { type: string, format: uuid }
+        status:
+          type: string
+          enum: [queued, running, succeeded, failed, cancelled, cached]
+        digest:
+          type: string
+          description: Populated immediately on `cached`; populated on `succeeded` after the build completes.
+        references:
+          type: array
+          items: { $ref: '#/components/schemas/BuildArtifactReference' }
+
+    BuildStatus:
+      type: object
+      description: Snapshot of a build's current state.
+      required: [buildId, status, templateId, startedAt]
+      properties:
+        buildId: { type: string, format: uuid }
+        status:
+          type: string
+          enum: [queued, running, succeeded, failed, cancelled, cached]
+        templateId: { type: string, format: uuid }
+        digest: { type: string }
+        references:
+          type: array
+          items: { $ref: '#/components/schemas/BuildArtifactReference' }
+        buildLog:
+          type: string
+          description: Captured stdout/stderr on `failed` / `succeeded`. Null while running.
+        startedAt: { type: string, format: date-time }
+        completedAt: { type: string, format: date-time }
+
+    BuildEvent:
+      type: object
+      description: |
+        One event in the SSE stream served by
+        `GET /api/images/build/{buildId}/events`. The event's `type`
+        discriminates the payload.
+      required: [type, timestamp]
+      properties:
+        type:
+          type: string
+          enum: [step-start, step-stdout, step-error, complete]
+        timestamp: { type: string, format: date-time }
+        stepName:
+          type: string
+          description: Set on `step-start`, `step-stdout`, `step-error`.
+        stepIndex:
+          type: integer
+          description: Set on `step-start`.
+        totalSteps:
+          type: integer
+          description: Set on `step-start`.
+        line:
+          type: string
+          description: One captured stdout line. Set on `step-stdout`.
+        message:
+          type: string
+          description: Set on `step-error` (per-step error) and `complete` (failure reason when status != succeeded).
+        outcome:
+          type: string
+          enum: [Succeeded, Failed, Cancelled]
+          description: Set on `complete`.
+        digest:
+          type: string
+          description: Set on `complete` when outcome is `Succeeded`.
+
+    BuildArtifactList:
+      type: object
+      required: [items, totalCount]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/BuildArtifact' }
+        totalCount: { type: integer }
+
+    ImageManagementError:
+      type: object
+      description: |
+        Structured error response returned by image management endpoints
+        when the request fails. The `code` is a stable identifier the
+        caller can branch on; `message` is the human-readable text.
+      required: [code, message]
+      properties:
+        code:
+          type: string
+          description: Stable error code (e.g. `template.spec.invalid`, `template.extends.cycle`, `build.engine.unavailable`).
+        message: { type: string }
+        field:
+          type: string
+          description: Field path when the error pertains to a specific spec field (e.g. `files[2].dest`).
+        buildLog:
+          type: string
+          description: Captured logs when the failure is a build (422). Truncated to 64 KiB; full log available via `GET /api/images/build/{buildId}`.
 
     InfrastructureProvider:
       type: object


### PR DESCRIPTION
Closes #254. **Last Phase 0 story for Epic IM (#249)** — once this lands, Phase 0 closes and Phase 1 (M1.9-critical local-zot path) begins.

## Summary

Documents the API contract that Phase 1 implementation (IM6–IM11) will deliver. Conductor's `ContainerImagesService` Swift client (`rivoli-ai/conductor#1022`) and `andy-containers-cli` both build against this spec.

## Schemas added

| Schema | Role |
|---|---|
| `RegisteredTemplate` | `POST /api/templates/from-yaml` response. Carries `templateId` + `specHash` + `created` flag for idempotent registration. |
| `BuildArtifact` | Digest-anchored image with `references[]` and free-form `markers` metadata. |
| `BuildArtifactReference` | Pointer from `(registryId, repoPath, tag)` to a digest. Many-to-one against `BuildArtifact`. |
| `BuildHandle` | Async-build acknowledgement. Status enum includes `cached` for content-addressable cache hits. |
| `BuildStatus` | Full build snapshot with optional `buildLog`. |
| `BuildEvent` | SSE payload for build progress (`step-start` / `step-stdout` / `step-error` / `complete`). |
| `BuildArtifactList` | Paged list response. |
| `ImageManagementError` | Structured error with stable `code` + optional `field` path + truncated `buildLog`. Used by 4xx/5xx responses across the new endpoints. |

## Endpoints added

| Endpoint | Purpose |
|---|---|
| `POST /api/templates/from-yaml` | Multipart for spec + uploaded files, JSON for spec-only. Idempotent on `specHash`. 409 on code-already-in-use-with-different-spec, 422 on `extends:` cycle, 400 on schema validation failure. |
| `GET /api/images` | List `BuildArtifact`s. Filters: `templateId`, `registryId`, `marker`. Pages with `skip`/`take`. |
| `GET /api/images/by-digest/{digest}` | Single artifact by OCI digest. |
| `DELETE /api/images/by-digest/{digest}/references/{referenceId}` | Untag one registry coordinate. Idempotent. Admin-only. |
| `GET /api/images/build/{buildId}` | Build status snapshot. |
| `GET /api/images/build/{buildId}/events` | SSE stream of `BuildEvent`s. Replays terminal event for completed builds and closes. |

## Endpoints modified

`POST /api/images/{templateId}/build` — response shape updated from `ContainerImage` to `BuildHandle`. Added `registryId` override and `force` flag for cache-bypass. New error codes: 422 with build logs, 503 for missing build engine, 507 for registry quota. **Implementation catches up in IM7.**

`/api/images/{templateId}/*` and `/api/images/diff` are tagged "legacy" in the spec descriptions. They stay during the IM6/IM7 migration; nothing about them changes in IM5.

## Two deviations from the IM5 issue's literal text

1. **Path: `POST /api/templates/from-yaml` rather than `POST /api/templates`** — the existing `POST /api/templates` already exists for typed JSON `CreateTemplateRequest` payload. Renaming would break callers. The new multipart YAML path is dedicated and explicit.
2. **Path: `GET /api/images/by-digest/{digest}` rather than `GET /api/images/{digest}`** — collides with the existing `GET /api/images/{templateId}`. The explicit `by-digest/` segment matches the convention used elsewhere (e.g. `GET /api/templates/by-code/{code}`).

Both deviations preserve back-compat and improve clarity. Documented in the spec descriptions.

## Validation

```python
import yaml
yaml.safe_load(open('openapi/containers-api.yaml'))     ✅ parses
# All 38 unique $ref entries resolve to a defined schema  ✅
# 31 paths, 38 schemas total
```

```
dotnet build Andy.Containers.sln               ✅ 0 warn / 0 err
dotnet test tests/Andy.Containers.Tests        ✅ 411 / 411
```

`Andy.Containers.Client` still compiles — the client is hand-rolled (not generated from the OpenAPI spec), so the new endpoints will be added there as part of IM6/IM7.

## Companion update queued

`rivoli-ai/conductor#1026` will update `docs/api-contracts/andy-containers.md` to mirror this spec once IM5 merges.

## Phase 0 complete

| Story | State |
|---|---|
| IM1 #250 — Architecture memo | PR #255 (draft) |
| IM2 #251 — Abstractions | merged |
| IM3 #252 — DB schema + store | merged |
| IM4 #253 — YAML extensions | merged |
| **IM5 #254 — OpenAPI** | **this PR** |

Once this lands, the abstractions, schema, YAML, and contract are all locked. Phase 1 (IM6 `LocalZotAdapter`, IM7 `LocalBuildBackend`, IM8 spec hashing, IM9 SSE, IM10 errors, IM11 zot ownership doc + integration test) is the M1.9 critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)