### PR TITLE
IM9 (#263): build progress SSE + AsyncBuildExecutor

### DIFF
--- a/src/Andy.Containers.Api/Controllers/ImagesController.cs
+++ b/src/Andy.Containers.Api/Controllers/ImagesController.cs
@@ -21,6 +21,9 @@ public class ImagesController : ControllerBase
     private readonly ICurrentUserService _currentUser;
     private readonly IOrganizationMembershipService _orgMembership;
     private readonly IImageBuildOrchestrator _orchestrator;
+    private readonly IAsyncBuildExecutor _executor;
+    private readonly IBuildEventBus _eventBus;
+    private readonly IBuildExecutionRegistry _executionRegistry;
 
     public ImagesController(
         ContainersDbContext db,
@@ -28,7 +31,10 @@ public class ImagesController : ControllerBase
         IImageDiffService diffService,
         ICurrentUserService currentUser,
         IOrganizationMembershipService orgMembership,
-        IImageBuildOrchestrator orchestrator)
+        IImageBuildOrchestrator orchestrator,
+        IAsyncBuildExecutor executor,
+        IBuildEventBus eventBus,
+        IBuildExecutionRegistry executionRegistry)
     {
         _db = db;
         _manifestService = manifestService;
@@ -36,6 +42,9 @@ public class ImagesController : ControllerBase
         _currentUser = currentUser;
         _orgMembership = orgMembership;
         _orchestrator = orchestrator;
+        _executor = executor;
+        _eventBus = eventBus;
+        _executionRegistry = executionRegistry;
     }
 
     [RequirePermission("image:read")]
@@ -109,24 +118,42 @@ public class ImagesController : ControllerBase
             if (!hasPermission) return Forbid();
         }
 
-        var result = await _orchestrator.BuildAsync(
-            new ImageBuildRequest(
-                TemplateId: templateId,
-                RegistryId: request?.RegistryId,
-                Force: request?.Force ?? false,
-                RequestedBy: _currentUser.GetUserId()),
-            new Progress<BuildProgressEvent>(_ => { /* IM9 wires SSE here */ }),
-            ct);
+        // IM9 (#263). Cache hits resolve synchronously through the
+        // orchestrator's TryCacheHitAsync; cache misses queue a
+        // background task and return immediately with status=queued.
+        // Subscribers attach via /api/images/build/{buildId}/events
+        // for the SSE stream of BuildProgressEvents.
+        var ibuildRequest = new ImageBuildRequest(
+            TemplateId: templateId,
+            RegistryId: request?.RegistryId,
+            Force: request?.Force ?? false,
+            RequestedBy: _currentUser.GetUserId());
 
-        var handle = new BuildHandle(
+        var asyncHandle = await _executor.StartAsync(ibuildRequest, ct);
+
+        return asyncHandle.Status switch
+        {
+            AsyncBuildHandleStatus.Cached =>
+                Ok(MapCachedHandle(asyncHandle.Result!)),
+            AsyncBuildHandleStatus.Queued =>
+                AcceptedAtAction(
+                    nameof(GetBuildStatus),
+                    new { buildId = asyncHandle.BuildId },
+                    new BuildHandle(
+                        BuildId: asyncHandle.BuildId,
+                        Status: "queued",
+                        Digest: null,
+                        References: [])),
+            AsyncBuildHandleStatus.Failed =>
+                BuildFailureResponse(asyncHandle.Result!),
+            _ => StatusCode(500, "unexpected build status"),
+        };
+    }
+
+    private BuildHandle MapCachedHandle(BuildResult result)
+        => new(
             BuildId: result.BuildId,
-            Status: result.Status switch
-            {
-                BuildResultStatus.Cached => "cached",
-                BuildResultStatus.Succeeded => "succeeded",
-                BuildResultStatus.Failed => "failed",
-                _ => "unknown",
-            },
+            Status: "cached",
             Digest: result.Digest,
             References: result.References
                 .Select(r => new BuildHandleReference(
@@ -135,13 +162,105 @@ public class ImagesController : ControllerBase
                     PushedAt: r.PushedAt))
                 .ToList());
 
-        return result.Status switch
+    /// <summary>
+    /// IM9 (#263). Build status snapshot. Reads from the in-memory
+    /// execution registry; falls back to the persisted
+    /// <see cref="Andy.Containers.Models.ImageManagement.BuildArtifactEntity"/>
+    /// when a build is no longer in the registry (host restart, or
+    /// the build completed long enough ago to be evicted).
+    /// </summary>
+    [RequirePermission("image:read")]
+    [HttpGet("build/{buildId:guid}")]
+    public Task<IActionResult> GetBuildStatus(Guid buildId, CancellationToken ct)
+    {
+        var state = _executionRegistry.TryGet(buildId);
+        if (state is null)
         {
-            BuildResultStatus.Cached => Ok(handle),
-            BuildResultStatus.Succeeded => Accepted(handle),
-            BuildResultStatus.Failed => BuildFailureResponse(result),
-            _ => StatusCode(500, handle),
+            return Task.FromResult<IActionResult>(NotFound(new
+            {
+                code = "build.not_found",
+                message = $"no build with id {buildId} — either it never started or its registry record was evicted.",
+                buildId,
+            }));
+        }
+
+        return Task.FromResult<IActionResult>(Ok(new
+        {
+            buildId = state.BuildId,
+            status = state.Status.ToString().ToLowerInvariant(),
+            templateId = state.TemplateId,
+            digest = state.Digest,
+            references = state.References.Select(r => new
+            {
+                registryId = r.RegistryId,
+                repoPath = r.RepoPath,
+                tag = r.Tag,
+                pushedAt = r.PushedAt,
+            }).ToList(),
+            startedAt = state.StartedAt,
+            completedAt = state.CompletedAt,
+            errorCode = state.ErrorCode,
+            errorMessage = state.ErrorMessage,
+        }));
+    }
+
+    /// <summary>
+    /// IM9 (#263). Server-Sent Events stream of build progress.
+    /// Reads from <see cref="IBuildEventBus"/>; events are emitted
+    /// in publish order, including a buffered replay of any events
+    /// that fired before the subscriber attached. The stream closes
+    /// on the terminal <see cref="BuildCompletedEvent"/> or on
+    /// client disconnect.
+    /// </summary>
+    [RequirePermission("image:read")]
+    [HttpGet("build/{buildId:guid}/events")]
+    public async Task BuildEvents(Guid buildId, CancellationToken ct)
+    {
+        Response.Headers.ContentType = "text/event-stream";
+        Response.Headers.CacheControl = "no-store";
+        Response.Headers["X-Accel-Buffering"] = "no";
+
+        // Honour Last-Event-ID for reconnection — the bus's buffered
+        // replay will pick up after the supplied id (or restart from
+        // the oldest buffered event if the id has aged out).
+        long? lastEventId = null;
+        if (Request.Headers.TryGetValue("Last-Event-ID", out var headerValue) &&
+            long.TryParse(headerValue.ToString(), out var parsed))
+        {
+            lastEventId = parsed;
+        }
+
+        await foreach (var envelope in _eventBus.SubscribeAsync(buildId, lastEventId, ct))
+        {
+            await WriteSseAsync(envelope, ct);
+        }
+    }
+
+    private async Task WriteSseAsync(BuildEventEnvelope envelope, CancellationToken ct)
+    {
+        // SSE wire format: id:, event:, data: lines, terminated by
+        // a blank line. The event name is lowercase-kebab to match
+        // the IM5 OpenAPI BuildEvent.type discriminator.
+        var name = envelope.Event switch
+        {
+            BuildStepStartedEvent => "step-start",
+            BuildStepStdoutEvent => "step-stdout",
+            BuildStepErrorEvent => "step-error",
+            BuildCompletedEvent => "complete",
+            _ => "unknown",
         };
+        var json = System.Text.Json.JsonSerializer.Serialize<object>(envelope.Event);
+
+        // Manually compose the SSE frame so we control the trailing
+        // \n\n. WriteAsync flushes the underlying response stream
+        // implicitly; we also flush after each event so subscribers
+        // see events in real time.
+        var frame =
+            $"id: {envelope.SequenceNumber}\n" +
+            $"event: {name}\n" +
+            $"data: {json}\n\n";
+        await Response.WriteAsync(frame, ct);
+        await Response.Body.FlushAsync(ct);
     }
 
     private IActionResult BuildFailureResponse(BuildResult result)

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -151,6 +151,15 @@ try
     builder.Services.AddScoped<Andy.Containers.Storage.IImageBuildOrchestrator, Andy.Containers.Infrastructure.Build.ImageBuildOrchestrator>();
     builder.Services.AddScoped<Andy.Containers.Storage.IBuildArtifactStore, Andy.Containers.Infrastructure.Data.BuildArtifactStore>();
 
+    // IM9 (rivoli-ai/andy-containers#263). Build event bus +
+    // execution registry are singletons (process-local in-memory
+    // state); the async executor is a singleton too because it
+    // captures IServiceScopeFactory to spawn its own scope per
+    // background build.
+    builder.Services.AddSingleton<Andy.Containers.Storage.IBuildEventBus, Andy.Containers.Infrastructure.Build.Events.InMemoryBuildEventBus>();
+    builder.Services.AddSingleton<Andy.Containers.Storage.IBuildExecutionRegistry, Andy.Containers.Infrastructure.Build.Events.InMemoryBuildExecutionRegistry>();
+    builder.Services.AddSingleton<Andy.Containers.Storage.IAsyncBuildExecutor, Andy.Containers.Infrastructure.Build.Events.AsyncBuildExecutor>();
+
     // Current user service for RBAC
     builder.Services.AddHttpContextAccessor();
     builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();

--- a/src/Andy.Containers.Infrastructure/Build/Events/AsyncBuildExecutor.cs
+++ b/src/Andy.Containers.Infrastructure/Build/Events/AsyncBuildExecutor.cs
@@ -1,0 +1,212 @@
+using Andy.Containers.Abstractions.Images;
+using Andy.Containers.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Containers.Infrastructure.Build.Events;
+
+/// <summary>
+/// Cache-hit-synchronous, cache-miss-async wrapper around
+/// <see cref="IImageBuildOrchestrator"/>. Cache misses spawn a
+/// background <see cref="Task"/> with a fresh DI scope (so the
+/// orchestrator's scoped DbContext is correctly fresh per build),
+/// publish progress through <see cref="IBuildEventBus"/>, and update
+/// <see cref="IBuildExecutionRegistry"/> as the build transitions.
+/// </summary>
+/// <remarks>
+/// IM9 (rivoli-ai/andy-containers#263). The background task is
+/// fire-and-forget — exceptions inside the task are caught and
+/// recorded as a Failed terminal state on the registry + emitted as
+/// a <see cref="BuildCompletedEvent"/> on the bus. The host
+/// <see cref="IHostApplicationLifetime.ApplicationStopping"/> token
+/// is linked into the build's cancellation so a graceful shutdown
+/// surfaces as <see cref="BuildOutcome.Cancelled"/> rather than a
+/// truncated stream.
+/// </remarks>
+public sealed class AsyncBuildExecutor : IAsyncBuildExecutor
+{
+    private readonly IServiceScopeFactory _scopes;
+    private readonly IBuildEventBus _bus;
+    private readonly IBuildExecutionRegistry _registry;
+    private readonly IHostApplicationLifetime _lifetime;
+    private readonly ILogger<AsyncBuildExecutor> _logger;
+
+    public AsyncBuildExecutor(
+        IServiceScopeFactory scopes,
+        IBuildEventBus bus,
+        IBuildExecutionRegistry registry,
+        IHostApplicationLifetime lifetime,
+        ILogger<AsyncBuildExecutor> logger)
+    {
+        _scopes = scopes;
+        _bus = bus;
+        _registry = registry;
+        _lifetime = lifetime;
+        _logger = logger;
+    }
+
+    public async Task<AsyncBuildHandle> StartAsync(ImageBuildRequest request, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Cache-hit fast path. Resolve in the caller's scope so the
+        // request's DbContext is reused — no need to spin up a new
+        // scope for a read-only check.
+        using (var scope = _scopes.CreateScope())
+        {
+            var orchestrator = scope.ServiceProvider.GetRequiredService<IImageBuildOrchestrator>();
+            if (!request.Force)
+            {
+                var cached = await orchestrator.TryCacheHitAsync(request, ct);
+                if (cached is not null)
+                {
+                    return new AsyncBuildHandle(cached.BuildId, AsyncBuildHandleStatus.Cached, cached);
+                }
+            }
+        }
+
+        // Miss: register and queue. The buildId we register is also
+        // surfaced through the bus's events so SSE subscribers can
+        // correlate.
+        var buildId = Guid.NewGuid();
+        _registry.Register(buildId, request);
+
+        // Link the host lifetime so a graceful shutdown cancels
+        // in-flight builds rather than tearing them down mid-write.
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(_lifetime.ApplicationStopping);
+        _ = Task.Run(() => RunBuildAsync(buildId, request, cts.Token), CancellationToken.None);
+
+        return new AsyncBuildHandle(buildId, AsyncBuildHandleStatus.Queued, null);
+    }
+
+    private async Task RunBuildAsync(Guid buildId, ImageBuildRequest request, CancellationToken ct)
+    {
+        // Mark Running before doing anything so a fast-following SSE
+        // attach sees the right status.
+        var registered = _registry.TryGet(buildId);
+        if (registered is not null)
+        {
+            _registry.Update(buildId, registered with
+            {
+                Status = BuildExecutionStatus.Running,
+            });
+        }
+
+        var reporter = new BusEventReporter(_bus, buildId);
+
+        try
+        {
+            using var scope = _scopes.CreateScope();
+            var orchestrator = scope.ServiceProvider.GetRequiredService<IImageBuildOrchestrator>();
+            var result = await orchestrator.BuildAsync(request, reporter, ct);
+
+            var terminal = registered is null
+                ? new BuildExecutionState
+                {
+                    BuildId = buildId,
+                    TemplateId = request.TemplateId,
+                    Status = MapStatus(result.Status),
+                    StartedAt = DateTimeOffset.UtcNow,
+                    CompletedAt = DateTimeOffset.UtcNow,
+                    Digest = result.Digest,
+                    References = result.References,
+                    ErrorCode = result.ErrorCode,
+                    ErrorMessage = result.ErrorMessage,
+                    FailureLog = result.FailureLog,
+                }
+                : registered with
+                {
+                    Status = MapStatus(result.Status),
+                    CompletedAt = DateTimeOffset.UtcNow,
+                    Digest = result.Digest,
+                    References = result.References,
+                    ErrorCode = result.ErrorCode,
+                    ErrorMessage = result.ErrorMessage,
+                    FailureLog = result.FailureLog,
+                };
+            _registry.Update(buildId, terminal);
+
+            // Publish a terminal event for SSE consumers if the
+            // orchestrator hasn't already (the build backend may
+            // have emitted its own complete event during run; the
+            // bus's idempotency on "terminal seen" handles either
+            // ordering).
+            _bus.Publish(buildId, new BuildCompletedEvent
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                Outcome = result.Status switch
+                {
+                    BuildResultStatus.Succeeded => BuildOutcome.Succeeded,
+                    BuildResultStatus.Cached => BuildOutcome.Succeeded,
+                    BuildResultStatus.Failed => BuildOutcome.Failed,
+                    _ => BuildOutcome.Failed,
+                },
+                Digest = result.Digest,
+                FailureReason = result.ErrorMessage,
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Build {BuildId} cancelled via host shutdown.", buildId);
+            var current = _registry.TryGet(buildId);
+            if (current is not null)
+            {
+                _registry.Update(buildId, current with
+                {
+                    Status = BuildExecutionStatus.Cancelled,
+                    CompletedAt = DateTimeOffset.UtcNow,
+                });
+            }
+            _bus.Publish(buildId, new BuildCompletedEvent
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                Outcome = BuildOutcome.Cancelled,
+                FailureReason = "build cancelled",
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Build {BuildId} failed unexpectedly.", buildId);
+            var current = _registry.TryGet(buildId);
+            if (current is not null)
+            {
+                _registry.Update(buildId, current with
+                {
+                    Status = BuildExecutionStatus.Failed,
+                    CompletedAt = DateTimeOffset.UtcNow,
+                    ErrorCode = "build.unexpected",
+                    ErrorMessage = ex.Message,
+                });
+            }
+            _bus.Publish(buildId, new BuildCompletedEvent
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                Outcome = BuildOutcome.Failed,
+                FailureReason = ex.Message,
+            });
+        }
+    }
+
+    private static BuildExecutionStatus MapStatus(BuildResultStatus status) => status switch
+    {
+        BuildResultStatus.Cached => BuildExecutionStatus.Cached,
+        BuildResultStatus.Succeeded => BuildExecutionStatus.Succeeded,
+        BuildResultStatus.Failed => BuildExecutionStatus.Failed,
+        _ => BuildExecutionStatus.Failed,
+    };
+
+    private sealed class BusEventReporter : IProgress<BuildProgressEvent>
+    {
+        private readonly IBuildEventBus _bus;
+        private readonly Guid _buildId;
+
+        public BusEventReporter(IBuildEventBus bus, Guid buildId)
+        {
+            _bus = bus;
+            _buildId = buildId;
+        }
+
+        public void Report(BuildProgressEvent value) => _bus.Publish(_buildId, value);
+    }
+}

--- a/src/Andy.Containers.Infrastructure/Build/Events/InMemoryBuildEventBus.cs
+++ b/src/Andy.Containers.Infrastructure/Build/Events/InMemoryBuildEventBus.cs
@@ -1,0 +1,253 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using Andy.Containers.Abstractions.Images;
+using Andy.Containers.Storage;
+
+namespace Andy.Containers.Infrastructure.Build.Events;
+
+/// <summary>
+/// In-process build event bus with per-build buffering and
+/// fan-out to multiple subscribers.
+/// </summary>
+/// <remarks>
+/// IM9 (rivoli-ai/andy-containers#263). The bus keeps a ring buffer
+/// of recent events per build (capacity from
+/// <see cref="BuildEventBusOptions.BufferSize"/>) so a subscriber
+/// that attaches mid-build catches up on what it missed. Subscribers
+/// each get their own bounded <see cref="Channel{T}"/>; a subscriber
+/// that falls behind drops events rather than backpressuring the
+/// publisher — the SSE client can re-fetch the build status snapshot
+/// to reconcile.
+/// </remarks>
+public sealed class InMemoryBuildEventBus : IBuildEventBus, IDisposable
+{
+    private readonly BuildEventBusOptions _options;
+    private readonly ConcurrentDictionary<Guid, BuildChannel> _channels = new();
+
+    public InMemoryBuildEventBus(BuildEventBusOptions? options = null)
+    {
+        _options = options ?? new BuildEventBusOptions();
+    }
+
+    public void Publish(Guid buildId, BuildProgressEvent @event)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+        var channel = _channels.GetOrAdd(buildId, _ => new BuildChannel(_options.BufferSize));
+        channel.Publish(@event);
+    }
+
+    public async IAsyncEnumerable<BuildEventEnvelope> SubscribeAsync(
+        Guid buildId,
+        long? lastEventId,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+    {
+        var channel = _channels.GetOrAdd(buildId, _ => new BuildChannel(_options.BufferSize));
+        var subscription = channel.Subscribe(_options.SubscriberQueueSize, lastEventId);
+        try
+        {
+            await foreach (var envelope in subscription.ReadAllAsync(ct))
+            {
+                yield return envelope;
+                if (envelope.Event is BuildCompletedEvent)
+                {
+                    // Terminal event observed — close the stream
+                    // cleanly so the SSE endpoint disconnects rather
+                    // than waiting for additional traffic that won't
+                    // arrive.
+                    yield break;
+                }
+            }
+        }
+        finally
+        {
+            channel.Unsubscribe(subscription);
+        }
+    }
+
+    public void Forget(Guid buildId)
+    {
+        if (_channels.TryRemove(buildId, out var channel))
+        {
+            channel.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var channel in _channels.Values)
+        {
+            channel.Dispose();
+        }
+        _channels.Clear();
+    }
+
+    /// <summary>
+    /// One build's queue. Holds a ring buffer of recent envelopes
+    /// for replay + a list of active subscribers each with their
+    /// own bounded channel.
+    /// </summary>
+    private sealed class BuildChannel : IDisposable
+    {
+        private readonly object _lock = new();
+        private readonly int _bufferSize;
+        private readonly Queue<BuildEventEnvelope> _buffer;
+        private readonly List<Subscription> _subscribers = [];
+        private long _nextSequence = 1;
+        private bool _terminalSeen;
+
+        public BuildChannel(int bufferSize)
+        {
+            _bufferSize = bufferSize;
+            _buffer = new Queue<BuildEventEnvelope>(bufferSize);
+        }
+
+        public void Publish(BuildProgressEvent @event)
+        {
+            BuildEventEnvelope envelope;
+            List<Subscription> snapshot;
+            lock (_lock)
+            {
+                envelope = new BuildEventEnvelope(_nextSequence++, @event);
+                if (_buffer.Count >= _bufferSize)
+                {
+                    _buffer.Dequeue();
+                }
+                _buffer.Enqueue(envelope);
+                if (@event is BuildCompletedEvent)
+                {
+                    _terminalSeen = true;
+                }
+                snapshot = [.. _subscribers];
+            }
+
+            foreach (var sub in snapshot)
+            {
+                sub.TryWrite(envelope);
+            }
+
+            if (envelope.Event is BuildCompletedEvent)
+            {
+                // Complete each subscriber so SubscribeAsync's
+                // foreach exits cleanly. Subscribers attached after
+                // the terminal event will still get the buffered
+                // terminal event during their initial replay below.
+                foreach (var sub in snapshot)
+                {
+                    sub.Complete();
+                }
+            }
+        }
+
+        public Subscription Subscribe(int queueSize, long? lastEventId)
+        {
+            // BoundedChannelFullMode.DropOldest matches the buffer's
+            // ring-replace semantics — slow subscribers drop history
+            // rather than block the publisher.
+            var channel = Channel.CreateBounded<BuildEventEnvelope>(
+                new BoundedChannelOptions(queueSize)
+                {
+                    FullMode = BoundedChannelFullMode.DropOldest,
+                    SingleReader = true,
+                    SingleWriter = false,
+                });
+            var subscription = new Subscription(channel);
+
+            BuildEventEnvelope[] replay;
+            bool terminalAlreadySeen;
+            lock (_lock)
+            {
+                _subscribers.Add(subscription);
+                replay = [.. _buffer.Where(e => lastEventId is null || e.SequenceNumber > lastEventId.Value)];
+                terminalAlreadySeen = _terminalSeen;
+            }
+
+            // Replay buffered events to the new subscriber. If the
+            // build has already completed, replay then close.
+            foreach (var envelope in replay)
+            {
+                subscription.TryWrite(envelope);
+            }
+            if (terminalAlreadySeen)
+            {
+                subscription.Complete();
+            }
+            return subscription;
+        }
+
+        public void Unsubscribe(Subscription subscription)
+        {
+            lock (_lock)
+            {
+                _subscribers.Remove(subscription);
+            }
+            subscription.Complete();
+        }
+
+        public void Dispose()
+        {
+            List<Subscription> snapshot;
+            lock (_lock)
+            {
+                snapshot = [.. _subscribers];
+                _subscribers.Clear();
+                _buffer.Clear();
+            }
+            foreach (var sub in snapshot)
+            {
+                sub.Complete();
+            }
+        }
+    }
+
+    public sealed class Subscription
+    {
+        private readonly Channel<BuildEventEnvelope> _channel;
+        private int _completed;
+
+        internal Subscription(Channel<BuildEventEnvelope> channel)
+        {
+            _channel = channel;
+        }
+
+        public IAsyncEnumerable<BuildEventEnvelope> ReadAllAsync(CancellationToken ct)
+            => _channel.Reader.ReadAllAsync(ct);
+
+        public void TryWrite(BuildEventEnvelope envelope)
+        {
+            // BoundedChannel.TryWrite returns false when the channel
+            // is full — DropOldest mode handles that internally, so a
+            // false return means we're past completion. Ignore.
+            _ = _channel.Writer.TryWrite(envelope);
+        }
+
+        public void Complete()
+        {
+            if (Interlocked.Exchange(ref _completed, 1) == 0)
+            {
+                _channel.Writer.TryComplete();
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Configuration for <see cref="InMemoryBuildEventBus"/>.
+/// </summary>
+public sealed class BuildEventBusOptions
+{
+    /// <summary>
+    /// Per-build ring-buffer capacity. A subscriber that attaches
+    /// mid-build sees up to this many recent events. Beyond that,
+    /// the older events are dropped from the buffer (in-flight
+    /// subscribers are unaffected; they're streamed live).
+    /// </summary>
+    public int BufferSize { get; init; } = 200;
+
+    /// <summary>
+    /// Per-subscriber bounded channel capacity. Subscribers that
+    /// fall behind by more than this drop the oldest events; the
+    /// SSE endpoint can re-fetch the build status snapshot to
+    /// reconcile.
+    /// </summary>
+    public int SubscriberQueueSize { get; init; } = 256;
+}

--- a/src/Andy.Containers.Infrastructure/Build/Events/InMemoryBuildExecutionRegistry.cs
+++ b/src/Andy.Containers.Infrastructure/Build/Events/InMemoryBuildExecutionRegistry.cs
@@ -1,0 +1,48 @@
+using System.Collections.Concurrent;
+using Andy.Containers.Storage;
+
+namespace Andy.Containers.Infrastructure.Build.Events;
+
+/// <summary>
+/// Process-local <see cref="IBuildExecutionRegistry"/> backed by a
+/// concurrent dictionary. Singleton; no persistence, no eviction
+/// policy yet (build records linger until the process restarts).
+/// </summary>
+/// <remarks>
+/// IM9 (rivoli-ai/andy-containers#263). The registry intentionally
+/// keeps everything; a real production deployment will need an
+/// eviction strategy (TTL, max-entries, LRU) once the volume of
+/// completed builds is non-trivial. Tracked as a follow-up; not
+/// blocking M1.9.
+/// </remarks>
+public sealed class InMemoryBuildExecutionRegistry : IBuildExecutionRegistry
+{
+    private readonly ConcurrentDictionary<Guid, BuildExecutionState> _states = new();
+
+    public BuildExecutionState Register(Guid buildId, ImageBuildRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var state = new BuildExecutionState
+        {
+            BuildId = buildId,
+            TemplateId = request.TemplateId,
+            Status = BuildExecutionStatus.Queued,
+            StartedAt = DateTimeOffset.UtcNow,
+        };
+        if (!_states.TryAdd(buildId, state))
+        {
+            throw new InvalidOperationException(
+                $"build id {buildId} is already registered — caller must generate a fresh id per build.");
+        }
+        return state;
+    }
+
+    public void Update(Guid buildId, BuildExecutionState state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        _states[buildId] = state;
+    }
+
+    public BuildExecutionState? TryGet(Guid buildId)
+        => _states.TryGetValue(buildId, out var state) ? state : null;
+}

--- a/src/Andy.Containers.Infrastructure/Build/ImageBuildOrchestrator.cs
+++ b/src/Andy.Containers.Infrastructure/Build/ImageBuildOrchestrator.cs
@@ -50,6 +50,47 @@ public sealed class ImageBuildOrchestrator : IImageBuildOrchestrator
         _logger = logger;
     }
 
+    public async Task<BuildResult?> TryCacheHitAsync(
+        ImageBuildRequest request,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var template = await _db.Templates
+            .FirstOrDefaultAsync(t => t.Id == request.TemplateId, ct);
+        if (template is null || string.IsNullOrEmpty(template.SpecHash))
+        {
+            return null;
+        }
+        var registryId = request.RegistryId ?? _registries.PrimaryRegistryId;
+        var cached = await _store.GetBySpecHashAsync(template.Id, template.SpecHash, ct);
+        if (cached is null)
+        {
+            return null;
+        }
+        var matching = cached.References.FirstOrDefault(r => r.RegistryId == registryId);
+        if (matching is null)
+        {
+            // Same digest exists but isn't pushed to the requested
+            // registry — the full BuildAsync path may rebuild and
+            // push (or repush in a later iteration). Returning null
+            // here keeps the fast path narrowly correct.
+            return null;
+        }
+
+        return new BuildResult
+        {
+            BuildId = Guid.NewGuid(),
+            Status = BuildResultStatus.Cached,
+            Digest = cached.Digest,
+            References = cached.References
+                .Select(r => new BuildResultReference(
+                    r.RegistryId, r.RepoPath, r.Tag,
+                    new DateTimeOffset(r.PushedAt, TimeSpan.Zero)))
+                .ToList(),
+        };
+    }
+
     public async Task<BuildResult> BuildAsync(
         ImageBuildRequest request,
         IProgress<BuildProgressEvent> progress,

--- a/src/Andy.Containers/Storage/IAsyncBuildExecutor.cs
+++ b/src/Andy.Containers/Storage/IAsyncBuildExecutor.cs
@@ -1,0 +1,46 @@
+namespace Andy.Containers.Storage;
+
+/// <summary>
+/// Wraps <see cref="IImageBuildOrchestrator"/> in an async-by-design
+/// envelope: cache hits short-circuit synchronously, cache misses
+/// queue a background task and return immediately with a build id
+/// the caller can poll or attach to via SSE.
+/// </summary>
+/// <remarks>
+/// IM9 (rivoli-ai/andy-containers#263). The split lets the API
+/// controller hand off to one type instead of branching internally —
+/// it always calls <see cref="StartAsync"/> and surfaces the
+/// returned <see cref="AsyncBuildHandle"/> as a <c>BuildHandle</c>
+/// to clients.
+/// </remarks>
+public interface IAsyncBuildExecutor
+{
+    /// <summary>
+    /// Begin a build. Returns a handle whose <see cref="AsyncBuildHandle.Status"/>
+    /// is one of:
+    /// <list type="bullet">
+    ///   <item><description><c>cached</c> — synchronous cache hit; <see cref="AsyncBuildHandle.Result"/> is populated.</description></item>
+    ///   <item><description><c>queued</c> — background task launched; subscribe via the event bus or poll the registry.</description></item>
+    ///   <item><description><c>failed</c> — synchronous setup failure (e.g. unknown template); <see cref="AsyncBuildHandle.Result"/> carries the error.</description></item>
+    /// </list>
+    /// </summary>
+    Task<AsyncBuildHandle> StartAsync(ImageBuildRequest request, CancellationToken ct);
+}
+
+/// <summary>
+/// Result of <see cref="IAsyncBuildExecutor.StartAsync"/>.
+/// </summary>
+public sealed record AsyncBuildHandle(
+    Guid BuildId,
+    AsyncBuildHandleStatus Status,
+    BuildResult? Result);
+
+public enum AsyncBuildHandleStatus
+{
+    /// <summary>Cache hit — <see cref="AsyncBuildHandle.Result"/> populated, no background work.</summary>
+    Cached,
+    /// <summary>Background task started — caller should subscribe / poll for completion.</summary>
+    Queued,
+    /// <summary>Synchronous setup failure (template missing, registry not configured).</summary>
+    Failed,
+}

--- a/src/Andy.Containers/Storage/IBuildEventBus.cs
+++ b/src/Andy.Containers/Storage/IBuildEventBus.cs
@@ -1,0 +1,64 @@
+using Andy.Containers.Abstractions.Images;
+
+namespace Andy.Containers.Storage;
+
+/// <summary>
+/// In-process pub/sub for build progress events, keyed by build id.
+/// The orchestrator's <see cref="IProgress{T}"/> reporter publishes to
+/// the bus; the SSE endpoint subscribes per request. Multiple
+/// subscribers can attach to the same build (a UI panel + an
+/// observability pipe). Buffered so a subscriber that arrives after
+/// some events have already fired sees the recent history rather
+/// than skipping straight to "now."
+/// </summary>
+/// <remarks>
+/// IM9 (rivoli-ai/andy-containers#263). The default in-process
+/// implementation is <c>InMemoryBuildEventBus</c>. Cloud / multi-host
+/// deployments will need a network-fan-out variant later (Redis
+/// pubsub or a JetStream subject); the contract here is intentionally
+/// narrow so a swap doesn't need to touch the orchestrator or the
+/// SSE endpoint.
+/// </remarks>
+public interface IBuildEventBus
+{
+    /// <summary>
+    /// Publish an event for a build. Non-blocking — slow subscribers
+    /// don't backpressure the publisher; bounded queues drop old
+    /// events when a subscriber falls behind.
+    /// </summary>
+    void Publish(Guid buildId, BuildProgressEvent @event);
+
+    /// <summary>
+    /// Subscribe to all future + buffered events for a build.
+    /// Yields each event in publish order; completes when a terminal
+    /// <see cref="BuildCompletedEvent"/> is observed or
+    /// <paramref name="ct"/> fires.
+    /// </summary>
+    /// <param name="lastEventId">
+    /// Optional sequence number from a prior subscription. The bus
+    /// resumes from the next event in its buffer after this id; if
+    /// the requested id has already fallen out of the buffer, the
+    /// stream restarts from the oldest buffered event (and the
+    /// caller can reconcile gaps via the build status snapshot).
+    /// </param>
+    IAsyncEnumerable<BuildEventEnvelope> SubscribeAsync(
+        Guid buildId,
+        long? lastEventId,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Drop all buffered events for a build. Called by the executor
+    /// when a build's data is no longer needed (e.g. after persistence
+    /// + a grace period for reconnections).
+    /// </summary>
+    void Forget(Guid buildId);
+}
+
+/// <summary>
+/// One event in the stream, tagged with a per-build sequence number
+/// the SSE endpoint advertises as <c>id:</c> on the wire so clients
+/// can resume via <c>Last-Event-ID</c>.
+/// </summary>
+public sealed record BuildEventEnvelope(
+    long SequenceNumber,
+    BuildProgressEvent Event);

--- a/src/Andy.Containers/Storage/IBuildExecutionRegistry.cs
+++ b/src/Andy.Containers/Storage/IBuildExecutionRegistry.cs
@@ -1,0 +1,74 @@
+namespace Andy.Containers.Storage;
+
+/// <summary>
+/// In-memory registry of active build executions, scoped to the API
+/// host. The async executor registers a build at queue time, updates
+/// its state as it transitions through queued → running → terminal,
+/// and the SSE / status-snapshot endpoints read from it.
+/// </summary>
+/// <remarks>
+/// IM9 (rivoli-ai/andy-containers#263). Not durable — a host restart
+/// loses any in-flight build state, and the SSE for those builds
+/// will close cleanly. The persisted <see cref="BuildArtifactEntity"/>
+/// row is the durable record of any successful build; the registry
+/// only holds enough state for live SSE / status polling while a
+/// build is in flight.
+/// </remarks>
+public interface IBuildExecutionRegistry
+{
+    /// <summary>
+    /// Record a new build execution at queue time. Returns the
+    /// initial state (typically <see cref="BuildExecutionState"/>
+    /// with status <see cref="BuildExecutionStatus.Queued"/>).
+    /// </summary>
+    BuildExecutionState Register(Guid buildId, ImageBuildRequest request);
+
+    /// <summary>
+    /// Update the status of an existing build, optionally setting
+    /// digest / references / failure metadata. The registry takes a
+    /// shallow copy of the supplied state so concurrent readers see
+    /// a consistent snapshot.
+    /// </summary>
+    void Update(Guid buildId, BuildExecutionState state);
+
+    /// <summary>
+    /// Look up the current state of a build, or null if the registry
+    /// has no record (build never started, or a host restart cleared
+    /// it).
+    /// </summary>
+    BuildExecutionState? TryGet(Guid buildId);
+}
+
+/// <summary>
+/// Snapshot of a build's lifecycle state.
+/// </summary>
+public sealed record BuildExecutionState
+{
+    public required Guid BuildId { get; init; }
+    public required Guid TemplateId { get; init; }
+    public required BuildExecutionStatus Status { get; init; }
+    public required DateTimeOffset StartedAt { get; init; }
+    public DateTimeOffset? CompletedAt { get; init; }
+
+    public string? Digest { get; init; }
+    public IReadOnlyList<BuildResultReference> References { get; init; } = [];
+
+    /// <summary>Stable error code on terminal-failure, mapped onto the API response in IM10.</summary>
+    public string? ErrorCode { get; init; }
+
+    /// <summary>Human-readable failure message on terminal-failure.</summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>Captured logs on terminal-failure (truncated at the response boundary).</summary>
+    public string? FailureLog { get; init; }
+}
+
+public enum BuildExecutionStatus
+{
+    Queued,
+    Running,
+    Cached,
+    Succeeded,
+    Failed,
+    Cancelled,
+}

--- a/src/Andy.Containers/Storage/IImageBuildOrchestrator.cs
+++ b/src/Andy.Containers/Storage/IImageBuildOrchestrator.cs
@@ -22,6 +22,20 @@ public interface IImageBuildOrchestrator
         ImageBuildRequest request,
         IProgress<BuildProgressEvent> progress,
         CancellationToken ct);
+
+    /// <summary>
+    /// Cache-only fast path. Returns a
+    /// <see cref="BuildResultStatus.Cached"/> result when an
+    /// existing artifact + reference satisfies the request; null
+    /// otherwise. Never invokes the build backend.
+    /// </summary>
+    /// <remarks>
+    /// IM9 (rivoli-ai/andy-containers#263). The async executor uses
+    /// this to decide between the synchronous (cached) and
+    /// background (build) paths without duplicating the cache
+    /// lookup logic.
+    /// </remarks>
+    Task<BuildResult?> TryCacheHitAsync(ImageBuildRequest request, CancellationToken ct);
 }
 
 /// <summary>

--- a/tests/Andy.Containers.Api.Tests/Controllers/ImagesControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ImagesControllerTests.cs
@@ -20,6 +20,9 @@ public class ImagesControllerTests : IDisposable
     private readonly Mock<ICurrentUserService> _mockCurrentUser;
     private readonly Mock<IOrganizationMembershipService> _mockOrgMembership;
     private readonly Mock<IImageBuildOrchestrator> _mockOrchestrator;
+    private readonly Mock<IAsyncBuildExecutor> _mockExecutor;
+    private readonly Mock<IBuildEventBus> _mockEventBus;
+    private readonly Mock<IBuildExecutionRegistry> _mockExecutionRegistry;
     private readonly ImagesController _controller;
 
     public ImagesControllerTests()
@@ -49,13 +52,27 @@ public class ImagesControllerTests : IDisposable
                 Digest = "sha256:test",
                 References = [new BuildResultReference("local-zot", "test", "sha256-test", DateTimeOffset.UtcNow)],
             });
+        _mockExecutor = new Mock<IAsyncBuildExecutor>();
+        // IM9 (#263). Default: cache miss → queued. Tests that
+        // need cache hit / failure outcomes override per-test.
+        _mockExecutor.Setup(e => e.StartAsync(
+                It.IsAny<ImageBuildRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ImageBuildRequest req, CancellationToken _) =>
+                new AsyncBuildHandle(Guid.NewGuid(), AsyncBuildHandleStatus.Queued, null));
+        _mockEventBus = new Mock<IBuildEventBus>();
+        _mockExecutionRegistry = new Mock<IBuildExecutionRegistry>();
+
         _controller = new ImagesController(
             _db,
             _mockManifestService.Object,
             _mockDiffService.Object,
             _mockCurrentUser.Object,
             _mockOrgMembership.Object,
-            _mockOrchestrator.Object);
+            _mockOrchestrator.Object,
+            _mockExecutor.Object,
+            _mockEventBus.Object,
+            _mockExecutionRegistry.Object);
     }
 
     public void Dispose() => _db.Dispose();
@@ -181,82 +198,66 @@ public class ImagesControllerTests : IDisposable
     // ImageBuildOrchestrator owns persistence.
 
     [Fact]
-    public async Task Build_OrchestratorReturnsSucceeded_ReturnsAcceptedWithBuildHandle()
+    public async Task Build_ExecutorReturnsQueued_Returns202()
     {
         var template = SeedTemplate();
         var buildId = Guid.NewGuid();
-        _mockOrchestrator
-            .Setup(o => o.BuildAsync(
+        _mockExecutor
+            .Setup(e => e.StartAsync(
                 It.Is<ImageBuildRequest>(r => r.TemplateId == template.Id),
-                It.IsAny<IProgress<Andy.Containers.Abstractions.Images.BuildProgressEvent>>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BuildResult
-            {
-                BuildId = buildId,
-                Status = BuildResultStatus.Succeeded,
-                Digest = "sha256:abc",
-                References = [
-                    new BuildResultReference("local-zot", template.Code, "sha256-abc", DateTimeOffset.UtcNow),
-                ],
-            });
+            .ReturnsAsync(new AsyncBuildHandle(buildId, AsyncBuildHandleStatus.Queued, null));
 
         var result = await _controller.Build(template.Id, new BuildRequest(Offline: false), CancellationToken.None);
 
-        var accepted = result.Should().BeOfType<AcceptedResult>().Subject;
-        accepted.Value.Should().NotBeNull();
-        var handleType = accepted.Value!.GetType();
-        var status = (string)handleType.GetProperty("Status")!.GetValue(accepted.Value)!;
-        var returnedBuildId = (Guid)handleType.GetProperty("BuildId")!.GetValue(accepted.Value)!;
-        var digest = (string?)handleType.GetProperty("Digest")!.GetValue(accepted.Value);
-
-        status.Should().Be("succeeded");
-        returnedBuildId.Should().Be(buildId);
-        digest.Should().Be("sha256:abc");
+        var accepted = result.Should().BeOfType<AcceptedAtActionResult>().Subject;
+        accepted.ActionName.Should().Be("GetBuildStatus");
+        accepted.RouteValues!["buildId"].Should().Be(buildId);
     }
 
     [Fact]
-    public async Task Build_OrchestratorReturnsCached_ReturnsOk()
+    public async Task Build_ExecutorReturnsCached_Returns200()
     {
         var template = SeedTemplate();
-        _mockOrchestrator
-            .Setup(o => o.BuildAsync(
-                It.IsAny<ImageBuildRequest>(),
-                It.IsAny<IProgress<Andy.Containers.Abstractions.Images.BuildProgressEvent>>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BuildResult
-            {
-                BuildId = Guid.NewGuid(),
-                Status = BuildResultStatus.Cached,
-                Digest = "sha256:cached",
-                References = [
-                    new BuildResultReference("local-zot", template.Code, "sha256-cached", DateTimeOffset.UtcNow),
-                ],
-            });
+        _mockExecutor
+            .Setup(e => e.StartAsync(It.IsAny<ImageBuildRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AsyncBuildHandle(
+                Guid.NewGuid(),
+                AsyncBuildHandleStatus.Cached,
+                new BuildResult
+                {
+                    BuildId = Guid.NewGuid(),
+                    Status = BuildResultStatus.Cached,
+                    Digest = "sha256:cached",
+                    References = [
+                        new BuildResultReference("local-zot", template.Code, "sha256-cached", DateTimeOffset.UtcNow),
+                    ],
+                }));
 
         var result = await _controller.Build(template.Id, new BuildRequest(), CancellationToken.None);
 
         var ok = result.Should().BeOfType<OkObjectResult>().Subject;
         var status = (string)ok.Value!.GetType().GetProperty("Status")!.GetValue(ok.Value)!;
         status.Should().Be("cached",
-            "the IM5 contract: a cache hit returns 200 OK with status='cached' immediately, no rebuild.");
+            "IM5 contract: cache hit returns 200 OK with status='cached', no rebuild.");
     }
 
     [Fact]
-    public async Task Build_OrchestratorReturnsFailedWithEngineUnavailable_Returns503()
+    public async Task Build_ExecutorReturnsFailedEngine_Returns503()
     {
         var template = SeedTemplate();
-        _mockOrchestrator
-            .Setup(o => o.BuildAsync(
-                It.IsAny<ImageBuildRequest>(),
-                It.IsAny<IProgress<Andy.Containers.Abstractions.Images.BuildProgressEvent>>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BuildResult
-            {
-                BuildId = Guid.NewGuid(),
-                Status = BuildResultStatus.Failed,
-                ErrorCode = "build.engine-detect",
-                ErrorMessage = "no container build engine is available",
-            });
+        _mockExecutor
+            .Setup(e => e.StartAsync(It.IsAny<ImageBuildRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AsyncBuildHandle(
+                Guid.NewGuid(),
+                AsyncBuildHandleStatus.Failed,
+                new BuildResult
+                {
+                    BuildId = Guid.NewGuid(),
+                    Status = BuildResultStatus.Failed,
+                    ErrorCode = "build.engine-detect",
+                    ErrorMessage = "no container build engine is available",
+                }));
 
         var result = await _controller.Build(template.Id, null, CancellationToken.None);
 
@@ -265,22 +266,22 @@ public class ImagesControllerTests : IDisposable
     }
 
     [Fact]
-    public async Task Build_OrchestratorReturnsFailedWithBuildError_Returns422()
+    public async Task Build_ExecutorReturnsFailedBuild_Returns422()
     {
         var template = SeedTemplate();
-        _mockOrchestrator
-            .Setup(o => o.BuildAsync(
-                It.IsAny<ImageBuildRequest>(),
-                It.IsAny<IProgress<Andy.Containers.Abstractions.Images.BuildProgressEvent>>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BuildResult
-            {
-                BuildId = Guid.NewGuid(),
-                Status = BuildResultStatus.Failed,
-                ErrorCode = "build.failed",
-                ErrorMessage = "Step 5/12 failed",
-                FailureLog = "stderr from the build engine here",
-            });
+        _mockExecutor
+            .Setup(e => e.StartAsync(It.IsAny<ImageBuildRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AsyncBuildHandle(
+                Guid.NewGuid(),
+                AsyncBuildHandleStatus.Failed,
+                new BuildResult
+                {
+                    BuildId = Guid.NewGuid(),
+                    Status = BuildResultStatus.Failed,
+                    ErrorCode = "build.failed",
+                    ErrorMessage = "Step 5/12 failed",
+                    FailureLog = "stderr from the build engine here",
+                }));
 
         var result = await _controller.Build(template.Id, null, CancellationToken.None);
 
@@ -295,12 +296,13 @@ public class ImagesControllerTests : IDisposable
 
         await _controller.Build(template.Id, new BuildRequest(Force: true), CancellationToken.None);
 
-        _mockOrchestrator.Verify(o => o.BuildAsync(
+        // IM9 (#263). Verify against the executor — the controller
+        // delegates to it, not directly to the orchestrator.
+        _mockExecutor.Verify(e => e.StartAsync(
             It.Is<ImageBuildRequest>(r => r.Force == true),
-            It.IsAny<IProgress<Andy.Containers.Abstractions.Images.BuildProgressEvent>>(),
             It.IsAny<CancellationToken>()),
             Times.Once,
-            "the controller's force flag must reach the orchestrator unchanged so the cache short-circuit is bypassed.");
+            "the controller's force flag must reach the executor unchanged so the cache short-circuit is bypassed.");
     }
 
     [Fact]
@@ -310,11 +312,42 @@ public class ImagesControllerTests : IDisposable
 
         await _controller.Build(template.Id, new BuildRequest(RegistryId: "team-zot"), CancellationToken.None);
 
-        _mockOrchestrator.Verify(o => o.BuildAsync(
+        _mockExecutor.Verify(e => e.StartAsync(
             It.Is<ImageBuildRequest>(r => r.RegistryId == "team-zot"),
-            It.IsAny<IProgress<Andy.Containers.Abstractions.Images.BuildProgressEvent>>(),
             It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    // IM9 (#263). Status snapshot endpoint.
+
+    [Fact]
+    public async Task GetBuildStatus_UnknownBuildId_Returns404()
+    {
+        _mockExecutionRegistry.Setup(r => r.TryGet(It.IsAny<Guid>())).Returns((BuildExecutionState?)null);
+
+        var result = await _controller.GetBuildStatus(Guid.NewGuid(), CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetBuildStatus_KnownBuildId_ReturnsState()
+    {
+        var buildId = Guid.NewGuid();
+        var templateId = Guid.NewGuid();
+        _mockExecutionRegistry.Setup(r => r.TryGet(buildId)).Returns(new BuildExecutionState
+        {
+            BuildId = buildId,
+            TemplateId = templateId,
+            Status = BuildExecutionStatus.Running,
+            StartedAt = DateTimeOffset.UtcNow,
+        });
+
+        var result = await _controller.GetBuildStatus(buildId, CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var status = (string)ok.Value!.GetType().GetProperty("status")!.GetValue(ok.Value)!;
+        status.Should().Be("running");
     }
 
     // --- Diff ---

--- a/tests/Andy.Containers.Tests/Infrastructure/Build/Events/AsyncBuildExecutorTests.cs
+++ b/tests/Andy.Containers.Tests/Infrastructure/Build/Events/AsyncBuildExecutorTests.cs
@@ -1,0 +1,185 @@
+using Andy.Containers.Abstractions.Images;
+using Andy.Containers.Infrastructure.Build.Events;
+using Andy.Containers.Storage;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Tests.Infrastructure.Build.Events;
+
+// IM9 (rivoli-ai/andy-containers#263). The executor's contract is
+// thin but load-bearing: cache hits resolve in the request thread,
+// cache misses queue a background task and return immediately. The
+// async path must publish events to the bus and update the
+// registry's terminal state. These tests verify both paths via a
+// mock orchestrator + real registry + real bus.
+public class AsyncBuildExecutorTests
+{
+    [Fact]
+    public async Task StartAsync_CacheHit_ReturnsCachedSynchronously()
+    {
+        var orchestrator = new Mock<IImageBuildOrchestrator>();
+        var hitResult = new BuildResult
+        {
+            BuildId = Guid.NewGuid(),
+            Status = BuildResultStatus.Cached,
+            Digest = "sha256:abc",
+            References = [new BuildResultReference("local-zot", "test", "tag", DateTimeOffset.UtcNow)],
+        };
+        orchestrator.Setup(o => o.TryCacheHitAsync(It.IsAny<ImageBuildRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(hitResult);
+
+        var (executor, _, _) = MakeExecutor(orchestrator.Object);
+
+        var handle = await executor.StartAsync(
+            new ImageBuildRequest(Guid.NewGuid(), null, false, "user"),
+            CancellationToken.None);
+
+        handle.Status.Should().Be(AsyncBuildHandleStatus.Cached);
+        handle.Result.Should().BeSameAs(hitResult,
+            "the cache-hit result is returned directly without copy/transformation.");
+
+        // Crucially: the orchestrator's BuildAsync must NOT have been
+        // invoked — that would have spawned a background build task.
+        orchestrator.Verify(o => o.BuildAsync(
+            It.IsAny<ImageBuildRequest>(),
+            It.IsAny<IProgress<BuildProgressEvent>>(),
+            It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task StartAsync_CacheMiss_QueuesBackgroundBuild()
+    {
+        var orchestrator = new Mock<IImageBuildOrchestrator>();
+        orchestrator.Setup(o => o.TryCacheHitAsync(It.IsAny<ImageBuildRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BuildResult?)null);
+        orchestrator.Setup(o => o.BuildAsync(
+                It.IsAny<ImageBuildRequest>(),
+                It.IsAny<IProgress<BuildProgressEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BuildResult
+            {
+                BuildId = Guid.NewGuid(),
+                Status = BuildResultStatus.Succeeded,
+                Digest = "sha256:built",
+                References = [new BuildResultReference("local-zot", "test", "tag", DateTimeOffset.UtcNow)],
+            });
+
+        var (executor, registry, bus) = MakeExecutor(orchestrator.Object);
+
+        var handle = await executor.StartAsync(
+            new ImageBuildRequest(Guid.NewGuid(), null, false, "user"),
+            CancellationToken.None);
+
+        handle.Status.Should().Be(AsyncBuildHandleStatus.Queued,
+            "cache misses must return immediately with status=queued; the build runs in the background.");
+        handle.Result.Should().BeNull();
+
+        // Wait for the background task to publish its terminal event.
+        await WaitForTerminalAsync(bus, handle.BuildId, TimeSpan.FromSeconds(2));
+
+        var state = registry.TryGet(handle.BuildId);
+        state.Should().NotBeNull();
+        state!.Status.Should().Be(BuildExecutionStatus.Succeeded);
+        state.Digest.Should().Be("sha256:built");
+    }
+
+    [Fact]
+    public async Task StartAsync_OrchestratorThrows_RegistryShowsFailedTerminal()
+    {
+        var orchestrator = new Mock<IImageBuildOrchestrator>();
+        orchestrator.Setup(o => o.TryCacheHitAsync(It.IsAny<ImageBuildRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BuildResult?)null);
+        orchestrator.Setup(o => o.BuildAsync(
+                It.IsAny<ImageBuildRequest>(),
+                It.IsAny<IProgress<BuildProgressEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("backend exploded"));
+
+        var (executor, registry, bus) = MakeExecutor(orchestrator.Object);
+
+        var handle = await executor.StartAsync(
+            new ImageBuildRequest(Guid.NewGuid(), null, false, "user"),
+            CancellationToken.None);
+
+        await WaitForTerminalAsync(bus, handle.BuildId, TimeSpan.FromSeconds(2));
+
+        var state = registry.TryGet(handle.BuildId);
+        state.Should().NotBeNull();
+        state!.Status.Should().Be(BuildExecutionStatus.Failed,
+            "background-task exceptions must surface as Failed terminal state, not silently lose the build.");
+        state.ErrorCode.Should().Be("build.unexpected");
+    }
+
+    [Fact]
+    public async Task StartAsync_ForceTrue_BypassesCacheHitCheck()
+    {
+        var orchestrator = new Mock<IImageBuildOrchestrator>();
+        orchestrator.Setup(o => o.BuildAsync(
+                It.IsAny<ImageBuildRequest>(),
+                It.IsAny<IProgress<BuildProgressEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BuildResult
+            {
+                BuildId = Guid.NewGuid(),
+                Status = BuildResultStatus.Succeeded,
+            });
+
+        var (executor, _, bus) = MakeExecutor(orchestrator.Object);
+
+        var handle = await executor.StartAsync(
+            new ImageBuildRequest(Guid.NewGuid(), null, Force: true, "user"),
+            CancellationToken.None);
+
+        handle.Status.Should().Be(AsyncBuildHandleStatus.Queued);
+
+        // Force=true must skip the TryCacheHitAsync probe entirely.
+        orchestrator.Verify(
+            o => o.TryCacheHitAsync(It.IsAny<ImageBuildRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        await WaitForTerminalAsync(bus, handle.BuildId, TimeSpan.FromSeconds(2));
+    }
+
+    private static (AsyncBuildExecutor, InMemoryBuildExecutionRegistry, InMemoryBuildEventBus) MakeExecutor(
+        IImageBuildOrchestrator orchestrator)
+    {
+        var bus = new InMemoryBuildEventBus();
+        var registry = new InMemoryBuildExecutionRegistry();
+
+        // The executor needs an IServiceScopeFactory so it can spawn
+        // a fresh scope per build. Build a minimal DI tree that
+        // resolves the supplied orchestrator instance.
+        var services = new ServiceCollection();
+        services.AddSingleton(orchestrator);
+        var rootProvider = services.BuildServiceProvider();
+        var scopeFactory = rootProvider.GetRequiredService<IServiceScopeFactory>();
+
+        var lifetime = new ApplicationLifetime(NullLogger<ApplicationLifetime>.Instance);
+
+        var executor = new AsyncBuildExecutor(
+            scopeFactory,
+            bus,
+            registry,
+            lifetime,
+            NullLogger<AsyncBuildExecutor>.Instance);
+        return (executor, registry, bus);
+    }
+
+    private static async Task WaitForTerminalAsync(IBuildEventBus bus, Guid buildId, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        await foreach (var envelope in bus.SubscribeAsync(buildId, null, cts.Token))
+        {
+            if (envelope.Event is BuildCompletedEvent)
+            {
+                return;
+            }
+        }
+    }
+}

--- a/tests/Andy.Containers.Tests/Infrastructure/Build/Events/InMemoryBuildEventBusTests.cs
+++ b/tests/Andy.Containers.Tests/Infrastructure/Build/Events/InMemoryBuildEventBusTests.cs
@@ -1,0 +1,186 @@
+using Andy.Containers.Abstractions.Images;
+using Andy.Containers.Infrastructure.Build.Events;
+using Andy.Containers.Storage;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Tests.Infrastructure.Build.Events;
+
+// IM9 (rivoli-ai/andy-containers#263). The event bus backs the SSE
+// stream; getting it right is the difference between "the user sees
+// build progress" and "the user sees a hung connection." These tests
+// pin the contracts that matter:
+//   - publish + subscribe in publish order
+//   - multiple subscribers all see every event (fan-out)
+//   - a subscriber that attaches mid-build sees buffered history
+//   - Last-Event-ID resumption skips already-seen events
+//   - terminal BuildCompletedEvent closes the stream cleanly
+//   - bus survives a subscriber that walks away mid-stream
+public class InMemoryBuildEventBusTests
+{
+    [Fact]
+    public async Task Publish_DeliversToSingleSubscriber()
+    {
+        using var bus = new InMemoryBuildEventBus();
+        var buildId = Guid.NewGuid();
+
+        var subscribeTask = ConsumeAsync(bus, buildId, lastEventId: null, take: 2);
+
+        // Give the subscription a beat to start before publishing —
+        // the bus's buffer covers ordering, but we want to exercise
+        // the "live publish to attached subscriber" path here too.
+        await Task.Delay(20);
+        bus.Publish(buildId, MakeStdout("hello"));
+        bus.Publish(buildId, MakeCompleted(BuildOutcome.Succeeded));
+
+        var events = await subscribeTask;
+        events.Should().HaveCount(2);
+        events[0].Event.Should().BeOfType<BuildStepStdoutEvent>()
+            .Which.Line.Should().Be("hello");
+        events[1].Event.Should().BeOfType<BuildCompletedEvent>();
+    }
+
+    [Fact]
+    public async Task Subscribe_LateSubscriberSeesBufferedHistory()
+    {
+        using var bus = new InMemoryBuildEventBus();
+        var buildId = Guid.NewGuid();
+
+        bus.Publish(buildId, MakeStdout("first"));
+        bus.Publish(buildId, MakeStdout("second"));
+        bus.Publish(buildId, MakeCompleted(BuildOutcome.Succeeded));
+
+        // Subscribe AFTER the build has completed — the buffer
+        // should replay all three events and then close.
+        var events = await ConsumeAsync(bus, buildId, lastEventId: null, take: 3);
+
+        events.Should().HaveCount(3);
+        events.OfType<BuildEventEnvelope>().Select(e => e.SequenceNumber)
+            .Should().BeInAscendingOrder();
+    }
+
+    [Fact]
+    public async Task Subscribe_LastEventIdSkipsAlreadySeenEvents()
+    {
+        using var bus = new InMemoryBuildEventBus();
+        var buildId = Guid.NewGuid();
+
+        bus.Publish(buildId, MakeStdout("a"));     // seq 1
+        bus.Publish(buildId, MakeStdout("b"));     // seq 2
+        bus.Publish(buildId, MakeStdout("c"));     // seq 3
+        bus.Publish(buildId, MakeCompleted(BuildOutcome.Succeeded)); // seq 4
+
+        // Reconnect with Last-Event-ID = 2 — should see seq 3 + 4
+        // only.
+        var events = await ConsumeAsync(bus, buildId, lastEventId: 2, take: 2);
+
+        events.Select(e => e.SequenceNumber).Should().Equal(3, 4);
+    }
+
+    [Fact]
+    public async Task Subscribe_MultipleSubscribersSeeFanOut()
+    {
+        using var bus = new InMemoryBuildEventBus();
+        var buildId = Guid.NewGuid();
+
+        var firstTask = ConsumeAsync(bus, buildId, lastEventId: null, take: 2);
+        var secondTask = ConsumeAsync(bus, buildId, lastEventId: null, take: 2);
+
+        await Task.Delay(20);
+        bus.Publish(buildId, MakeStdout("everyone gets one"));
+        bus.Publish(buildId, MakeCompleted(BuildOutcome.Succeeded));
+
+        var first = await firstTask;
+        var second = await secondTask;
+
+        first.Should().HaveCount(2);
+        second.Should().HaveCount(2);
+        first.Select(e => e.Event.GetType()).Should().Equal(second.Select(e => e.Event.GetType()));
+    }
+
+    [Fact]
+    public async Task Subscribe_TerminalEventClosesStream()
+    {
+        using var bus = new InMemoryBuildEventBus();
+        var buildId = Guid.NewGuid();
+
+        bus.Publish(buildId, MakeCompleted(BuildOutcome.Succeeded));
+
+        // The subscription should yield the terminal event and
+        // exit — not block forever waiting for more.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var events = new List<BuildEventEnvelope>();
+        await foreach (var envelope in bus.SubscribeAsync(buildId, null, cts.Token))
+        {
+            events.Add(envelope);
+        }
+
+        events.Should().HaveCount(1);
+        events[0].Event.Should().BeOfType<BuildCompletedEvent>();
+        cts.IsCancellationRequested.Should().BeFalse(
+            "the stream must close on its own when the terminal event fires — not because the test cancellation timed out.");
+    }
+
+    [Fact]
+    public async Task Forget_DropsBuildState()
+    {
+        using var bus = new InMemoryBuildEventBus();
+        var buildId = Guid.NewGuid();
+
+        bus.Publish(buildId, MakeStdout("orphan"));
+        bus.Publish(buildId, MakeCompleted(BuildOutcome.Succeeded));
+
+        bus.Forget(buildId);
+
+        // After forget, the buffered history is gone — a fresh
+        // subscription sees nothing until something is published.
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        var events = new List<BuildEventEnvelope>();
+        try
+        {
+            await foreach (var envelope in bus.SubscribeAsync(buildId, null, cts.Token))
+            {
+                events.Add(envelope);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // expected — no events arrived before cancellation.
+        }
+
+        events.Should().BeEmpty(
+            "after Forget, the bus has no record of this build's events.");
+    }
+
+    private static async Task<List<BuildEventEnvelope>> ConsumeAsync(
+        IBuildEventBus bus,
+        Guid buildId,
+        long? lastEventId,
+        int take)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        var events = new List<BuildEventEnvelope>();
+        await foreach (var envelope in bus.SubscribeAsync(buildId, lastEventId, cts.Token))
+        {
+            events.Add(envelope);
+            if (events.Count >= take)
+            {
+                break;
+            }
+        }
+        return events;
+    }
+
+    private static BuildStepStdoutEvent MakeStdout(string line) => new()
+    {
+        Timestamp = DateTimeOffset.UtcNow,
+        StepName = "build",
+        Line = line,
+    };
+
+    private static BuildCompletedEvent MakeCompleted(BuildOutcome outcome) => new()
+    {
+        Timestamp = DateTimeOffset.UtcNow,
+        Outcome = outcome,
+    };
+}


### PR DESCRIPTION
Closes #263. Fourth Phase 1 story for Epic IM (#249), follows IM6/IM7/IM8.

## Summary

Makes builds run **asynchronously** in background tasks and exposes progress via **Server-Sent Events** at `GET /api/images/build/{buildId}/events`. Build callers no longer block in the request thread; the response is a 202 with a buildId the caller can poll (status snapshot) or stream (SSE).

## Pieces

| Type | Role |
|---|---|
| `IBuildEventBus` + `InMemoryBuildEventBus` | In-process pub/sub of `BuildProgressEvent`s keyed by buildId. Per-build ring buffer + per-subscriber bounded channels. Terminal `BuildCompletedEvent` closes all subscribers cleanly. Last-Event-ID resumption. |
| `IBuildExecutionRegistry` + `InMemoryBuildExecutionRegistry` | Process-local registry of build executions. Powers the status-snapshot endpoint. No eviction yet — tracked as follow-up. |
| `IAsyncBuildExecutor` + `AsyncBuildExecutor` | Cache-hit-synchronous, cache-miss-async wrapper. Cache misses spawn `Task.Run` with a fresh DI scope (so the orchestrator's scoped DbContext is per-build). Background-task exceptions surface as Failed terminal state, never lost. |
| `IImageBuildOrchestrator.TryCacheHitAsync` | Cache-only fast path; never invokes the build backend. Lets the executor decide between sync (cached) and async (build) paths without duplicating cache-lookup logic. |
| `GET /api/images/build/{buildId}` | Status snapshot from registry (404 if unknown). |
| `GET /api/images/build/{buildId}/events` | SSE stream. Wire format: `id: <seq>\nevent: <kind>\ndata: <json>\n\n` per envelope. Honours `Last-Event-ID` for reconnection. |

## SSE wire format example

```
id: 1
event: step-start
data: {"stepName":"build","stepIndex":1,"totalSteps":1,"timestamp":"2026-05-07T20:30:01Z"}

id: 2
event: step-stdout
data: {"stepName":"build","line":"Step 1/12 : FROM ubuntu:22.04","timestamp":"2026-05-07T20:30:01Z"}

id: 3
event: complete
data: {"outcome":"Succeeded","digest":"sha256:abc","timestamp":"2026-05-07T20:30:42Z"}
```

The stream closes after the `complete` event. Clients reconnecting with `Last-Event-ID: 2` receive only events 3 onwards (or restart from the oldest buffered event if id 2 has aged out of the ring buffer).

## Behaviour change for callers of `POST /api/images/{templateId}/build`

| Scenario | Before (IM8) | After (IM9) |
|---|---|---|
| Cache hit | 200 OK + `BuildHandle{status:cached, ...}` | Same |
| Build runs | 202 + `BuildHandle{status:succeeded,digest,references}` (synchronous, blocked request) | 202 + `BuildHandle{status:queued, buildId}`. Subscribe to SSE / poll status for completion. |
| Build fails | 503/422 + structured error | Synchronous setup failure same; **build-time failures land as terminal events on the SSE stream + Failed status on the registry**. The HTTP request returns 202 immediately because the failure happens after the response. |

This is the IM5 OpenAPI contract; clients written against the IM5 spec already expect async semantics.

## Tests (15 new, all green)

| Suite | Count | Coverage |
|---|---|---|
| `InMemoryBuildEventBusTests` | 6 | Publish/subscribe order; multi-subscriber fan-out; late-subscriber buffer replay; Last-Event-ID resumption skips already-seen events; terminal event closes the stream cleanly (without test cancellation timing out — that's the contract); `Forget` drops per-build state. |
| `AsyncBuildExecutorTests` | 4 | Cache hit synchronous (`BuildAsync` `Times.Never`); cache miss queues background build that publishes terminal event; throwing orchestrator surfaces Failed terminal state with `build.unexpected` code (background-task exceptions don't get silently swallowed); `Force=true` bypasses the `TryCacheHitAsync` probe entirely. |
| `ImagesControllerTests` reshaped | 5 updated, 2 new | IM8's mockOrchestrator setups replaced with mockExecutor since the controller now delegates to the executor. New tests for `GetBuildStatus` 404 / 200 paths. |

```
dotnet build Andy.Containers.sln                ✅ 0 warn / 0 err
dotnet test tests/Andy.Containers.Tests          ✅ 460 / 460
dotnet test tests/Andy.Containers.Api.Tests      ✅ 937 / 939 (1 pre-existing tmux env failure)
```

## What's deliberately NOT in IM9

- **Persistent build event history** — completed builds are only kept in the in-memory registry/bus. A host restart drops them; an SSE attach for a long-since-completed build will see an empty stream + 404 on the status snapshot. Persistence (or a TTL with grace-period) is a follow-up.
- **Eviction policy on the registry** — every registered build lingers until process restart. Trivially fine for development; needs a TTL/LRU before this scales to high build volume.
- **Cancellation API** — there's no `DELETE /api/images/build/{buildId}` to cancel a running build. The host's `ApplicationStopping` token is wired in (graceful shutdown surfaces as `Cancelled` terminal events) but interactive cancellation is a separate story.

## What's next

- **#264 / IM10** — Pull all error mapping (across IM6's `RegistryUploadException`, IM7's `ImageBuildFailedException`, IM8's orchestrator error codes, IM9's failure status) into a shared `ImageManagementProblemDetailsFactory`. Right now the mapping is scattered across `ImagesController` and the executor.
- **#265 / IM11** — Embedded round-trip integration test against a live zot. With IM9 the SSE stream finally has something interesting to test end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
