### PR TITLE
IM8 (#262): spec-hash cache + ImageBuildOrchestrator

### DIFF
--- a/src/Andy.Containers.Api/Controllers/ImagesController.cs
+++ b/src/Andy.Containers.Api/Controllers/ImagesController.cs
@@ -1,6 +1,8 @@
+using Andy.Containers.Abstractions.Images;
 using Andy.Containers.Api.Services;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Models;
+using Andy.Containers.Storage;
 using Andy.Rbac.Authorization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -18,19 +20,22 @@ public class ImagesController : ControllerBase
     private readonly IImageDiffService _diffService;
     private readonly ICurrentUserService _currentUser;
     private readonly IOrganizationMembershipService _orgMembership;
+    private readonly IImageBuildOrchestrator _orchestrator;
 
     public ImagesController(
         ContainersDbContext db,
         IImageManifestService manifestService,
         IImageDiffService diffService,
         ICurrentUserService currentUser,
-        IOrganizationMembershipService orgMembership)
+        IOrganizationMembershipService orgMembership,
+        IImageBuildOrchestrator orchestrator)
     {
         _db = db;
         _manifestService = manifestService;
         _diffService = diffService;
         _currentUser = currentUser;
         _orgMembership = orgMembership;
+        _orchestrator = orchestrator;
     }
 
     [RequirePermission("image:read")]
@@ -87,12 +92,16 @@ public class ImagesController : ControllerBase
     [HttpPost("{templateId:guid}/build")]
     public async Task<IActionResult> Build(Guid templateId, [FromBody] BuildRequest? request, CancellationToken ct)
     {
+        // IM8 (#262). Replaced the legacy ContainerImage path with
+        // a delegation to IImageBuildOrchestrator. The orchestrator
+        // owns cache-hit short-circuit, build invocation via
+        // IBuildBackend, push via IRegistryAdapter, and persistence
+        // of BuildArtifactEntity + RegistryReferenceEntity rows.
+        // Response shape is BuildHandle per the IM5 OpenAPI.
         var template = await _db.Templates.FindAsync([templateId], ct);
         if (template is null) return NotFound();
 
-        Guid? organizationId = request?.OrganizationId;
-
-        // Validate org membership and permission for org-scoped builds
+        var organizationId = request?.OrganizationId;
         if (organizationId.HasValue && !_currentUser.IsAdmin())
         {
             var hasPermission = await _orgMembership.HasPermissionAsync(
@@ -100,51 +109,81 @@ public class ImagesController : ControllerBase
             if (!hasPermission) return Forbid();
         }
 
-        // Create the image record with a temporary content hash
-        var image = new ContainerImage
+        var result = await _orchestrator.BuildAsync(
+            new ImageBuildRequest(
+                TemplateId: templateId,
+                RegistryId: request?.RegistryId,
+                Force: request?.Force ?? false,
+                RequestedBy: _currentUser.GetUserId()),
+            new Progress<BuildProgressEvent>(_ => { /* IM9 wires SSE here */ }),
+            ct);
+
+        var handle = new BuildHandle(
+            BuildId: result.BuildId,
+            Status: result.Status switch
+            {
+                BuildResultStatus.Cached => "cached",
+                BuildResultStatus.Succeeded => "succeeded",
+                BuildResultStatus.Failed => "failed",
+                _ => "unknown",
+            },
+            Digest: result.Digest,
+            References: result.References
+                .Select(r => new BuildHandleReference(
+                    RegistryId: r.RegistryId,
+                    Ref: $"{r.RegistryId}/{r.RepoPath}:{r.Tag}",
+                    PushedAt: r.PushedAt))
+                .ToList());
+
+        return result.Status switch
         {
-            TemplateId = templateId,
-            ContentHash = $"sha256:{Guid.NewGuid():N}",
-            Tag = $"{template.Code}:{template.Version}-{DateTime.UtcNow:yyyyMMddHHmmss}",
-            ImageReference = $"andy-containers/{template.Code}:{template.Version}",
-            BaseImageDigest = $"sha256:{Guid.NewGuid():N}",
-            DependencyManifest = "{}",
-            DependencyLock = "{}",
-            BuildNumber = await _db.Images.CountAsync(i => i.TemplateId == templateId, ct) + 1,
-            BuildStatus = ImageBuildStatus.Building,
-            BuildStartedAt = DateTime.UtcNow,
-            BuiltOffline = request?.Offline ?? false,
-            OrganizationId = organizationId,
-            OwnerId = _currentUser.GetUserId(),
-            Visibility = organizationId.HasValue ? ImageVisibility.Organization : ImageVisibility.Global
+            BuildResultStatus.Cached => Ok(handle),
+            BuildResultStatus.Succeeded => Accepted(handle),
+            BuildResultStatus.Failed => BuildFailureResponse(result),
+            _ => StatusCode(500, handle),
+        };
+    }
+
+    private IActionResult BuildFailureResponse(BuildResult result)
+    {
+        // IM10 will move this mapping into a shared
+        // ImageManagementProblemDetailsFactory; for IM8 we keep the
+        // mapping inline so the response shape is at least
+        // consistent with the OpenAPI ImageManagementError schema.
+        var status = result.ErrorCode switch
+        {
+            var c when c?.StartsWith("build.engine") == true => StatusCodes.Status503ServiceUnavailable,
+            var c when c?.StartsWith("registry.quota") == true => StatusCodes.Status507InsufficientStorage,
+            var c when c?.StartsWith("template.not_found") == true => StatusCodes.Status404NotFound,
+            var c when c?.StartsWith("registry.not_configured") == true => StatusCodes.Status503ServiceUnavailable,
+            _ => StatusCodes.Status422UnprocessableEntity,
         };
 
-        _db.Images.Add(image);
-        await _db.SaveChangesAsync(ct);
-
-        try
+        return StatusCode(status, new
         {
-            // Run introspection to populate the real manifest
-            var (manifest, finalImage) = await _manifestService.GenerateManifestAsync(image.Id, ct);
-
-            finalImage.BuildStatus = ImageBuildStatus.Succeeded;
-            finalImage.BuildCompletedAt = DateTime.UtcNow;
-            finalImage.Changelog = "Build with introspection";
-            await _db.SaveChangesAsync(ct);
-
-            return Accepted(finalImage);
-        }
-        catch (Exception)
-        {
-            // If introspection fails, the image still succeeds but without manifest data
-            image.BuildStatus = ImageBuildStatus.Succeeded;
-            image.BuildCompletedAt = DateTime.UtcNow;
-            image.Changelog = "Build completed (introspection unavailable)";
-            await _db.SaveChangesAsync(ct);
-
-            return Accepted(image);
-        }
+            code = result.ErrorCode ?? "build.failed",
+            message = result.ErrorMessage ?? "build failed",
+            buildLog = Truncate(result.FailureLog, 64 * 1024),
+            buildId = result.BuildId,
+        });
     }
+
+    private static string? Truncate(string? s, int max)
+        => string.IsNullOrEmpty(s) || s.Length <= max ? s : s[..max] + "…[truncated]";
+
+    /// <summary>
+    /// IM5 BuildHandle response shape — async-build acknowledgement.
+    /// </summary>
+    public sealed record BuildHandle(
+        Guid BuildId,
+        string Status,
+        string? Digest,
+        IReadOnlyList<BuildHandleReference> References);
+
+    public sealed record BuildHandleReference(
+        string RegistryId,
+        string Ref,
+        DateTimeOffset PushedAt);
 
     [RequirePermission("image:read")]
     [HttpGet("diff")]
@@ -232,4 +271,8 @@ public class ImagesController : ControllerBase
     }
 }
 
-public record BuildRequest(bool Offline = false, bool Force = false, Guid? OrganizationId = null);
+public record BuildRequest(
+    bool Offline = false,
+    bool Force = false,
+    Guid? OrganizationId = null,
+    string? RegistryId = null);

--- a/src/Andy.Containers.Api/Controllers/TemplatesController.cs
+++ b/src/Andy.Containers.Api/Controllers/TemplatesController.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using Andy.Containers.Api.Services;
+using Andy.Containers.Crypto;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Models;
 using Andy.Rbac.Authorization;
@@ -267,10 +269,117 @@ public class TemplatesController : ControllerBase
 
         var template = _parser.Parse(request.Content);
         template.OwnerId = _currentUser.GetUserId();
+
+        // IM8 (#262). Compute the content-addressable spec hash so a
+        // future build against this template can short-circuit when
+        // the same spec has already been built. Files are not yet
+        // wired through this JSON-only endpoint, so the hash is
+        // computed against the canonical-JSON form alone (no file
+        // digests). The multipart variant (per IM5's contract) will
+        // mix file digests in once it lands as part of the
+        // orchestration in Phase 1.
+        template.SpecHash = ComputeSpecHash(template);
+
+        // IM8 (#262). Idempotent re-register: if a template with the
+        // same code AND the same spec hash already exists, return
+        // that existing row instead of creating a duplicate. This is
+        // what makes 'register the same spec twice' a no-op — the
+        // contract documented in the IM5 OpenAPI for
+        // RegisteredTemplate.created.
+        var existing = await _db.Templates
+            .FirstOrDefaultAsync(t => t.Code == template.Code, ct);
+        if (existing is not null)
+        {
+            if (existing.SpecHash == template.SpecHash)
+            {
+                return Ok(new RegisteredTemplate(
+                    TemplateId: existing.Id,
+                    SpecHash: existing.SpecHash ?? string.Empty,
+                    Created: false,
+                    Code: existing.Code,
+                    Name: existing.Name,
+                    Version: existing.Version));
+            }
+
+            // Same code, different spec — reject as a structured
+            // 409 so callers see the conflict explicitly. Mirrors
+            // the 'template.code.in-use' error code in IM5.
+            return Conflict(new
+            {
+                code = "template.code.in-use",
+                message = $"template '{existing.Code}' is already registered with a different specHash. " +
+                          "Bump the template version or update the existing template via PUT /templates/{id}/definition.",
+                field = "code",
+            });
+        }
+
         _db.Templates.Add(template);
         await _db.SaveChangesAsync(ct);
-        return CreatedAtAction(nameof(Get), new { id = template.Id }, template);
+        return CreatedAtAction(
+            nameof(Get),
+            new { id = template.Id },
+            new RegisteredTemplate(
+                TemplateId: template.Id,
+                SpecHash: template.SpecHash ?? string.Empty,
+                Created: true,
+                Code: template.Code,
+                Name: template.Name,
+                Version: template.Version));
     }
+
+    /// <summary>
+    /// Compute the IM3 content-addressable spec hash for a parsed
+    /// template. Aligns with the formula in the architecture memo:
+    /// <c>sha256(canonicalJson(parsedSpec) || sortedFileDigests)</c>.
+    /// In the JSON-only register endpoint there are no uploaded
+    /// files, so the file-digest map is empty.
+    /// </summary>
+    private static string ComputeSpecHash(ContainerTemplate template)
+    {
+        // Build a stable JSON projection of the template fields that
+        // matter for the build outcome. Canonical-JSON normalisation
+        // handles key ordering and whitespace; the projection just
+        // needs to be deterministic and complete.
+        var projection = new
+        {
+            code = template.Code,
+            version = template.Version,
+            base_image = template.BaseImage,
+            extends = template.Extends,
+            packages = SafeDeserialize(template.Packages),
+            files = SafeDeserialize(template.Files),
+            install = SafeDeserialize(template.Install),
+            entrypoint = template.EntryPoint,
+            markers = SafeDeserialize(template.Markers),
+            // Toolchains (the existing dependency model) is part of
+            // the template too; include it so changes to dependencies
+            // bust the cache the same way changes to imperative
+            // fields do.
+            toolchains = SafeDeserialize(template.Toolchains),
+        };
+        var json = JsonSerializer.Serialize(projection);
+        var canonical = CanonicalJson.Serialize(json);
+        return CanonicalJson.ComputeSpecHash(
+            canonical,
+            new Dictionary<string, string>());
+    }
+
+    private static object? SafeDeserialize(string? json)
+        => string.IsNullOrWhiteSpace(json)
+            ? null
+            : JsonSerializer.Deserialize<JsonElement>(json);
+
+    /// <summary>
+    /// Response shape for <c>POST /api/templates/from-yaml</c>
+    /// matching the IM5 OpenAPI contract.
+    /// </summary>
+    public sealed record RegisteredTemplate(
+        Guid TemplateId,
+        string SpecHash,
+        bool Created,
+        string Code,
+        string Name,
+        string Version);
 
     [RequirePermission("template:write")]
     [HttpPut("{id:guid}/definition")]

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -3,8 +3,11 @@ using Andy.Containers.Abstractions;
 using Andy.Containers.Api.Data;
 using Andy.Containers.Api.Services;
 using Andy.Containers.Configurator;
+using Andy.Containers.DependencyInjection;
+using Andy.Containers.Infrastructure.Build.Local;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Infrastructure.Registries.Local;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using Andy.Containers.Api.Telemetry;
@@ -134,6 +137,19 @@ try
     builder.Services.AddScoped<IToolVersionDetector, ToolVersionDetector>();
     builder.Services.AddScoped<IImageManifestService, ImageManifestService>();
     builder.Services.AddScoped<IImageDiffService, ImageDiffService>();
+
+    // IM8 (rivoli-ai/andy-containers#262). First time the IM6 +
+    // IM7 wiring composes into the API host. AddImageManagement
+    // wires the abstraction layer (IRegistryConfiguration);
+    // AddLocalZotRegistry registers the local-zot adapter +
+    // DockerCliUploader; AddLocalBuildBackend registers the
+    // engine detector + LocalBuildBackend; the orchestrator
+    // ties the lot together for ImagesController.Build.
+    builder.Services.AddImageManagement(builder.Configuration);
+    builder.Services.AddLocalZotRegistry();
+    builder.Services.AddLocalBuildBackend();
+    builder.Services.AddScoped<Andy.Containers.Storage.IImageBuildOrchestrator, Andy.Containers.Infrastructure.Build.ImageBuildOrchestrator>();
+    builder.Services.AddScoped<Andy.Containers.Storage.IBuildArtifactStore, Andy.Containers.Infrastructure.Data.BuildArtifactStore>();
 
     // Current user service for RBAC
     builder.Services.AddHttpContextAccessor();

--- a/src/Andy.Containers.Infrastructure/Build/ImageBuildOrchestrator.cs
+++ b/src/Andy.Containers.Infrastructure/Build/ImageBuildOrchestrator.cs
@@ -1,0 +1,391 @@
+using Andy.Containers.Abstractions.Images;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Infrastructure.Registries;
+using Andy.Containers.Models;
+using Andy.Containers.Models.ImageManagement;
+using Andy.Containers.Storage;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Containers.Infrastructure.Build;
+
+/// <summary>
+/// EF + adapter-backed implementation of
+/// <see cref="IImageBuildOrchestrator"/>. Loads the template, checks
+/// the content-addressable cache, builds + pushes when needed, and
+/// persists the resulting <see cref="BuildArtifactEntity"/> +
+/// <see cref="RegistryReferenceEntity"/> rows.
+/// </summary>
+/// <remarks>
+/// IM8 (rivoli-ai/andy-containers#262). The cache-hit short-circuit
+/// is the critical contract — when a build with the same template +
+/// spec hash exists AND has a reference in the target registry,
+/// return <see cref="BuildResultStatus.Cached"/> immediately
+/// without invoking the backend. The full async / SSE machinery
+/// lands in IM9; for IM8 the orchestrator runs synchronously in
+/// the request thread.
+/// </remarks>
+public sealed class ImageBuildOrchestrator : IImageBuildOrchestrator
+{
+    private readonly ContainersDbContext _db;
+    private readonly IBuildArtifactStore _store;
+    private readonly IRegistryConfiguration _registries;
+    private readonly IEnumerable<IRegistryAdapter> _adapters;
+    private readonly IBuildBackend _backend;
+    private readonly ILogger<ImageBuildOrchestrator> _logger;
+
+    public ImageBuildOrchestrator(
+        ContainersDbContext db,
+        IBuildArtifactStore store,
+        IRegistryConfiguration registries,
+        IEnumerable<IRegistryAdapter> adapters,
+        IBuildBackend backend,
+        ILogger<ImageBuildOrchestrator> logger)
+    {
+        _db = db;
+        _store = store;
+        _registries = registries;
+        _adapters = adapters;
+        _backend = backend;
+        _logger = logger;
+    }
+
+    public async Task<BuildResult> BuildAsync(
+        ImageBuildRequest request,
+        IProgress<BuildProgressEvent> progress,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(progress);
+
+        var buildId = Guid.NewGuid();
+
+        var template = await _db.Templates
+            .FirstOrDefaultAsync(t => t.Id == request.TemplateId, ct);
+        if (template is null)
+        {
+            return new BuildResult
+            {
+                BuildId = buildId,
+                Status = BuildResultStatus.Failed,
+                ErrorCode = "template.not_found",
+                ErrorMessage = $"no template with id '{request.TemplateId}'.",
+            };
+        }
+        if (string.IsNullOrEmpty(template.SpecHash))
+        {
+            // Pre-IM8 templates (no spec hash) fall through to the
+            // build path rather than treating the missing hash as
+            // an error. They just won't get cache hits.
+            _logger.LogWarning(
+                "ImageBuildOrchestrator template {Code} has no SpecHash — cache will always miss until the template is re-registered.",
+                template.Code);
+        }
+
+        var registryId = request.RegistryId ?? _registries.PrimaryRegistryId;
+        var adapter = ResolveAdapter(registryId);
+        if (adapter is null)
+        {
+            return new BuildResult
+            {
+                BuildId = buildId,
+                Status = BuildResultStatus.Failed,
+                ErrorCode = "registry.not_configured",
+                ErrorMessage = $"no IRegistryAdapter registered for id '{registryId}'.",
+            };
+        }
+
+        if (!request.Force && !string.IsNullOrEmpty(template.SpecHash))
+        {
+            var cached = await _store.GetBySpecHashAsync(template.Id, template.SpecHash, ct);
+            if (cached is not null)
+            {
+                var matching = cached.References.FirstOrDefault(r => r.RegistryId == registryId);
+                if (matching is not null)
+                {
+                    _logger.LogInformation(
+                        "ImageBuildOrchestrator cache hit for template {Code} specHash {Hash} on registry {Registry}.",
+                        template.Code, template.SpecHash, registryId);
+                    return new BuildResult
+                    {
+                        BuildId = buildId,
+                        Status = BuildResultStatus.Cached,
+                        Digest = cached.Digest,
+                        References = cached.References
+                            .Select(r => new BuildResultReference(
+                                r.RegistryId, r.RepoPath, r.Tag,
+                                new DateTimeOffset(r.PushedAt, TimeSpan.Zero)))
+                            .ToList(),
+                    };
+                }
+                // The artifact exists but hasn't been pushed to the
+                // requested registry. Re-pushing without rebuild
+                // requires the local image bytes which we no longer
+                // have at this point — fall through to a rebuild.
+                // IM11 / a follow-up may add an "extract from
+                // registry, re-push" path. Tracked as a known gap.
+                _logger.LogInformation(
+                    "ImageBuildOrchestrator cache hit on digest but missing reference in registry {Registry} — rebuilding.",
+                    registryId);
+            }
+        }
+
+        try
+        {
+            var spec = MapToSpec(template);
+            var contextDir = Path.Combine(Path.GetTempPath(), $"andy-orchestrator-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(contextDir);
+            var context = new EmptyBuildContext(contextDir);
+
+            try
+            {
+                var artifact = await _backend.BuildAsync(spec, context, progress, ct);
+
+                var repoPath = template.Code;
+                var tag = ToTagFromHash(template.SpecHash ?? artifact.SpecHash);
+                var reference = await adapter.PushAsync(artifact, repoPath, tag, ct);
+
+                var entity = new BuildArtifactEntity
+                {
+                    Id = Guid.NewGuid(),
+                    Digest = reference.Digest,
+                    MediaType = artifact.MediaType,
+                    SizeBytes = artifact.SizeBytes,
+                    SpecHash = artifact.SpecHash,
+                    TemplateId = template.Id,
+                    BuildBackendId = _backend.BackendId,
+                    BuiltBy = request.RequestedBy,
+                    BuiltAt = DateTime.UtcNow,
+                };
+                await _store.AddAsync(entity, ct);
+
+                // Force-rebuilds and re-registers can produce the same
+                // (registryId, repoPath, tag) coordinate as an existing
+                // reference (typically when SpecHash is unchanged but
+                // the build was re-run). Tags are mutable in OCI; the
+                // registry happily overwrites — so we mirror that by
+                // updating the existing row to point at the new digest
+                // rather than letting the composite unique constraint
+                // fire.
+                var existingRef = await _db.RegistryReferences
+                    .FirstOrDefaultAsync(r =>
+                        r.RegistryId == reference.RegistryId &&
+                        r.RepoPath == reference.RepoPath &&
+                        r.Tag == reference.Tag, ct);
+                if (existingRef is not null)
+                {
+                    existingRef.BuildArtifactId = entity.Id;
+                    existingRef.PushedAt = reference.PushedAt.UtcDateTime;
+                    existingRef.PushedBy = string.IsNullOrEmpty(reference.PushedBy) ? request.RequestedBy : reference.PushedBy;
+                    await _db.SaveChangesAsync(ct);
+                }
+                else
+                {
+                    var refEntity = new RegistryReferenceEntity
+                    {
+                        Id = reference.Id,
+                        RegistryId = reference.RegistryId,
+                        RepoPath = reference.RepoPath,
+                        Tag = reference.Tag,
+                        PushedAt = reference.PushedAt.UtcDateTime,
+                        PushedBy = string.IsNullOrEmpty(reference.PushedBy) ? request.RequestedBy : reference.PushedBy,
+                    };
+                    await _store.AddReferenceAsync(entity.Id, refEntity, ct);
+                }
+
+                return new BuildResult
+                {
+                    BuildId = buildId,
+                    Status = BuildResultStatus.Succeeded,
+                    Digest = reference.Digest,
+                    References = [
+                        new BuildResultReference(
+                            reference.RegistryId,
+                            reference.RepoPath,
+                            reference.Tag,
+                            reference.PushedAt),
+                    ],
+                };
+            }
+            finally
+            {
+                try { Directory.Delete(contextDir, recursive: true); }
+                catch { /* best-effort cleanup */ }
+            }
+        }
+        catch (ImageBuildFailedException ex)
+        {
+            return new BuildResult
+            {
+                BuildId = buildId,
+                Status = BuildResultStatus.Failed,
+                ErrorCode = $"build.{ex.FailingStepName ?? "failed"}",
+                ErrorMessage = ex.Message,
+                FailureLog = ex.CapturedLogs,
+            };
+        }
+        catch (RegistryUploadException ex)
+        {
+            return new BuildResult
+            {
+                BuildId = buildId,
+                Status = BuildResultStatus.Failed,
+                ErrorCode = ex.Code,
+                ErrorMessage = ex.Message,
+                FailureLog = ex.CapturedOutput,
+            };
+        }
+    }
+
+    private IRegistryAdapter? ResolveAdapter(string registryId)
+        => _adapters.FirstOrDefault(a =>
+            string.Equals(a.RegistryId, registryId, StringComparison.OrdinalIgnoreCase));
+
+    private static TemplateSpec MapToSpec(ContainerTemplate t)
+    {
+        return new TemplateSpec(
+            Code: t.Code,
+            Version: t.Version,
+            SpecHash: t.SpecHash ?? string.Empty,
+            CanonicalJson: string.Empty)
+        {
+            BaseImage = t.BaseImage,
+            Extends = t.Extends,
+            EntryPoint = t.EntryPoint,
+            Packages = ParseStringList(t.Packages),
+            Files = ParseFiles(t.Files),
+            Install = ParseStringList(t.Install),
+            Markers = ParseMarkers(t.Markers),
+        };
+    }
+
+    private static IReadOnlyList<string> ParseStringList(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return [];
+        }
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != System.Text.Json.JsonValueKind.Array)
+            {
+                return [];
+            }
+            return doc.RootElement.EnumerateArray()
+                .Select(e => e.GetString() ?? string.Empty)
+                .Where(s => !string.IsNullOrEmpty(s))
+                .ToList();
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static IReadOnlyList<TemplateFile> ParseFiles(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return [];
+        }
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != System.Text.Json.JsonValueKind.Array)
+            {
+                return [];
+            }
+            var files = new List<TemplateFile>();
+            foreach (var entry in doc.RootElement.EnumerateArray())
+            {
+                if (entry.ValueKind != System.Text.Json.JsonValueKind.Object) { continue; }
+                var source = entry.TryGetProperty("source", out var s) ? s.GetString() ?? string.Empty : string.Empty;
+                var dest = entry.TryGetProperty("dest", out var d) ? d.GetString() ?? string.Empty : string.Empty;
+                int? mode = null;
+                if (entry.TryGetProperty("mode", out var m) && m.ValueKind == System.Text.Json.JsonValueKind.Number)
+                {
+                    mode = m.GetInt32();
+                }
+                if (!string.IsNullOrEmpty(source) && !string.IsNullOrEmpty(dest))
+                {
+                    files.Add(new TemplateFile(source, dest, mode));
+                }
+            }
+            return files;
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static IReadOnlyDictionary<string, IReadOnlyList<string>> ParseMarkers(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new Dictionary<string, IReadOnlyList<string>>();
+        }
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != System.Text.Json.JsonValueKind.Object)
+            {
+                return new Dictionary<string, IReadOnlyList<string>>();
+            }
+            var markers = new Dictionary<string, IReadOnlyList<string>>();
+            foreach (var prop in doc.RootElement.EnumerateObject())
+            {
+                if (prop.Value.ValueKind == System.Text.Json.JsonValueKind.Array)
+                {
+                    markers[prop.Name] = prop.Value.EnumerateArray()
+                        .Select(e => e.GetString() ?? string.Empty)
+                        .ToList();
+                }
+                else if (prop.Value.ValueKind == System.Text.Json.JsonValueKind.String)
+                {
+                    markers[prop.Name] = new List<string> { prop.Value.GetString() ?? string.Empty };
+                }
+            }
+            return markers;
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return new Dictionary<string, IReadOnlyList<string>>();
+        }
+    }
+
+    private static string ToTagFromHash(string specHash)
+    {
+        // OCI tags can't contain ':', so 'sha256:abc...' becomes
+        // 'sha256-abc...'. Truncated to 12 hex chars after the
+        // prefix to keep registry UIs scannable.
+        const int shortHexLen = 12;
+        if (string.IsNullOrEmpty(specHash))
+        {
+            return $"unhashed-{Guid.NewGuid():N}"[..32];
+        }
+        var idx = specHash.IndexOf(':');
+        var algo = idx > 0 ? specHash[..idx] : "sha256";
+        var hex = idx > 0 ? specHash[(idx + 1)..] : specHash;
+        if (hex.Length > shortHexLen)
+        {
+            hex = hex[..shortHexLen];
+        }
+        return $"{algo}-{hex}";
+    }
+
+    /// <summary>
+    /// Empty <see cref="IBuildContext"/> for orchestrator-managed builds.
+    /// IM8 doesn't yet plumb multipart-uploaded files through the
+    /// orchestrator (the JSON-only register endpoint doesn't accept
+    /// them); files-on-disk staging will land alongside the multipart
+    /// register variant.
+    /// </summary>
+    private sealed class EmptyBuildContext : IBuildContext
+    {
+        public EmptyBuildContext(string dir) { ContextDirectoryPath = dir; }
+        public string ContextDirectoryPath { get; }
+        public IReadOnlyList<UploadedFile> Files => Array.Empty<UploadedFile>();
+    }
+}

--- a/src/Andy.Containers.Infrastructure/Migrations/20260507195251_AddTemplateSpecHash.Designer.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260507195251_AddTemplateSpecHash.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Andy.Containers.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Containers.Infrastructure.Migrations
 {
     [DbContext(typeof(ContainersDbContext))]
-    partial class ContainersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260507195251_AddTemplateSpecHash")]
+    partial class AddTemplateSpecHash
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Containers.Infrastructure/Migrations/20260507195251_AddTemplateSpecHash.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260507195251_AddTemplateSpecHash.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Containers.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTemplateSpecHash : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SpecHash",
+                table: "Templates",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SpecHash",
+                table: "Templates");
+        }
+    }
+}

--- a/src/Andy.Containers/Models/ContainerTemplate.cs
+++ b/src/Andy.Containers/Models/ContainerTemplate.cs
@@ -95,6 +95,17 @@ public class ContainerTemplate
     /// without having to introspect the filesystem.
     /// </summary>
     public string? Markers { get; set; }
+
+    /// <summary>
+    /// IM8 (rivoli-ai/andy-containers#262). Content-addressable hash
+    /// of the spec at register-time —
+    /// <c>sha256(canonicalJson(parsedSpec) || sortedFileDigests)</c>.
+    /// Indexed alongside the template id so the orchestrator can
+    /// short-circuit a build when an artifact already exists for
+    /// this template + this spec. Null on legacy rows that pre-date
+    /// IM8; populated on every register-from-yaml call thereafter.
+    /// </summary>
+    public string? SpecHash { get; set; }
 }
 
 public enum CatalogScope

--- a/src/Andy.Containers/Storage/IImageBuildOrchestrator.cs
+++ b/src/Andy.Containers/Storage/IImageBuildOrchestrator.cs
@@ -1,0 +1,93 @@
+using Andy.Containers.Abstractions.Images;
+
+namespace Andy.Containers.Storage;
+
+/// <summary>
+/// Owns the cache-check → build → push → persist flow for a single
+/// image build request. Sits above <see cref="IBuildBackend"/>,
+/// <see cref="IRegistryAdapter"/>, and <see cref="IBuildArtifactStore"/>;
+/// the API controller delegates to this service so the
+/// orchestration logic lives in one place.
+/// </summary>
+/// <remarks>
+/// IM8 (rivoli-ai/andy-containers#262). The cache short-circuit is
+/// the critical correctness contract: same spec hash + existing
+/// reference in the target registry ⇒ <see cref="BuildResultStatus.Cached"/>
+/// with no rebuild and no new DB row. Anything else falls through
+/// to a real build via the backend.
+/// </remarks>
+public interface IImageBuildOrchestrator
+{
+    Task<BuildResult> BuildAsync(
+        ImageBuildRequest request,
+        IProgress<BuildProgressEvent> progress,
+        CancellationToken ct);
+}
+
+/// <summary>
+/// Inputs for a build invocation.
+/// </summary>
+/// <param name="TemplateId">Template to build.</param>
+/// <param name="RegistryId">
+/// Override the primary push registry. When null, the orchestrator
+/// uses <see cref="IRegistryConfiguration.PrimaryRegistryId"/>.
+/// </param>
+/// <param name="Force">
+/// Bypass the content-addressable cache and rebuild from scratch.
+/// Useful when the spec is unchanged but external state has shifted
+/// (for example a base image was re-tagged upstream).
+/// </param>
+/// <param name="RequestedBy">
+/// Principal that triggered the build (user id or service identity).
+/// Recorded on <see cref="BuildArtifactEntity.BuiltBy"/> /
+/// <see cref="RegistryReferenceEntity.PushedBy"/>.
+/// </param>
+public sealed record ImageBuildRequest(
+    Guid TemplateId,
+    string? RegistryId,
+    bool Force,
+    string RequestedBy);
+
+/// <summary>
+/// Outcome of a build attempt.
+/// </summary>
+public sealed record BuildResult
+{
+    public required Guid BuildId { get; init; }
+    public required BuildResultStatus Status { get; init; }
+
+    /// <summary>OCI digest, populated on <see cref="BuildResultStatus.Cached"/> and <see cref="BuildResultStatus.Succeeded"/>.</summary>
+    public string? Digest { get; init; }
+
+    /// <summary>References created or already-present in the target registry.</summary>
+    public IReadOnlyList<BuildResultReference> References { get; init; } = [];
+
+    /// <summary>Stable error code on <see cref="BuildResultStatus.Failed"/> — maps to the API response in IM10.</summary>
+    public string? ErrorCode { get; init; }
+
+    /// <summary>Human-readable message on <see cref="BuildResultStatus.Failed"/>.</summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>Captured logs on <see cref="BuildResultStatus.Failed"/> (truncated by the API at the response boundary).</summary>
+    public string? FailureLog { get; init; }
+}
+
+/// <summary>
+/// Where the artifact lives in a registry. Mirrors
+/// <see cref="RegistryReferenceEntity"/> but flattened for transport.
+/// </summary>
+public sealed record BuildResultReference(
+    string RegistryId,
+    string RepoPath,
+    string Tag,
+    DateTimeOffset PushedAt);
+
+public enum BuildResultStatus
+{
+    /// <summary>Existing artifact returned without rebuilding.</summary>
+    Cached,
+    /// <summary>New artifact built and pushed.</summary>
+    Succeeded,
+    /// <summary>Build or push failed; <see cref="BuildResult.ErrorCode"/> identifies the failure mode.</summary>
+    Failed,
+}

--- a/tests/Andy.Containers.Api.Tests/Controllers/ImagesControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ImagesControllerTests.cs
@@ -3,7 +3,9 @@ using Andy.Containers.Api.Services;
 using Andy.Containers.Api.Tests.Helpers;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Models;
+using Andy.Containers.Storage;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
@@ -17,6 +19,7 @@ public class ImagesControllerTests : IDisposable
     private readonly Mock<IImageDiffService> _mockDiffService;
     private readonly Mock<ICurrentUserService> _mockCurrentUser;
     private readonly Mock<IOrganizationMembershipService> _mockOrgMembership;
+    private readonly Mock<IImageBuildOrchestrator> _mockOrchestrator;
     private readonly ImagesController _controller;
 
     public ImagesControllerTests()
@@ -31,7 +34,28 @@ public class ImagesControllerTests : IDisposable
         _mockOrgMembership = new Mock<IOrganizationMembershipService>();
         _mockOrgMembership.Setup(o => o.IsMemberAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
         _mockOrgMembership.Setup(o => o.HasPermissionAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
-        _controller = new ImagesController(_db, _mockManifestService.Object, _mockDiffService.Object, _mockCurrentUser.Object, _mockOrgMembership.Object);
+        _mockOrchestrator = new Mock<IImageBuildOrchestrator>();
+        // IM8 (#262). Default: orchestrator returns a Succeeded result
+        // for any build call. Tests that need different outcomes
+        // (cache hit, failure) override this on a per-test basis.
+        _mockOrchestrator.Setup(o => o.BuildAsync(
+                It.IsAny<ImageBuildRequest>(),
+                It.IsAny<IProgress<Andy.Containers.Abstractions.Images.BuildProgressEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BuildResult
+            {
+                BuildId = Guid.NewGuid(),
+                Status = BuildResultStatus.Succeeded,
+                Digest = "sha256:test",
+                References = [new BuildResultReference("local-zot", "test", "sha256-test", DateTimeOffset.UtcNow)],
+            });
+        _controller = new ImagesController(
+            _db,
+            _mockManifestService.Object,
+            _mockDiffService.Object,
+            _mockCurrentUser.Object,
+            _mockOrgMembership.Object,
+            _mockOrchestrator.Object);
     }
 
     public void Dispose() => _db.Dispose();
@@ -148,76 +172,149 @@ public class ImagesControllerTests : IDisposable
         result.Should().BeOfType<NotFoundResult>();
     }
 
+    // IM8 (#262). Replaced the four legacy-ContainerImage build tests
+    // with the new orchestrator-delegated assertions. Old tests asserted
+    // BuildNumber / BuildStatus / BuiltOffline on a ContainerImage row;
+    // the new contract returns BuildHandle instead. ContainerImage
+    // creation is no longer the responsibility of the build endpoint —
+    // BuildArtifactEntity is the new digest-anchored row, and the
+    // ImageBuildOrchestrator owns persistence.
+
     [Fact]
-    public async Task Build_WithIntrospection_ShouldReturnAccepted()
+    public async Task Build_OrchestratorReturnsSucceeded_ReturnsAcceptedWithBuildHandle()
     {
         var template = SeedTemplate();
-        var manifest = CreateTestManifest();
-
-        _mockManifestService
-            .Setup(s => s.GenerateManifestAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Guid imageId, CancellationToken _) =>
+        var buildId = Guid.NewGuid();
+        _mockOrchestrator
+            .Setup(o => o.BuildAsync(
+                It.Is<ImageBuildRequest>(r => r.TemplateId == template.Id),
+                It.IsAny<IProgress<Andy.Containers.Abstractions.Images.BuildProgressEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BuildResult
             {
-                var img = _db.Images.Find(imageId)!;
-                return (manifest, img);
+                BuildId = buildId,
+                Status = BuildResultStatus.Succeeded,
+                Digest = "sha256:abc",
+                References = [
+                    new BuildResultReference("local-zot", template.Code, "sha256-abc", DateTimeOffset.UtcNow),
+                ],
             });
 
         var result = await _controller.Build(template.Id, new BuildRequest(Offline: false), CancellationToken.None);
 
         var accepted = result.Should().BeOfType<AcceptedResult>().Subject;
-        var image = accepted.Value.Should().BeOfType<ContainerImage>().Subject;
-        image.BuildStatus.Should().Be(ImageBuildStatus.Succeeded);
-        image.Changelog.Should().Be("Build with introspection");
+        accepted.Value.Should().NotBeNull();
+        var handleType = accepted.Value!.GetType();
+        var status = (string)handleType.GetProperty("Status")!.GetValue(accepted.Value)!;
+        var returnedBuildId = (Guid)handleType.GetProperty("BuildId")!.GetValue(accepted.Value)!;
+        var digest = (string?)handleType.GetProperty("Digest")!.GetValue(accepted.Value);
+
+        status.Should().Be("succeeded");
+        returnedBuildId.Should().Be(buildId);
+        digest.Should().Be("sha256:abc");
     }
 
     [Fact]
-    public async Task Build_IntrospectionFails_ShouldStillReturnAccepted()
+    public async Task Build_OrchestratorReturnsCached_ReturnsOk()
     {
         var template = SeedTemplate();
+        _mockOrchestrator
+            .Setup(o => o.BuildAsync(
+                It.IsAny<ImageBuildRequest>(),
+                It.IsAny<IProgress<Andy.Containers.Abstractions.Images.BuildProgressEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BuildResult
+            {
+                BuildId = Guid.NewGuid(),
+                Status = BuildResultStatus.Cached,
+                Digest = "sha256:cached",
+                References = [
+                    new BuildResultReference("local-zot", template.Code, "sha256-cached", DateTimeOffset.UtcNow),
+                ],
+            });
 
-        _mockManifestService
-            .Setup(s => s.GenerateManifestAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("Introspection failed"));
+        var result = await _controller.Build(template.Id, new BuildRequest(), CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var status = (string)ok.Value!.GetType().GetProperty("Status")!.GetValue(ok.Value)!;
+        status.Should().Be("cached",
+            "the IM5 contract: a cache hit returns 200 OK with status='cached' immediately, no rebuild.");
+    }
+
+    [Fact]
+    public async Task Build_OrchestratorReturnsFailedWithEngineUnavailable_Returns503()
+    {
+        var template = SeedTemplate();
+        _mockOrchestrator
+            .Setup(o => o.BuildAsync(
+                It.IsAny<ImageBuildRequest>(),
+                It.IsAny<IProgress<Andy.Containers.Abstractions.Images.BuildProgressEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BuildResult
+            {
+                BuildId = Guid.NewGuid(),
+                Status = BuildResultStatus.Failed,
+                ErrorCode = "build.engine-detect",
+                ErrorMessage = "no container build engine is available",
+            });
 
         var result = await _controller.Build(template.Id, null, CancellationToken.None);
 
-        var accepted = result.Should().BeOfType<AcceptedResult>().Subject;
-        var image = accepted.Value.Should().BeOfType<ContainerImage>().Subject;
-        image.BuildStatus.Should().Be(ImageBuildStatus.Succeeded);
-        image.Changelog.Should().Contain("introspection unavailable");
+        var statusResult = result.Should().BeOfType<ObjectResult>().Subject;
+        statusResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
     }
 
     [Fact]
-    public async Task Build_ShouldIncrementBuildNumber()
+    public async Task Build_OrchestratorReturnsFailedWithBuildError_Returns422()
     {
         var template = SeedTemplate();
-        SeedImage(template.Id, 1);
-
-        _mockManifestService
-            .Setup(s => s.GenerateManifestAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new Exception("skip"));
+        _mockOrchestrator
+            .Setup(o => o.BuildAsync(
+                It.IsAny<ImageBuildRequest>(),
+                It.IsAny<IProgress<Andy.Containers.Abstractions.Images.BuildProgressEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BuildResult
+            {
+                BuildId = Guid.NewGuid(),
+                Status = BuildResultStatus.Failed,
+                ErrorCode = "build.failed",
+                ErrorMessage = "Step 5/12 failed",
+                FailureLog = "stderr from the build engine here",
+            });
 
         var result = await _controller.Build(template.Id, null, CancellationToken.None);
 
-        var accepted = result.Should().BeOfType<AcceptedResult>().Subject;
-        var image = accepted.Value.Should().BeOfType<ContainerImage>().Subject;
-        image.BuildNumber.Should().Be(2);
+        var statusResult = result.Should().BeOfType<ObjectResult>().Subject;
+        statusResult.StatusCode.Should().Be(StatusCodes.Status422UnprocessableEntity);
     }
 
     [Fact]
-    public async Task Build_OfflineFlag_ShouldBePreserved()
+    public async Task Build_ForceFlag_FlowsThroughToOrchestrator()
     {
         var template = SeedTemplate();
 
-        _mockManifestService
-            .Setup(s => s.GenerateManifestAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new Exception("skip"));
+        await _controller.Build(template.Id, new BuildRequest(Force: true), CancellationToken.None);
 
-        var result = await _controller.Build(template.Id, new BuildRequest(Offline: true), CancellationToken.None);
+        _mockOrchestrator.Verify(o => o.BuildAsync(
+            It.Is<ImageBuildRequest>(r => r.Force == true),
+            It.IsAny<IProgress<Andy.Containers.Abstractions.Images.BuildProgressEvent>>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the controller's force flag must reach the orchestrator unchanged so the cache short-circuit is bypassed.");
+    }
 
-        var accepted = result.Should().BeOfType<AcceptedResult>().Subject;
-        var image = accepted.Value.Should().BeOfType<ContainerImage>().Subject;
-        image.BuiltOffline.Should().BeTrue();
+    [Fact]
+    public async Task Build_RegistryIdOverride_FlowsThroughToOrchestrator()
+    {
+        var template = SeedTemplate();
+
+        await _controller.Build(template.Id, new BuildRequest(RegistryId: "team-zot"), CancellationToken.None);
+
+        _mockOrchestrator.Verify(o => o.BuildAsync(
+            It.Is<ImageBuildRequest>(r => r.RegistryId == "team-zot"),
+            It.IsAny<IProgress<Andy.Containers.Abstractions.Images.BuildProgressEvent>>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     // --- Diff ---

--- a/tests/Andy.Containers.Api.Tests/Controllers/TemplatesControllerYamlTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/TemplatesControllerYamlTests.cs
@@ -95,9 +95,97 @@ public class TemplatesControllerYamlTests : IDisposable
 
         var created = result.Should().BeOfType<CreatedAtActionResult>().Subject;
         created.StatusCode.Should().Be(201);
-        var template = created.Value.Should().BeOfType<ContainerTemplate>().Subject;
-        template.Code.Should().Be("test-template");
-        template.OwnerId.Should().Be("test-user");
+
+        // IM8 (#262). Response shape changed from ContainerTemplate
+        // to RegisteredTemplate { TemplateId, SpecHash, Created,
+        // Code, Name, Version }. The persisted ContainerTemplate
+        // still carries OwnerId; the response carries the
+        // content-addressable identity callers need to drive a
+        // build.
+        var registered = created.Value.Should().BeOfType<TemplatesController.RegisteredTemplate>().Subject;
+        registered.Code.Should().Be("test-template");
+        registered.Created.Should().BeTrue();
+        registered.SpecHash.Should().StartWith("sha256:",
+            "the registration response carries the content-addressable hash so callers can match it against future builds.");
+
+        // The persisted row still gets ownership correctly.
+        var persisted = _db.Templates.Single(t => t.Code == "test-template");
+        persisted.OwnerId.Should().Be("test-user");
+        persisted.SpecHash.Should().Be(registered.SpecHash);
+    }
+
+    [Fact]
+    public async Task CreateFromYaml_SameSpecTwice_IsIdempotent()
+    {
+        // IM8 (#262). Re-registering an identical spec returns the
+        // existing template id with Created=false. The contract is
+        // documented in the IM5 OpenAPI for RegisteredTemplate.
+        var validResult = new YamlValidationResult { IsValid = true };
+        _mockParser.Setup(p => p.Validate(ValidYaml)).Returns(validResult);
+        _mockParser.Setup(p => p.Parse(ValidYaml)).Returns(() => new ContainerTemplate
+        {
+            Code = "test-template",
+            Name = "Test Template",
+            Version = "1.0.0",
+            BaseImage = "ubuntu:24.04",
+        });
+
+        var first = await _controller.CreateFromYaml(new YamlContentRequest(ValidYaml), CancellationToken.None);
+        var firstCreated = first.Should().BeOfType<CreatedAtActionResult>().Subject;
+        var firstRegistered = firstCreated.Value.Should().BeOfType<TemplatesController.RegisteredTemplate>().Subject;
+
+        var second = await _controller.CreateFromYaml(new YamlContentRequest(ValidYaml), CancellationToken.None);
+        var secondOk = second.Should().BeOfType<OkObjectResult>().Subject;
+        var secondRegistered = secondOk.Value.Should().BeOfType<TemplatesController.RegisteredTemplate>().Subject;
+
+        secondRegistered.TemplateId.Should().Be(firstRegistered.TemplateId,
+            "the same spec hashed to the same value must return the existing template id, not create a new row.");
+        secondRegistered.SpecHash.Should().Be(firstRegistered.SpecHash);
+        secondRegistered.Created.Should().BeFalse();
+
+        _db.Templates.Count(t => t.Code == "test-template").Should().Be(1,
+            "idempotent registration must not duplicate rows.");
+    }
+
+    [Fact]
+    public async Task CreateFromYaml_SameCodeDifferentSpec_ReturnsConflict()
+    {
+        // IM8 (#262). Re-registering with the same code but a
+        // different spec is a structured 409 with code
+        // template.code.in-use, matching the IM5 contract.
+        var validResult = new YamlValidationResult { IsValid = true };
+        _mockParser.Setup(p => p.Validate(It.IsAny<string>())).Returns(validResult);
+
+        // First register: a template with package list [curl].
+        _mockParser.Setup(p => p.Parse(ValidYaml)).Returns(() => new ContainerTemplate
+        {
+            Code = "test-template",
+            Name = "Test Template",
+            Version = "1.0.0",
+            BaseImage = "ubuntu:24.04",
+            Packages = """["curl"]""",
+        });
+        await _controller.CreateFromYaml(new YamlContentRequest(ValidYaml), CancellationToken.None);
+
+        // Second register with the same code but a different spec.
+        const string updatedYaml = "version: bumped";
+        _mockParser.Setup(p => p.Parse(updatedYaml)).Returns(() => new ContainerTemplate
+        {
+            Code = "test-template",
+            Name = "Test Template",
+            Version = "1.0.0",
+            BaseImage = "ubuntu:24.04",
+            Packages = """["curl", "git"]""",
+        });
+
+        var second = await _controller.CreateFromYaml(new YamlContentRequest(updatedYaml), CancellationToken.None);
+
+        var conflict = second.Should().BeOfType<ConflictObjectResult>().Subject;
+        conflict.Value.Should().BeEquivalentTo(new
+        {
+            code = "template.code.in-use",
+            field = "code",
+        }, options => options.ExcludingMissingMembers());
     }
 
     [Fact]

--- a/tests/Andy.Containers.Integration.Tests/Andy.Containers.Integration.Tests.csproj
+++ b/tests/Andy.Containers.Integration.Tests/Andy.Containers.Integration.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
 
 </Project>

--- a/tests/Andy.Containers.Integration.Tests/Build/ImageBuildOrchestratorTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/Build/ImageBuildOrchestratorTests.cs
@@ -1,0 +1,296 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Abstractions.Images;
+using Andy.Containers.Infrastructure.Build;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Infrastructure.Registries;
+using Andy.Containers.Models;
+using Andy.Containers.Models.ImageManagement;
+using Andy.Containers.Storage;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Andy.Containers.Configuration;
+using Andy.Containers.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Integration.Tests.Build;
+
+// IM8 (rivoli-ai/andy-containers#262). End-to-end tests of the
+// orchestrator's cache-vs-build branching against a real EF stack
+// (SQLite in-memory). The build backend and registry adapter are
+// mocked because their own tests already exercise their internals;
+// this suite proves the *orchestration* logic — what gets called
+// when, what gets persisted, and what the response shape is.
+public class ImageBuildOrchestratorTests : IAsyncLifetime
+{
+    private SqliteConnection _conn = null!;
+    private ContainersDbContext _db = null!;
+    private BuildArtifactStore _store = null!;
+    private Mock<IBuildBackend> _backend = null!;
+    private Mock<IRegistryAdapter> _adapter = null!;
+    private ImageBuildOrchestrator _orchestrator = null!;
+    private Guid _templateId;
+
+    public async Task InitializeAsync()
+    {
+        _conn = new SqliteConnection("DataSource=:memory:");
+        await _conn.OpenAsync();
+        var options = new DbContextOptionsBuilder<ContainersDbContext>()
+            .UseSqlite(_conn).Options;
+        _db = new ContainersDbContext(options);
+        await _db.Database.EnsureCreatedAsync();
+        _store = new BuildArtifactStore(_db);
+
+        _backend = new Mock<IBuildBackend>();
+        _backend.SetupGet(b => b.BackendId).Returns("local");
+        _backend.SetupGet(b => b.Capabilities).Returns(new BuildBackendCapabilities(
+            false, ["amd64"], true, false, false));
+
+        _adapter = new Mock<IRegistryAdapter>();
+        _adapter.SetupGet(a => a.RegistryId).Returns("local-zot");
+
+        // Wire IRegistryConfiguration the same way Program.cs does —
+        // through AddImageManagement + an IOptions binding — so the
+        // test exercises the production registration path rather than
+        // a stub. The internal default impl stays internal that way.
+        var services = new ServiceCollection();
+        services.AddImageManagement();
+        services.Configure<RegistryConfigurationOptions>(opts =>
+        {
+            opts.PrimaryRegistryId = "local-zot";
+            opts.Registries.Add(new RegistryConfigEntry
+            {
+                Id = "local-zot",
+                Kind = "zot",
+                Url = "http://localhost:5050",
+                IsPrimary = true,
+            });
+        });
+        var registries = services.BuildServiceProvider().GetRequiredService<IRegistryConfiguration>();
+
+        _orchestrator = new ImageBuildOrchestrator(
+            _db, _store, registries, [_adapter.Object], _backend.Object,
+            NullLogger<ImageBuildOrchestrator>.Instance);
+
+        _templateId = Guid.NewGuid();
+        _db.Templates.Add(new ContainerTemplate
+        {
+            Id = _templateId,
+            Code = "test",
+            Name = "Test",
+            Version = "1.0.0",
+            BaseImage = "ubuntu:24.04",
+            SpecHash = "sha256:test-hash",
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _db.DisposeAsync();
+        await _conn.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task BuildAsync_TemplateNotFound_ReturnsFailedWithCode()
+    {
+        var result = await _orchestrator.BuildAsync(
+            new ImageBuildRequest(Guid.NewGuid(), null, false, "user"),
+            new Progress<BuildProgressEvent>(_ => { }),
+            CancellationToken.None);
+
+        result.Status.Should().Be(BuildResultStatus.Failed);
+        result.ErrorCode.Should().Be("template.not_found");
+    }
+
+    [Fact]
+    public async Task BuildAsync_CacheMiss_BuildsAndPushes()
+    {
+        SetupBackendBuilds("andy-build:tmp", "sha256:test-hash");
+        SetupAdapterPush("local-zot", "test", "sha256-test-hash", returnedDigest: "sha256:abc");
+
+        var result = await _orchestrator.BuildAsync(
+            new ImageBuildRequest(_templateId, null, false, "user"),
+            new Progress<BuildProgressEvent>(_ => { }),
+            CancellationToken.None);
+
+        result.Status.Should().Be(BuildResultStatus.Succeeded);
+        result.Digest.Should().Be("sha256:abc");
+        result.References.Should().ContainSingle()
+            .Which.RegistryId.Should().Be("local-zot");
+
+        // Persistence: BuildArtifactEntity + RegistryReferenceEntity
+        // both written under one orchestrator call.
+        (await _db.BuildArtifacts.AnyAsync(b => b.Digest == "sha256:abc")).Should().BeTrue();
+        (await _db.RegistryReferences.AnyAsync(r => r.RegistryId == "local-zot" && r.Tag == "sha256-test-hash")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task BuildAsync_CacheHit_ReturnsCachedWithoutInvokingBackend()
+    {
+        // Pre-seed an existing artifact + reference for the template's
+        // current spec hash. This is what a previous successful build
+        // would have written.
+        var artifact = new BuildArtifactEntity
+        {
+            Id = Guid.NewGuid(),
+            Digest = "sha256:cached",
+            MediaType = "application/vnd.oci.image.manifest.v1+json",
+            SizeBytes = 1000,
+            SpecHash = "sha256:test-hash",
+            TemplateId = _templateId,
+            BuildBackendId = "local",
+            BuiltBy = "previous-user",
+            BuiltAt = DateTime.UtcNow.AddMinutes(-5),
+        };
+        _db.BuildArtifacts.Add(artifact);
+        _db.RegistryReferences.Add(new RegistryReferenceEntity
+        {
+            Id = Guid.NewGuid(),
+            BuildArtifactId = artifact.Id,
+            RegistryId = "local-zot",
+            RepoPath = "test",
+            Tag = "sha256-test-hash",
+            PushedAt = DateTime.UtcNow.AddMinutes(-5),
+            PushedBy = "previous-user",
+        });
+        await _db.SaveChangesAsync();
+
+        var result = await _orchestrator.BuildAsync(
+            new ImageBuildRequest(_templateId, null, false, "user"),
+            new Progress<BuildProgressEvent>(_ => { }),
+            CancellationToken.None);
+
+        result.Status.Should().Be(BuildResultStatus.Cached);
+        result.Digest.Should().Be("sha256:cached");
+        _backend.Verify(b => b.BuildAsync(
+            It.IsAny<TemplateSpec>(),
+            It.IsAny<IBuildContext>(),
+            It.IsAny<IProgress<BuildProgressEvent>>(),
+            It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the build backend MUST NOT be invoked on a cache hit — that's the whole point of content-addressable caching.");
+    }
+
+    [Fact]
+    public async Task BuildAsync_ForceFlag_BypassesCache()
+    {
+        // Same setup as the cache-hit test, but force=true.
+        var artifact = new BuildArtifactEntity
+        {
+            Id = Guid.NewGuid(),
+            Digest = "sha256:cached",
+            MediaType = "application/vnd.oci.image.manifest.v1+json",
+            SizeBytes = 1000,
+            SpecHash = "sha256:test-hash",
+            TemplateId = _templateId,
+            BuildBackendId = "local",
+            BuiltBy = "previous-user",
+            BuiltAt = DateTime.UtcNow.AddMinutes(-5),
+        };
+        _db.BuildArtifacts.Add(artifact);
+        _db.RegistryReferences.Add(new RegistryReferenceEntity
+        {
+            Id = Guid.NewGuid(),
+            BuildArtifactId = artifact.Id,
+            RegistryId = "local-zot",
+            RepoPath = "test",
+            Tag = "sha256-test-hash",
+            PushedAt = DateTime.UtcNow.AddMinutes(-5),
+            PushedBy = "previous-user",
+        });
+        await _db.SaveChangesAsync();
+
+        SetupBackendBuilds("andy-build:rebuilt", "sha256:test-hash");
+        SetupAdapterPush("local-zot", "test", "sha256-test-hash-fresh", returnedDigest: "sha256:rebuilt");
+
+        var result = await _orchestrator.BuildAsync(
+            new ImageBuildRequest(_templateId, null, Force: true, "user"),
+            new Progress<BuildProgressEvent>(_ => { }),
+            CancellationToken.None);
+
+        result.Status.Should().Be(BuildResultStatus.Succeeded,
+            "Force=true must produce a fresh build even when a cached artifact exists.");
+        _backend.Verify(b => b.BuildAsync(
+            It.IsAny<TemplateSpec>(),
+            It.IsAny<IBuildContext>(),
+            It.IsAny<IProgress<BuildProgressEvent>>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task BuildAsync_BuildBackendThrows_ReturnsFailedWithCapturedLogs()
+    {
+        _backend.Setup(b => b.BuildAsync(
+                It.IsAny<TemplateSpec>(),
+                It.IsAny<IBuildContext>(),
+                It.IsAny<IProgress<BuildProgressEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ImageBuildFailedException(
+                backendId: "local",
+                capturedLogs: "ERROR Step 7/12 failed",
+                specHash: "sha256:test-hash",
+                failingStepName: "packages-install",
+                message: "build failed at packages-install"));
+
+        var result = await _orchestrator.BuildAsync(
+            new ImageBuildRequest(_templateId, null, false, "user"),
+            new Progress<BuildProgressEvent>(_ => { }),
+            CancellationToken.None);
+
+        result.Status.Should().Be(BuildResultStatus.Failed);
+        result.ErrorCode.Should().Be("build.packages-install");
+        result.FailureLog.Should().Contain("ERROR Step 7/12");
+    }
+
+    [Fact]
+    public async Task BuildAsync_RegistryNotConfigured_ReturnsFailed()
+    {
+        var result = await _orchestrator.BuildAsync(
+            new ImageBuildRequest(_templateId, RegistryId: "ghost-registry", false, "user"),
+            new Progress<BuildProgressEvent>(_ => { }),
+            CancellationToken.None);
+
+        result.Status.Should().Be(BuildResultStatus.Failed);
+        result.ErrorCode.Should().Be("registry.not_configured");
+    }
+
+    private void SetupBackendBuilds(string localTag, string specHash)
+    {
+        _backend.Setup(b => b.BuildAsync(
+                It.IsAny<TemplateSpec>(),
+                It.IsAny<IBuildContext>(),
+                It.IsAny<IProgress<BuildProgressEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BuildArtifact(
+                Digest: string.Empty,
+                MediaType: "application/vnd.oci.image.manifest.v1+json",
+                SizeBytes: 1000,
+                SpecHash: specHash,
+                LocalReference: localTag));
+    }
+
+    private void SetupAdapterPush(string registryId, string repo, string tag, string returnedDigest)
+    {
+        _adapter.Setup(a => a.PushAsync(
+                It.IsAny<BuildArtifact>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BuildArtifact a, string repoArg, string tagArg, CancellationToken _) =>
+                new RegistryReference(
+                    Id: Guid.NewGuid(),
+                    RegistryId: registryId,
+                    RepoPath: repoArg,
+                    Tag: tagArg,
+                    Digest: returnedDigest,
+                    PushedAt: DateTimeOffset.UtcNow,
+                    PushedBy: "test-user"));
+    }
+}


### PR DESCRIPTION
Closes #262. Third Phase 1 story for Epic IM (#249), follows IM6 (#260) and IM7 (#261).

## Summary

Wires IM6's `LocalZotAdapter` and IM7's `LocalBuildBackend` together behind a thin orchestrator that owns the **cache-check → build → push → persist** flow. **First time the IM6 + IM7 abstraction stack actually composes into the API host.**

## Changes

| Area | Change |
|---|---|
| `ContainerTemplate.SpecHash` (new column) | Migration `AddTemplateSpecHash`. Populated at register-time; null on legacy rows. |
| `TemplatesController.CreateFromYaml` | Computes the content-addressable spec hash via `CanonicalJson.ComputeSpecHash` (IM3) over a stable projection of build-relevant fields. **Idempotent re-register**: same code + same hash returns existing template id with `Created=false`. **Conflict on code re-use**: same code + different hash returns 409 with `template.code.in-use`. Response shape now `RegisteredTemplate` (per IM5 OpenAPI). |
| `IImageBuildOrchestrator` (new) + `ImageBuildOrchestrator` impl | Cache-hit short-circuit; force-flag bypass; cache-miss builds + pushes; failure paths surface stable error codes for IM10. |
| `ImagesController.Build` | Replaced legacy `ContainerImage`-creation with delegation to the orchestrator. Returns `BuildHandle` per the IM5 OpenAPI. Status maps to 200 (cached) / 202 (succeeded) / 503 (no engine) / 422 (build failed) / 404 (template missing). |
| `Program.cs` | `AddImageManagement` + `AddLocalZotRegistry` + `AddLocalBuildBackend` + orchestrator + store registrations. First wire-up. |

## Critical contract: cache-hit short-circuit

```
1. Look up template, compute its current SpecHash.
2. Look up BuildArtifact by (TemplateId, SpecHash) via IBuildArtifactStore.
3. If hit AND has a RegistryReference matching the requested registryId
   → return BuildResultStatus.Cached. Do NOT invoke IBuildBackend.
4. Otherwise: build, push, persist, return Succeeded.
```

The "do NOT invoke IBuildBackend" is the critical contract — the test pins it via `Times.Never`.

## Force-flag tag-collision handling

When `Force=true` and the rebuild lands at a `(RegistryId, RepoPath, Tag)` coordinate that already exists (typical when SpecHash didn't change), the orchestrator **updates** the existing reference row to point at the new digest rather than letting the composite unique constraint fire. Tags are mutable in OCI; the registry happily overwrites, so the DB now mirrors that.

## Known gap (deferred to IM11)

Cache-hit-but-missing-reference falls through to rebuild for IM8. Re-pushing already-built bytes requires the local image cache, which we may not have for an artifact built minutes/days ago. Tracked as a known gap; the embedded round-trip integration test (IM11) will exercise this path against a live zot.

## Tests

| Suite | Count | Coverage |
|---|---|---|
| `ImageBuildOrchestratorTests` (Integration, SQLite) | 6 | template-not-found, cache miss builds + persists, cache hit returns Cached without backend (`Times.Never`), force-flag bypass + reference-update, backend throws → Failed with code/logs, unknown registry → `registry.not_configured` |
| `ImagesControllerTests` | 6 new (4 legacy removed) | new BuildHandle response shape; Cached → 200; Succeeded → 202; Failed engine → 503; Failed build → 422; force flag flows through; registryId override flows through |
| `TemplatesControllerYamlTests` | 3 new | `CreateFromYaml` returns `RegisteredTemplate` with populated `SpecHash`; idempotent re-register returns same id with `Created=false`; same code + different spec returns 409 with `template.code.in-use` |

```
dotnet build Andy.Containers.sln                         ✅ 0 warn / 0 err
dotnet test tests/Andy.Containers.Tests                   ✅ 450 / 450
dotnet test tests/Andy.Containers.Integration.Tests/Build ✅ 6 / 6
dotnet test tests/Andy.Containers.Api.Tests               ✅ 933 / 935 (2 pre-existing env failures)
```

## What's deliberately NOT in IM8

- **Async build with SSE** — the orchestrator runs synchronously in the request thread for IM8. **IM9 (#263)** layers async + SSE on top.
- **Mapping every error code to a `Problem`-shaped response** — IM8 has the mapping inline in `ImagesController`. **IM10 (#264)** moves it to a shared factory.
- **Files in the build context** — the JSON-only register endpoint doesn't accept multipart files. The orchestrator stages an empty build context. The multipart variant lands when files are needed (likely IM11).
- **Removing the legacy template-build flow** — the existing `IImageBuildService` and `ContainerImage` table stay. The new path doesn't touch them; both paths can coexist while UIs migrate.

## What's next

- **#263 / IM9** — Build progress SSE. The orchestrator's `IProgress<BuildProgressEvent>` parameter already plumbs through; IM9 adds the SSE controller and the in-memory event bus.
- **#264 / IM10** — Pull all error mapping into a structured-response factory.
- **#265 / IM11** — Embedded round-trip integration test against a live zot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)