### PR TITLE
fix(im11): zot fixture mirrors prod compat config; add real docker-push round-trip

### DIFF
--- a/tests/Andy.Containers.Integration.Tests/RoundTrip/LocalZotAdapterRoundTripTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/RoundTrip/LocalZotAdapterRoundTripTests.cs
@@ -109,6 +109,107 @@ public class LocalZotAdapterRoundTripTests : IClassFixture<ZotContainerFixture>
     }
 
     /// <summary>
+    /// The actual production push path: build a real image, push it
+    /// via <see cref="DockerCliUploader"/> (shells out to
+    /// <c>docker tag</c> + <c>docker push</c>), let the adapter read
+    /// the post-push digest via HEAD. This is what M1.9 builds will
+    /// do; if any step regresses, builds fail with "manifest invalid"
+    /// — the bug rivoli-ai/conductor#1028 fixed by enabling
+    /// <c>http.compat: ["docker2s2"]</c>. The
+    /// <see cref="ZotContainerFixture"/> mirrors that config so the
+    /// test exercises the same path that production runs.
+    /// </summary>
+    [Fact]
+    public async Task PushPath_DockerCliUploaderToRealZot()
+    {
+        if (!_zot.IsAvailable)
+        {
+            return;
+        }
+
+        var contextDir = Directory.CreateTempSubdirectory("im11-pushpath-").FullName;
+        var localTag = $"andy-containers-im11-push-{Guid.NewGuid():N}";
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(contextDir, "Dockerfile"),
+                "FROM hello-world\n");
+
+            // --provenance / --sbom off — the BuildKit attached
+            // manifests confuse OCI-strict registries even when
+            // compat is enabled. Production uses these flags too.
+            await RunDockerCliAsync([
+                "buildx", "build",
+                "--provenance=false", "--sbom=false",
+                "--output=type=docker",
+                "-t", localTag,
+                contextDir,
+            ]);
+
+            using var http = new HttpClient { BaseAddress = new Uri(_zot.BaseUrl) };
+            var adapter = new LocalZotAdapter(
+                http,
+                new DockerCliUploader(NullLogger<DockerCliUploader>.Instance),
+                NullLogger<LocalZotAdapter>.Instance,
+                registryId: "test-zot");
+
+            var artifact = new BuildArtifact(
+                Digest: string.Empty,
+                MediaType: "application/vnd.docker.distribution.manifest.v2+json",
+                SizeBytes: 0,
+                SpecHash: "sha256:test-spec-pushpath",
+                LocalReference: localTag);
+
+            var reference = await adapter.PushAsync(
+                artifact,
+                repoPath: "im11-push",
+                tag: "v1",
+                CancellationToken.None);
+
+            reference.Digest.Should().StartWith("sha256:",
+                "the post-push HEAD must yield Docker-Content-Digest from zot.");
+
+            (await adapter.ExistsAsync("im11-push", reference.Digest, CancellationToken.None))
+                .Should().BeTrue("the manifest just pushed must be reachable by digest.");
+
+            var refs = await adapter.ListReferencesAsync("im11-push", CancellationToken.None);
+            refs.Should().ContainSingle()
+                .Which.Digest.Should().Be(reference.Digest);
+
+            await RunDockerCliAsync(["rmi", "-f", localTag]);
+        }
+        finally
+        {
+            try { Directory.Delete(contextDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    private static async Task RunDockerCliAsync(string[] args)
+    {
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "docker",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+        using var proc = new System.Diagnostics.Process { StartInfo = psi };
+        proc.Start();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+        await proc.StandardOutput.ReadToEndAsync();
+        await proc.WaitForExitAsync();
+        if (proc.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"docker {string.Join(' ', args)} exited {proc.ExitCode}: {await stderrTask}");
+        }
+    }
+
+    /// <summary>
     /// Push a minimal valid OCI image manifest to zot via the
     /// OCI Distribution v1.1 protocol. Returns the digests so the
     /// caller can assert against them.

--- a/tests/Andy.Containers.Integration.Tests/TestSupport/ZotContainerFixture.cs
+++ b/tests/Andy.Containers.Integration.Tests/TestSupport/ZotContainerFixture.cs
@@ -35,6 +35,7 @@ public sealed class ZotContainerFixture : IAsyncLifetime
 
     public bool IsAvailable { get; private set; }
     public string BaseUrl { get; private set; } = "http://localhost:5050";
+    private string? _configPath;
 
     public async Task InitializeAsync()
     {
@@ -53,10 +54,36 @@ public sealed class ZotContainerFixture : IAsyncLifetime
         };
         var image = $"ghcr.io/project-zot/zot-minimal-linux-{arch}:{ZotImageVersion}";
 
+        // Materialise a zot config that mirrors what Conductor's
+        // bundled config.template.json ships — most importantly
+        // http.compat: ["docker2s2"], without which zot v2.1+ rejects
+        // Docker manifest v2 with HTTP 415. Without that flag the
+        // production push path (DockerCliUploader → docker push) would
+        // fail in the round-trip tests below; rivoli-ai/conductor#1028
+        // is the matching fix on Conductor's side.
+        _configPath = Path.Combine(
+            Path.GetTempPath(),
+            $"zot-config-{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(
+            _configPath,
+            """
+            {
+              "distSpecVersion": "1.1.1",
+              "storage": { "rootDirectory": "/var/lib/registry" },
+              "http": {
+                "address": "0.0.0.0",
+                "port": "5000",
+                "compat": ["docker2s2"]
+              },
+              "log": { "level": "info" }
+            }
+            """);
+
         var run = await RunDockerAsync(
             "run", "-d",
             "-p", $"{_hostPort}:5000",
             "--rm",
+            "-v", $"{_configPath}:/etc/zot/config.json:ro",
             image);
         if (run.ExitCode != 0)
         {
@@ -88,17 +115,25 @@ public sealed class ZotContainerFixture : IAsyncLifetime
 
     private async Task StopAsync()
     {
-        if (_containerId is null) return;
-        try
+        if (_containerId is not null)
         {
-            await RunDockerAsync("kill", _containerId);
+            try
+            {
+                await RunDockerAsync("kill", _containerId);
+            }
+            catch (Exception)
+            {
+                // Best-effort cleanup; if `docker kill` fails the
+                // --rm flag still tears the container down on exit.
+            }
+            _containerId = null;
         }
-        catch (Exception)
+
+        if (_configPath is not null)
         {
-            // Best-effort cleanup; if `docker kill` fails the
-            // --rm flag still tears the container down on exit.
+            try { File.Delete(_configPath); } catch { /* best-effort */ }
+            _configPath = null;
         }
-        _containerId = null;
     }
 
     private async Task<bool> DockerIsHealthyAsync()


### PR DESCRIPTION
Closes the two IM11-deferred follow-ups noted in #271's PR description.

## Root cause investigation

The IM11 round-trip test (#271) had to fall back to direct OCI HTTP populate because **`docker push` failed against zot with `manifest invalid`** — blobs uploaded fine, but the manifest PUT came back HTTP 415. zot's logs revealed:

```
"method":"PUT","path":"/v2/foo/manifests/v1","statusCode":415,
"Content-Type":["application/vnd.docker.distribution.manifest.v2+json"]
```

**zot v2.1+ rejects Docker manifest v2 by default.** `http.compat: [\"docker2s2\"]` is required to accept it. Without that flag, every M1.9 build's `docker push` step would fail in production.

## Two fixes

### 1. Fixture mirrors production config

`ZotContainerFixture` now bind-mounts a config that matches what Conductor's bundled `scripts/zot/config.template.json` ships (after the matching Conductor fix in **rivoli-ai/conductor#1028**). The test fixture and production config stay in sync; what M1.9 builds encounter at runtime is what the tests exercise.

### 2. Real docker-push round-trip

New test `PushPath_DockerCliUploaderToRealZot` exercises the **actual production path**:

```
docker buildx build (hello-world base, --provenance/sbom off)
  → DockerCliUploader (docker tag + docker push)
  → LocalZotAdapter (post-push HEAD reads Docker-Content-Digest)
  → ExistsAsync + ListReferencesAsync confirm the manifest landed
```

This is the missing layer between the IM11 OCI-HTTP-populate test (which proved the read-side works) and what production code actually does.

## Test results

```
Andy.Containers.Integration.Tests.RoundTrip.LocalZotAdapterRoundTripTests
  ✅ ExistsListDelete_AgainstRealZot           [125 ms]   (OCI HTTP populate)
  ✅ ListReferencesAsync_EmptyForUnknownRepo    [  7 ms]
  ✅ PushPath_DockerCliUploaderToRealZot        [  4 s]   ← NEW

Total: 3/3 in 6.4s including fixture boot.
```

## Coordinated PRs

| Repo | PR | Role |
|---|---|---|
| `rivoli-ai/conductor` | #1028 | Adds `http.compat: ["docker2s2"]` to bundled config + regression test |
| `rivoli-ai/andy-containers` | **this PR** | Mirrors the same compat config in test fixture + adds real docker-push round-trip |

Both must merge for M1.9 to work end-to-end. The Conductor fix is the production fix; this PR is the test that proves the production fix actually works.

## What's still deferred

The third follow-up from IM11 — WebApplicationFactory<Program>-based HTTP integration test for the full register → build → SSE pipeline — is intentionally not in this PR. That's a heavier piece of work (`Program.cs`'s host config pulls in auth, DataProtection, NATS) that warrants its own story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)