### PR TITLE
#278: GET /api/images, by-digest, DELETE references — IM5 missing endpoints

### DIFF
--- a/src/Andy.Containers.Api/Controllers/ImagesController.cs
+++ b/src/Andy.Containers.Api/Controllers/ImagesController.cs
@@ -24,6 +24,7 @@ public class ImagesController : ControllerBase
     private readonly IAsyncBuildExecutor _executor;
     private readonly IBuildEventBus _eventBus;
     private readonly IBuildExecutionRegistry _executionRegistry;
+    private readonly IBuildArtifactStore _artifactStore;
 
     public ImagesController(
         ContainersDbContext db,
@@ -34,7 +35,8 @@ public class ImagesController : ControllerBase
         IImageBuildOrchestrator orchestrator,
         IAsyncBuildExecutor executor,
         IBuildEventBus eventBus,
-        IBuildExecutionRegistry executionRegistry)
+        IBuildExecutionRegistry executionRegistry,
+        IBuildArtifactStore artifactStore)
     {
         _db = db;
         _manifestService = manifestService;
@@ -45,6 +47,7 @@ public class ImagesController : ControllerBase
         _executor = executor;
         _eventBus = eventBus;
         _executionRegistry = executionRegistry;
+        _artifactStore = artifactStore;
     }
 
     [RequirePermission("image:read")]
@@ -397,6 +400,141 @@ public class ImagesController : ControllerBase
             return StatusCode(500, new { Error = ex.Message });
         }
     }
+
+    // ----- #278 IM5 endpoints (digest-anchored artifact list/get/untag) -----
+
+    /// <summary>
+    /// #278. <c>GET /api/images</c>. Lists `BuildArtifact` rows.
+    ///
+    /// Distinct from the existing <see cref="List(Guid, Guid?, CancellationToken)"/>
+    /// which is the legacy template-keyed `ContainerImage` listing — this
+    /// endpoint walks `BuildArtifactEntity` (the digest-anchored row that
+    /// IM3 introduced) and returns the IM5 OpenAPI `BuildArtifactList`
+    /// shape `{ items, totalCount }`.
+    ///
+    /// The `marker` query parameter is declared by the OpenAPI spec but
+    /// not yet honoured: there is no `Markers` column on
+    /// <c>BuildArtifactEntity</c> today. When marker support lands the
+    /// filter wires here without a contract change.
+    /// </summary>
+    [RequirePermission("image:read")]
+    [HttpGet]
+    public async Task<IActionResult> ListArtifacts(
+        [FromQuery] Guid? templateId,
+        [FromQuery] string? registryId,
+        [FromQuery] string? marker,
+        [FromQuery] int skip = 0,
+        [FromQuery] int take = 20,
+        CancellationToken ct = default)
+    {
+        // Cap the page size to keep one user from accidentally pulling
+        // a 100k-row payload.
+        take = Math.Clamp(take, 1, 100);
+        skip = Math.Max(0, skip);
+
+        if (!string.IsNullOrWhiteSpace(marker))
+        {
+            // No `Markers` column on BuildArtifactEntity yet; refuse the
+            // filter rather than silently returning unfiltered results.
+            return BadRequest(new ImageManagementErrorBody
+            {
+                Code = "image.list.marker.unsupported",
+                Message = "marker filter is declared in the OpenAPI but not yet implemented; tracked as a follow-up to #278.",
+            });
+        }
+
+        var (items, total) = await _artifactStore.ListAsync(
+            templateId: templateId,
+            registryId: registryId,
+            skip: skip,
+            take: take,
+            ct: ct);
+        return Ok(new BuildArtifactListResponse(
+            Items: items.Select(BuildArtifactResponse.From).ToArray(),
+            TotalCount: total));
+    }
+
+    /// <summary>
+    /// #278. <c>GET /api/images/by-digest/{digest}</c>. Returns the
+    /// single artifact for an OCI manifest digest, or 404 if no
+    /// artifact has been registered for it.
+    ///
+    /// The digest is taken verbatim from the path. ASP.NET routing
+    /// accepts the colon inside the path segment per RFC 3986 §3.3 —
+    /// callers do not need to percent-encode the `sha256:` prefix.
+    /// </summary>
+    [RequirePermission("image:read")]
+    [HttpGet("by-digest/{digest}")]
+    public async Task<IActionResult> GetByDigest(string digest, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(digest))
+        {
+            return BadRequest(new ImageManagementErrorBody
+            {
+                Code = "image.digest.required",
+                Message = "digest path segment is required.",
+            });
+        }
+
+        var entity = await _artifactStore.GetByDigestAsync(digest, ct);
+        if (entity is null)
+        {
+            return ImageManagementProblemDetailsFactory.NotFound(
+                code: "image.not-found",
+                message: $"No artifact for digest '{digest}'.");
+        }
+        return Ok(BuildArtifactResponse.From(entity));
+    }
+
+    /// <summary>
+    /// #278. <c>DELETE /api/images/by-digest/{digest}/references/{referenceId}</c>.
+    /// Removes one `(registryId, repoPath, tag)` reference.
+    ///
+    /// Idempotent — already-gone references return 204 too.
+    /// `image:delete` (the existing RBAC permission for image deletion)
+    /// gates the action; the IM5 OpenAPI calls this an admin-only
+    /// operation so non-admins are rejected by the RBAC layer.
+    ///
+    /// Does NOT delete the underlying artifact bytes; registry-side
+    /// garbage collection reclaims those when no reference points at
+    /// the digest. The artifact row stays in the DB so the digest
+    /// remains a stable audit anchor.
+    /// </summary>
+    [RequirePermission("image:delete")]
+    [HttpDelete("by-digest/{digest}/references/{referenceId:guid}")]
+    public async Task<IActionResult> Untag(string digest, Guid referenceId, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(digest))
+        {
+            return BadRequest(new ImageManagementErrorBody
+            {
+                Code = "image.digest.required",
+                Message = "digest path segment is required.",
+            });
+        }
+
+        // Resolve the artifact first so we can verify the reference
+        // actually belongs to this digest. A request for
+        // /by-digest/sha256:A/references/<id-of-ref-to-sha256:B> should
+        // 404, not silently delete the wrong row.
+        var artifact = await _artifactStore.GetByDigestAsync(digest, ct);
+        if (artifact is null)
+        {
+            return ImageManagementProblemDetailsFactory.NotFound(
+                code: "image.not-found",
+                message: $"No artifact for digest '{digest}'.");
+        }
+
+        var reference = artifact.References.FirstOrDefault(r => r.Id == referenceId);
+        if (reference is null)
+        {
+            // Idempotent: already-gone is not an error.
+            return NoContent();
+        }
+
+        await _artifactStore.RemoveReferenceAsync(referenceId, ct);
+        return NoContent();
+    }
 }
 
 public record BuildRequest(
@@ -404,3 +542,82 @@ public record BuildRequest(
     bool Force = false,
     Guid? OrganizationId = null,
     string? RegistryId = null);
+
+// ----- #278 IM5 response DTOs -----
+
+/// <summary>
+/// IM5 OpenAPI <c>BuildArtifact</c> shape. Distinct from the abstraction
+/// <see cref="Andy.Containers.Abstractions.Images.BuildArtifact"/> record
+/// which carries fewer fields (no templateId, no references list).
+/// </summary>
+public sealed record BuildArtifactResponse(
+    string Digest,
+    string MediaType,
+    long SizeBytes,
+    string SpecHash,
+    Guid TemplateId,
+    string? BuildBackendId,
+    string? BuiltBy,
+    DateTime BuiltAt,
+    IReadOnlyList<BuildArtifactReferenceResponse> References,
+    IReadOnlyDictionary<string, object>? Markers)
+{
+    public static BuildArtifactResponse From(Andy.Containers.Models.ImageManagement.BuildArtifactEntity entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        return new BuildArtifactResponse(
+            Digest: entity.Digest,
+            MediaType: entity.MediaType,
+            SizeBytes: entity.SizeBytes,
+            SpecHash: entity.SpecHash,
+            TemplateId: entity.TemplateId,
+            BuildBackendId: entity.BuildBackendId,
+            BuiltBy: entity.BuiltBy,
+            BuiltAt: entity.BuiltAt,
+            References: entity.References.Select(BuildArtifactReferenceResponse.From).ToArray(),
+            // No `Markers` column today — null until a future migration
+            // adds one. Conductor's Swift client treats this field as
+            // optional.
+            Markers: null);
+    }
+}
+
+/// <summary>
+/// IM5 OpenAPI <c>BuildArtifactReference</c> shape. The on-disk
+/// <see cref="Andy.Containers.Models.ImageManagement.RegistryReferenceEntity"/>
+/// does not carry the artifact's digest itself (it foreign-keys the
+/// owning artifact); the response shape needs the digest for the
+/// reference-side surface, so the mapper from the parent
+/// <see cref="BuildArtifactResponse.From(Andy.Containers.Models.ImageManagement.BuildArtifactEntity)"/>
+/// supplies it indirectly via the parent envelope.
+/// </summary>
+public sealed record BuildArtifactReferenceResponse(
+    Guid Id,
+    string RegistryId,
+    string RepoPath,
+    string Tag,
+    string? Digest,
+    DateTime PushedAt,
+    string PushedBy)
+{
+    public static BuildArtifactReferenceResponse From(Andy.Containers.Models.ImageManagement.RegistryReferenceEntity entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        return new BuildArtifactReferenceResponse(
+            Id: entity.Id,
+            RegistryId: entity.RegistryId,
+            RepoPath: entity.RepoPath,
+            Tag: entity.Tag,
+            // RegistryReferenceEntity doesn't store the digest directly
+            // — it's reachable via the BuildArtifact navigation property
+            // when populated. Leave as null when not loaded; consumers
+            // (per the IM5 OpenAPI) treat it as nullable.
+            Digest: entity.BuildArtifact?.Digest,
+            PushedAt: entity.PushedAt,
+            PushedBy: entity.PushedBy);
+    }
+}
+
+public sealed record BuildArtifactListResponse(
+    IReadOnlyList<BuildArtifactResponse> Items,
+    int TotalCount);

--- a/src/Andy.Containers.Infrastructure/Data/BuildArtifactStore.cs
+++ b/src/Andy.Containers.Infrastructure/Data/BuildArtifactStore.cs
@@ -95,4 +95,38 @@ public sealed class BuildArtifactStore : IBuildArtifactStore
             .ToListAsync(ct)
             .ConfigureAwait(false);
     }
+
+    public async Task<(IReadOnlyList<BuildArtifactEntity> Items, int TotalCount)> ListAsync(
+        Guid? templateId,
+        string? registryId,
+        int skip,
+        int take,
+        CancellationToken ct)
+    {
+        // Build the filtered query once; reuse for the count + page so
+        // a paged response with totalCount mirrors what an unfiltered
+        // SELECT COUNT(*) WHERE … would produce.
+        var query = _db.BuildArtifacts.AsQueryable();
+        if (templateId.HasValue)
+        {
+            query = query.Where(b => b.TemplateId == templateId.Value);
+        }
+        if (!string.IsNullOrWhiteSpace(registryId))
+        {
+            // Match artifacts whose reference set includes the registry.
+            // The translation lands as an EXISTS subquery in the
+            // generated SQL.
+            query = query.Where(b => b.References.Any(r => r.RegistryId == registryId));
+        }
+
+        var total = await query.CountAsync(ct).ConfigureAwait(false);
+        var items = await query
+            .OrderByDescending(b => b.BuiltAt)
+            .Skip(Math.Max(0, skip))
+            .Take(Math.Max(0, take))
+            .Include(b => b.References)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+        return (items, total);
+    }
 }

--- a/src/Andy.Containers/Storage/IBuildArtifactStore.cs
+++ b/src/Andy.Containers/Storage/IBuildArtifactStore.cs
@@ -64,4 +64,22 @@ public interface IBuildArtifactStore
     Task<IReadOnlyList<RegistryReferenceEntity>> ListReferencesAsync(
         Guid artifactId,
         CancellationToken ct);
+
+    /// <summary>
+    /// #278. Paged list of artifacts with optional filters. Used by
+    /// <c>GET /api/images</c>. References are eagerly loaded so the
+    /// IM5 <c>BuildArtifact.references</c> field can be populated in
+    /// the response without a per-row N+1.
+    /// </summary>
+    /// <param name="templateId">Restrict to artifacts owned by this template; null = no filter.</param>
+    /// <param name="registryId">Restrict to artifacts that have at least one reference in this registry; null = no filter.</param>
+    /// <param name="skip">Pagination offset.</param>
+    /// <param name="take">Page size.</param>
+    /// <returns>Page of artifacts and the total matching count (for the same filter, ignoring skip/take).</returns>
+    Task<(IReadOnlyList<BuildArtifactEntity> Items, int TotalCount)> ListAsync(
+        Guid? templateId,
+        string? registryId,
+        int skip,
+        int take,
+        CancellationToken ct);
 }

--- a/tests/Andy.Containers.Api.Tests/Controllers/ImagesControllerIm5Tests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ImagesControllerIm5Tests.cs
@@ -1,0 +1,324 @@
+using Andy.Containers.Api.Controllers;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models.ImageManagement;
+using Andy.Containers.Storage;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Controllers;
+
+/// <summary>
+/// #278. Coverage for the IM5 digest-anchored artifact endpoints
+/// added on top of <see cref="ImagesController"/>:
+///
+/// - <c>GET /api/images</c> — paged list with optional filters
+/// - <c>GET /api/images/by-digest/{digest}</c> — single artifact lookup
+/// - <c>DELETE /api/images/by-digest/{digest}/references/{referenceId}</c> — untag
+///
+/// The legacy template-keyed `ContainerImage` endpoints stay covered by
+/// <see cref="ImagesControllerTests"/>; this file focuses purely on
+/// the new BuildArtifact-keyed surface.
+/// </summary>
+public class ImagesControllerIm5Tests : IDisposable
+{
+    private readonly ContainersDbContext _db;
+    private readonly Mock<IBuildArtifactStore> _mockArtifactStore;
+    private readonly ImagesController _controller;
+
+    public ImagesControllerIm5Tests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+        _mockArtifactStore = new Mock<IBuildArtifactStore>();
+
+        var mockCurrentUser = new Mock<ICurrentUserService>();
+        mockCurrentUser.Setup(u => u.GetUserId()).Returns("test-user");
+        mockCurrentUser.Setup(u => u.IsAdmin()).Returns(true);
+        mockCurrentUser.Setup(u => u.IsAuthenticated()).Returns(true);
+        var mockOrg = new Mock<IOrganizationMembershipService>();
+
+        _controller = new ImagesController(
+            _db,
+            new Mock<IImageManifestService>().Object,
+            new Mock<IImageDiffService>().Object,
+            mockCurrentUser.Object,
+            mockOrg.Object,
+            new Mock<IImageBuildOrchestrator>().Object,
+            new Mock<IAsyncBuildExecutor>().Object,
+            new Mock<IBuildEventBus>().Object,
+            new Mock<IBuildExecutionRegistry>().Object,
+            _mockArtifactStore.Object);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    // -------------------------------------------------------------
+    // GET /api/images
+    // -------------------------------------------------------------
+
+    [Fact]
+    public async Task ListArtifacts_ReturnsPagedShape()
+    {
+        var templateId = Guid.NewGuid();
+        var artifact = MakeArtifact(templateId, digest: "sha256:abc");
+        artifact.References.Add(MakeReference("local-zot", "code/test", "v1"));
+
+        _mockArtifactStore.Setup(s => s.ListAsync(null, null, 0, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<BuildArtifactEntity> { artifact }, 1));
+
+        var result = await _controller.ListArtifacts(
+            templateId: null,
+            registryId: null,
+            marker: null,
+            skip: 0,
+            take: 20,
+            ct: CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var page = ok.Value.Should().BeOfType<BuildArtifactListResponse>().Subject;
+        page.TotalCount.Should().Be(1);
+        page.Items.Should().HaveCount(1);
+        var item = page.Items[0];
+        item.Digest.Should().Be("sha256:abc");
+        item.TemplateId.Should().Be(templateId);
+        item.References.Should().HaveCount(1, "the IM5 BuildArtifact shape carries the references list inline.");
+    }
+
+    [Fact]
+    public async Task ListArtifacts_PassesFiltersToStore()
+    {
+        var templateId = Guid.NewGuid();
+        _mockArtifactStore.Setup(s => s.ListAsync(templateId, "local-zot", 5, 10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<BuildArtifactEntity>(), 0))
+            .Verifiable();
+
+        var result = await _controller.ListArtifacts(
+            templateId: templateId,
+            registryId: "local-zot",
+            marker: null,
+            skip: 5,
+            take: 10,
+            ct: CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>();
+        _mockArtifactStore.Verify();
+    }
+
+    [Fact]
+    public async Task ListArtifacts_ClampsTakeToMax()
+    {
+        // Take is clamped to 100 to keep a single request from pulling
+        // arbitrary amounts of data. Anything above gets capped silently
+        // — callers paginate normally and the contract still holds.
+        _mockArtifactStore.Setup(s => s.ListAsync(null, null, 0, 100, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<BuildArtifactEntity>(), 0))
+            .Verifiable();
+
+        var result = await _controller.ListArtifacts(null, null, null, skip: 0, take: 5000, ct: CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>();
+        _mockArtifactStore.Verify();
+    }
+
+    [Fact]
+    public async Task ListArtifacts_NegativeSkipNormalisesToZero()
+    {
+        _mockArtifactStore.Setup(s => s.ListAsync(null, null, 0, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<BuildArtifactEntity>(), 0))
+            .Verifiable();
+
+        var result = await _controller.ListArtifacts(null, null, null, skip: -10, take: 20, ct: CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>();
+        _mockArtifactStore.Verify();
+    }
+
+    [Fact]
+    public async Task ListArtifacts_MarkerFilter_ReturnsBadRequest()
+    {
+        // marker is OpenAPI-declared but not yet implemented. Refuse
+        // explicitly so callers don't get unfiltered results back and
+        // mistake them for a marker match.
+        var result = await _controller.ListArtifacts(
+            templateId: null,
+            registryId: null,
+            marker: "baked-assistants:claude-code",
+            skip: 0,
+            take: 20,
+            ct: CancellationToken.None);
+
+        var bad = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var body = bad.Value.Should().BeOfType<ImageManagementErrorBody>().Subject;
+        body.Code.Should().Be("image.list.marker.unsupported");
+    }
+
+    // -------------------------------------------------------------
+    // GET /api/images/by-digest/{digest}
+    // -------------------------------------------------------------
+
+    [Fact]
+    public async Task GetByDigest_ReturnsArtifact()
+    {
+        var templateId = Guid.NewGuid();
+        var artifact = MakeArtifact(templateId, digest: "sha256:abc");
+        artifact.References.Add(MakeReference("local-zot", "code/test", "v1"));
+
+        _mockArtifactStore.Setup(s => s.GetByDigestAsync("sha256:abc", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(artifact);
+
+        var result = await _controller.GetByDigest("sha256:abc", CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = ok.Value.Should().BeOfType<BuildArtifactResponse>().Subject;
+        response.Digest.Should().Be("sha256:abc");
+        response.References.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task GetByDigest_NotFoundShape_Is404WithImageManagementError()
+    {
+        _mockArtifactStore.Setup(s => s.GetByDigestAsync("sha256:nope", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BuildArtifactEntity?)null);
+
+        var result = await _controller.GetByDigest("sha256:nope", CancellationToken.None);
+
+        var notFound = result.Should().BeOfType<ObjectResult>().Subject;
+        notFound.StatusCode.Should().Be(404);
+        var body = notFound.Value.Should().BeOfType<ImageManagementErrorBody>().Subject;
+        body.Code.Should().Be("image.not-found");
+    }
+
+    [Fact]
+    public async Task GetByDigest_EmptyDigestPath_Returns400()
+    {
+        var result = await _controller.GetByDigest("", CancellationToken.None);
+        var bad = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var body = bad.Value.Should().BeOfType<ImageManagementErrorBody>().Subject;
+        body.Code.Should().Be("image.digest.required");
+    }
+
+    // -------------------------------------------------------------
+    // DELETE /api/images/by-digest/{digest}/references/{referenceId}
+    // -------------------------------------------------------------
+
+    [Fact]
+    public async Task Untag_RemovesReferenceAndReturns204()
+    {
+        var templateId = Guid.NewGuid();
+        var refId = Guid.NewGuid();
+        var artifact = MakeArtifact(templateId, digest: "sha256:abc");
+        var reference = MakeReference("local-zot", "code/test", "v1");
+        reference.Id = refId;
+        artifact.References.Add(reference);
+
+        _mockArtifactStore.Setup(s => s.GetByDigestAsync("sha256:abc", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(artifact);
+        _mockArtifactStore.Setup(s => s.RemoveReferenceAsync(refId, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+
+        var result = await _controller.Untag("sha256:abc", refId, CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+        _mockArtifactStore.Verify();
+    }
+
+    [Fact]
+    public async Task Untag_AlreadyGoneReference_IsIdempotent204()
+    {
+        var refId = Guid.NewGuid();
+        var artifact = MakeArtifact(Guid.NewGuid(), digest: "sha256:abc");
+        // No reference with the requested id on this artifact.
+
+        _mockArtifactStore.Setup(s => s.GetByDigestAsync("sha256:abc", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(artifact);
+
+        var result = await _controller.Untag("sha256:abc", refId, CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>(
+            "removing an already-gone reference is not an error per the IM5 OpenAPI.");
+        _mockArtifactStore.Verify(s => s.RemoveReferenceAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never,
+            "no DB write should fire when the reference doesn't exist on the artifact.");
+    }
+
+    [Fact]
+    public async Task Untag_DigestNotFound_Returns404()
+    {
+        var refId = Guid.NewGuid();
+        _mockArtifactStore.Setup(s => s.GetByDigestAsync("sha256:nope", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BuildArtifactEntity?)null);
+
+        var result = await _controller.Untag("sha256:nope", refId, CancellationToken.None);
+
+        var notFound = result.Should().BeOfType<ObjectResult>().Subject;
+        notFound.StatusCode.Should().Be(404);
+        var body = notFound.Value.Should().BeOfType<ImageManagementErrorBody>().Subject;
+        body.Code.Should().Be("image.not-found");
+    }
+
+    [Fact]
+    public async Task Untag_RefBelongsToDifferentDigest_Returns204_WithoutDelete()
+    {
+        // Defence in depth: a request shaped as
+        // /by-digest/sha256:A/references/<id-of-ref-on-sha256:B> should
+        // NOT silently delete the wrong reference. The artifact for
+        // sha256:A is loaded; the reference id isn't in its References
+        // collection; we 204 (idempotent) and skip the store call.
+        var refId = Guid.NewGuid();
+        var artifactA = MakeArtifact(Guid.NewGuid(), digest: "sha256:A");
+        // refId belongs to a different artifact, so it's NOT in artifactA.References.
+
+        _mockArtifactStore.Setup(s => s.GetByDigestAsync("sha256:A", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(artifactA);
+
+        var result = await _controller.Untag("sha256:A", refId, CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+        _mockArtifactStore.Verify(s => s.RemoveReferenceAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Untag_EmptyDigest_Returns400()
+    {
+        var result = await _controller.Untag("", Guid.NewGuid(), CancellationToken.None);
+        var bad = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var body = bad.Value.Should().BeOfType<ImageManagementErrorBody>().Subject;
+        body.Code.Should().Be("image.digest.required");
+    }
+
+    // -------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------
+
+    private static BuildArtifactEntity MakeArtifact(Guid templateId, string digest)
+    {
+        return new BuildArtifactEntity
+        {
+            Id = Guid.NewGuid(),
+            Digest = digest,
+            MediaType = "application/vnd.oci.image.manifest.v1+json",
+            SizeBytes = 1234,
+            SpecHash = "sha256:" + new string('s', 64),
+            TemplateId = templateId,
+            BuildBackendId = "local-docker",
+            BuiltBy = "test-user",
+            BuiltAt = DateTime.UtcNow,
+        };
+    }
+
+    private static RegistryReferenceEntity MakeReference(string registryId, string repoPath, string tag)
+    {
+        return new RegistryReferenceEntity
+        {
+            Id = Guid.NewGuid(),
+            RegistryId = registryId,
+            RepoPath = repoPath,
+            Tag = tag,
+            PushedAt = DateTime.UtcNow,
+            PushedBy = "test-user",
+        };
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Controllers/ImagesControllerSseTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ImagesControllerSseTests.cs
@@ -51,6 +51,7 @@ public class ImagesControllerSseTests : IDisposable
         var mockOrg = new Mock<IOrganizationMembershipService>();
         var mockOrchestrator = new Mock<IImageBuildOrchestrator>();
         var mockExecutor = new Mock<IAsyncBuildExecutor>();
+        var mockArtifactStore = new Mock<IBuildArtifactStore>();
 
         _controller = new ImagesController(
             _db,
@@ -61,7 +62,8 @@ public class ImagesControllerSseTests : IDisposable
             mockOrchestrator.Object,
             mockExecutor.Object,
             _bus,
-            _registry);
+            _registry,
+            mockArtifactStore.Object);
     }
 
     public void Dispose()

--- a/tests/Andy.Containers.Api.Tests/Controllers/ImagesControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ImagesControllerTests.cs
@@ -23,6 +23,7 @@ public class ImagesControllerTests : IDisposable
     private readonly Mock<IAsyncBuildExecutor> _mockExecutor;
     private readonly Mock<IBuildEventBus> _mockEventBus;
     private readonly Mock<IBuildExecutionRegistry> _mockExecutionRegistry;
+    private readonly Mock<IBuildArtifactStore> _mockArtifactStore;
     private readonly ImagesController _controller;
 
     public ImagesControllerTests()
@@ -62,6 +63,7 @@ public class ImagesControllerTests : IDisposable
                 new AsyncBuildHandle(Guid.NewGuid(), AsyncBuildHandleStatus.Queued, null));
         _mockEventBus = new Mock<IBuildEventBus>();
         _mockExecutionRegistry = new Mock<IBuildExecutionRegistry>();
+        _mockArtifactStore = new Mock<IBuildArtifactStore>();
 
         _controller = new ImagesController(
             _db,
@@ -72,7 +74,8 @@ public class ImagesControllerTests : IDisposable
             _mockOrchestrator.Object,
             _mockExecutor.Object,
             _mockEventBus.Object,
-            _mockExecutionRegistry.Object);
+            _mockExecutionRegistry.Object,
+            _mockArtifactStore.Object);
     }
 
     public void Dispose() => _db.Dispose();


### PR DESCRIPTION
## Summary

Phase-1 gap. The IM5 OpenAPI declared 3 image-management endpoints that the controller didn't implement:

| Verb | Path | Returns |
|---|---|---|
| GET | `/api/images` | Paged `BuildArtifactList` with `templateId` / `registryId` filters |
| GET | `/api/images/by-digest/{digest}` | Single `BuildArtifact` by OCI digest |
| DELETE | `/api/images/by-digest/{digest}/references/{referenceId}` | Untag (idempotent) |

Without these, Conductor (and CLI / MCP) can kick off builds but never list, inspect, or untag the artifacts they produce. Surfaced by Conductor #1042 (PR-E E2E suite) which had to ship a register-only test scope because the rest of the IM5 round-trip didn't exist server-side.

## Changes

- **`IBuildArtifactStore.ListAsync(templateId, registryId, skip, take, ct)`** added to the storage port + EF implementation. EXISTS subquery for the registryId filter; eagerly loads References to avoid N+1.
- **`ImagesController` constructor** gains `IBuildArtifactStore` and three new actions:
  - `[HttpGet] ListArtifacts` — `image:read`. `take` clamped to [1, 100]; `skip` clamped to ≥ 0.
  - `[HttpGet("by-digest/{digest}")] GetByDigest` — `image:read`. 404 with `image.not-found` body shape on miss.
  - `[HttpDelete("by-digest/{digest}/references/{referenceId:guid}")] Untag` — `image:delete` (matches existing RBAC seed; closest to OpenAPI's "admin-only"). Idempotent: missing reference returns 204. Defence-in-depth: verifies the reference actually belongs to the requested digest before deleting.
- **Response DTOs** `BuildArtifactResponse` / `BuildArtifactReferenceResponse` / `BuildArtifactListResponse` matching the IM5 wire shape. Distinct from the abstraction-layer `BuildArtifact` record (which carries fewer fields).
- **`marker` query param**: declared in OpenAPI but `BuildArtifactEntity` has no Markers column today. Refused with 400 `image.list.marker.unsupported` rather than silently returning unfiltered results — wires through cleanly when the column lands.

## Test plan

- [x] **12 new tests in `ImagesControllerIm5Tests`** covering: paged shape, filter passthrough, take clamp, skip normalisation, marker rejection, by-digest happy path + 404 + empty-digest, untag happy path + idempotent + 404 + cross-digest defence + empty-digest.
- [x] **Existing `ImagesControllerTests` (29) + `ImagesControllerSseTests` (9) updated** to inject the new `IBuildArtifactStore` mock; all still pass.
- [x] **Local end-to-end probes** against bundled stack:
  ```
  $ curl http://localhost:9100/containers/api/images
  → 200 {"items":[],"totalCount":0}
  $ curl http://localhost:9100/containers/api/images?marker=foo
  → 400 {"code":"image.list.marker.unsupported", …}
  $ curl http://localhost:9100/containers/api/images/by-digest/sha256:0…
  → 404 {"code":"image.not-found", …}
  $ curl -X DELETE …/by-digest/sha256:0…/references/<uuid>
  → 404 {"code":"image.not-found", …}
  ```

Closes #278. Conductor's `ContainerImagesService.listImages` / `image(digest:)` / `untag` (already implemented in conductor#1036) become callable end-to-end once this lands. Conductor PR E (#1042) can also expand its slimmed test suite to the full register → build → drain → list → fetch → untag walk-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)