### PR TITLE
feat(rivoli-ai/conductor#944): inject ANDY_SERVICE_TOKEN + ANDY_PROXY_BASE_URL into containers

### DIFF
--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -23,6 +23,7 @@ public class ContainerOrchestrationService : IContainerService
     private readonly IApiKeyService _apiKeyService;
     private readonly IConfiguration _configuration;
     private readonly ILogger<ContainerOrchestrationService> _logger;
+    private readonly IServiceTokenService? _serviceTokenService;
 
     /// <summary>
     /// Conductor #878. Default per-user simultaneous-container
@@ -41,7 +42,8 @@ public class ContainerOrchestrationService : IContainerService
         IGitRepositoryProbeService probeService,
         IApiKeyService apiKeyService,
         IConfiguration configuration,
-        ILogger<ContainerOrchestrationService> logger)
+        ILogger<ContainerOrchestrationService> logger,
+        IServiceTokenService? serviceTokenService = null)
     {
         _db = db;
         _routing = routing;
@@ -51,6 +53,10 @@ public class ContainerOrchestrationService : IContainerService
         _apiKeyService = apiKeyService;
         _configuration = configuration;
         _logger = logger;
+        // #944. Optional so existing tests (which don't construct one)
+        // keep working; live DI always supplies the registered impl.
+        // When null, the per-container token-injection step is a no-op.
+        _serviceTokenService = serviceTokenService;
     }
 
     /// <summary>
@@ -424,6 +430,48 @@ public class ContainerOrchestrationService : IContainerService
             envVars ??= new Dictionary<string, string>();
             foreach (var kv in request.EnvironmentVariables.Where(kv => !envVars.ContainsKey(kv.Key)))
                 envVars[kv.Key] = kv.Value;
+        }
+
+        // #944. Inject the proxy URL + service token so a code
+        // assistant installed inside the container can authenticate
+        // against andy-models without the user supplying a token.
+        // Both are best-effort: a missing config or a token-mint
+        // failure logs a warning and the container still starts.
+        // User-supplied env vars (above) win — if a caller already
+        // set ANDY_PROXY_BASE_URL or ANDY_SERVICE_TOKEN explicitly,
+        // we don't overwrite.
+        var containerFacingProxyUrl = _configuration.GetValue<string?>("Proxy:ContainerFacingBaseUrl");
+        if (!string.IsNullOrWhiteSpace(containerFacingProxyUrl))
+        {
+            envVars ??= new Dictionary<string, string>();
+            if (!envVars.ContainsKey("ANDY_PROXY_BASE_URL"))
+            {
+                envVars["ANDY_PROXY_BASE_URL"] = containerFacingProxyUrl;
+                _logger.LogInformation("Injecting ANDY_PROXY_BASE_URL={Url} into container env",
+                    UrlRedactor.Redact(containerFacingProxyUrl));
+            }
+        }
+        if (_serviceTokenService is not null && (envVars is null || !envVars.ContainsKey("ANDY_SERVICE_TOKEN")))
+        {
+            try
+            {
+                var serviceToken = await _serviceTokenService.GetAccessTokenAsync(ct);
+                envVars ??= new Dictionary<string, string>();
+                envVars["ANDY_SERVICE_TOKEN"] = serviceToken;
+                _logger.LogInformation("Injected ANDY_SERVICE_TOKEN (length={Length}) into container env",
+                    serviceToken.Length);
+            }
+            catch (Exception tokenEx)
+            {
+                // Don't fail container creation. The container will
+                // start without a service token; an assistant inside
+                // it that tries to call andy-models will hit a 401
+                // and the user can still configure a personal API
+                // key via the existing apiKey resolution path.
+                _logger.LogWarning(tokenEx,
+                    "Failed to mint service token for container {ContainerName}; container will start without ANDY_SERVICE_TOKEN.",
+                    container.Name);
+            }
         }
 
         // X4: profile-driven overrides. When a profile is bound, its

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTokenInjectionTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTokenInjectionTests.cs
@@ -1,0 +1,252 @@
+using Andy.Containers.Abstractions;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+/// <summary>
+/// #944 / M1.5.2. Coverage of `ANDY_SERVICE_TOKEN` + `ANDY_PROXY_BASE_URL`
+/// env-var injection performed by
+/// <see cref="ContainerOrchestrationService.CreateContainerAsync"/>.
+/// Asserts on the queued <see cref="ContainerProvisionJob"/>'s
+/// `EnvironmentVariables` because that's what the worker hands to
+/// the infrastructure provider's `CreateContainerAsync`.
+/// </summary>
+public class ContainerOrchestrationServiceTokenInjectionTests : IDisposable
+{
+    private readonly ContainersDbContext _db;
+    private readonly Mock<IInfrastructureRoutingService> _mockRouting = new();
+    private readonly Mock<IInfrastructureProviderFactory> _mockFactory = new();
+    private readonly Mock<IInfrastructureProvider> _mockInfra = new();
+    private readonly ContainerProvisioningQueue _queue = new();
+    private readonly Mock<IGitRepositoryProbeService> _mockProbe = new();
+
+    public ContainerOrchestrationServiceTokenInjectionTests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+        _mockFactory.Setup(f => f.GetProvider(It.IsAny<InfrastructureProvider>()))
+            .Returns(_mockInfra.Object);
+        _mockProbe.Setup(p => p.ProbeRepositoriesAsync(It.IsAny<IReadOnlyList<GitRepositoryConfig>>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<string>());
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    // -----------------------------------------------------------------
+    // Happy paths
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateContainer_WhenProxyUrlAndTokenServiceConfigured_InjectsBothEnvVars()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+        var config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Proxy:ContainerFacingBaseUrl"] = "http://host.docker.internal:9100",
+        });
+        var tokenService = new StubTokenService("test-jwt-bearer");
+        var service = MakeService(config, tokenService);
+
+        var request = new CreateContainerRequest
+        {
+            Name = "with-andy-env",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+        };
+        await service.CreateContainerAsync(request, CancellationToken.None);
+
+        var job = await ReadEnqueuedJobAsync();
+        var env = job.EnvironmentVariables;
+        env.Should().NotBeNull();
+        env!["ANDY_PROXY_BASE_URL"].Should().Be("http://host.docker.internal:9100");
+        env["ANDY_SERVICE_TOKEN"].Should().Be("test-jwt-bearer");
+    }
+
+    [Fact]
+    public async Task CreateContainer_NoProxyUrl_DoesNotInjectAndyProxyBaseUrl()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+        var config = BuildConfig(new Dictionary<string, string?>());
+        // Token still injects (independent of Proxy URL).
+        var tokenService = new StubTokenService("token-only");
+        var service = MakeService(config, tokenService);
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "no-proxy",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+        }, CancellationToken.None);
+
+        var job = await ReadEnqueuedJobAsync();
+        job.EnvironmentVariables.Should().NotBeNull();
+        job.EnvironmentVariables.Should().NotContainKey("ANDY_PROXY_BASE_URL");
+        job.EnvironmentVariables!["ANDY_SERVICE_TOKEN"].Should().Be("token-only");
+    }
+
+    [Fact]
+    public async Task CreateContainer_NoTokenService_StillSetsProxyUrl()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+        var config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Proxy:ContainerFacingBaseUrl"] = "http://host.docker.internal:9100",
+        });
+        // No token service registered.
+        var service = MakeService(config, tokenService: null);
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "no-token-service",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+        }, CancellationToken.None);
+
+        var job = await ReadEnqueuedJobAsync();
+        job.EnvironmentVariables.Should().NotBeNull();
+        job.EnvironmentVariables!["ANDY_PROXY_BASE_URL"].Should().Be("http://host.docker.internal:9100");
+        job.EnvironmentVariables.Should().NotContainKey("ANDY_SERVICE_TOKEN");
+    }
+
+    // -----------------------------------------------------------------
+    // Failure path: token mint throws
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateContainer_TokenMintFails_ContainerStillCreatedWithoutToken()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+        var config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Proxy:ContainerFacingBaseUrl"] = "http://host.docker.internal:9100",
+        });
+        var tokenService = new StubTokenService(throwException: new ServiceTokenException("auth unreachable"));
+        var service = MakeService(config, tokenService);
+
+        // The container creation must NOT fail just because the
+        // token endpoint is down — that would be a single point of
+        // failure on every container creation.
+        var container = await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "mint-fails",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+        }, CancellationToken.None);
+
+        container.Status.Should().Be(ContainerStatus.Pending);
+
+        var job = await ReadEnqueuedJobAsync();
+        job.EnvironmentVariables.Should().NotBeNull();
+        job.EnvironmentVariables!["ANDY_PROXY_BASE_URL"].Should().Be("http://host.docker.internal:9100");
+        job.EnvironmentVariables.Should().NotContainKey("ANDY_SERVICE_TOKEN");
+    }
+
+    // -----------------------------------------------------------------
+    // User-supplied env vars take precedence
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateContainer_UserSetAndyProxyBaseUrl_DoesNotOverride()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+        var config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Proxy:ContainerFacingBaseUrl"] = "http://default-proxy:9100",
+        });
+        var tokenService = new StubTokenService("default-token");
+        var service = MakeService(config, tokenService);
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "user-overrides",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            EnvironmentVariables = new Dictionary<string, string>
+            {
+                ["ANDY_PROXY_BASE_URL"] = "http://user-supplied:1234",
+                ["ANDY_SERVICE_TOKEN"] = "user-supplied-token",
+            },
+        }, CancellationToken.None);
+
+        var job = await ReadEnqueuedJobAsync();
+        job.EnvironmentVariables!["ANDY_PROXY_BASE_URL"].Should().Be("http://user-supplied:1234",
+                "explicit user-supplied env vars must win — otherwise the user can't escape the default for testing.");
+        job.EnvironmentVariables["ANDY_SERVICE_TOKEN"].Should().Be("user-supplied-token");
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private async Task<(ContainerTemplate template, InfrastructureProvider provider)> SeedTemplateAndProvider()
+    {
+        var template = new ContainerTemplate
+        {
+            Code = "tok-test",
+            Name = "Token Test",
+            Version = "1.0.0",
+            BaseImage = "ubuntu:24.04",
+        };
+        var provider = new InfrastructureProvider
+        {
+            Code = "tok-provider",
+            Name = "Provider",
+            Type = ProviderType.Docker,
+            IsEnabled = true,
+        };
+        _db.Templates.Add(template);
+        _db.Providers.Add(provider);
+        await _db.SaveChangesAsync();
+        return (template, provider);
+    }
+
+    private static IConfiguration BuildConfig(IDictionary<string, string?> values)
+        => new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    private ContainerOrchestrationService MakeService(IConfiguration configuration, IServiceTokenService? tokenService)
+    {
+        return new ContainerOrchestrationService(
+            _db,
+            _mockRouting.Object,
+            _mockFactory.Object,
+            _queue,
+            _mockProbe.Object,
+            new Mock<IApiKeyService>().Object,
+            configuration,
+            NullLogger<ContainerOrchestrationService>.Instance,
+            tokenService);
+    }
+
+    private async Task<ContainerProvisionJob> ReadEnqueuedJobAsync()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        return await _queue.Reader.ReadAsync(cts.Token);
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IServiceTokenService"/> stub: returns a fixed
+    /// token, or throws the supplied exception. Avoids dragging in
+    /// Moq just for one method.
+    /// </summary>
+    private sealed class StubTokenService : IServiceTokenService
+    {
+        private readonly string? _token;
+        private readonly Exception? _exception;
+
+        public StubTokenService(string token) { _token = token; }
+        public StubTokenService(Exception throwException) { _exception = throwException; }
+
+        public Task<string> GetAccessTokenAsync(CancellationToken ct = default)
+            => _exception is not null
+                ? Task.FromException<string>(_exception)
+                : Task.FromResult(_token!);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the consumer-side wiring for the M2M flow shipped in #284. With this, every Conductor-launched container starts with:

\`\`\`
ANDY_PROXY_BASE_URL=http://host.docker.internal:9100  # if configured
ANDY_SERVICE_TOKEN=<bearer>                            # if mintable
\`\`\`

A code assistant installed inside the container (rivoli-ai/conductor#502, rivoli-ai/conductor#1047) can hit `$ANDY_PROXY_BASE_URL/models` with `Authorization: Bearer $ANDY_SERVICE_TOKEN` and the chat surface works end-to-end without the user having to configure anything.

## Changes

- `ContainerOrchestrationService` takes an optional `IServiceTokenService` (nullable so existing tests keep building without rewiring; live DI always supplies the impl).
- In `CreateContainerAsync`, after the existing API-key + user env-var resolution, two new injection steps:
  1. Read `Proxy:ContainerFacingBaseUrl` from `IConfiguration`. If set, add `ANDY_PROXY_BASE_URL` to the container env.
  2. If a token service is available, mint via `GetAccessTokenAsync` and add `ANDY_SERVICE_TOKEN`. Best-effort — a mint failure logs a warning and the container starts without the token; the existing apiKey resolution path still works as a manual fallback.
- Explicit user-supplied env vars (via `CreateContainerRequest.EnvironmentVariables`) always win over our defaults — escape hatch for testing.

## What this PR does not do (follow-ups)

- **Token persistence + refresh** for long-lived containers. The token is minted once at creation; restart carries the same (now-expired) env var. Documented as a known limitation.
- **Conductor-side config**: the embedded andy-containers needs `Proxy__ContainerFacingBaseUrl` + `ServiceAuth__*` env vars injected from `ContainersServiceConfig`. **Companion conductor PR ships immediately after this lands.**
- **Provider-specific host URLs**: `host.docker.internal` only works on Docker Desktop. Apple Containers / Linux Docker need different URLs. The Conductor-side config picks the right one; this PR is provider-agnostic.

## Test plan

- [x] **5 new tests in `ContainerOrchestrationServiceTokenInjectionTests`** covering: happy path, no proxy URL → only token injects, no token service → only proxy URL injects, token mint throws → container creation still succeeds, user-supplied env var wins.
- [x] Full `ContainerOrchestrationService` suite re-run: **54/54 pass** (49 existing + 5 new). The optional-parameter constructor change kept all existing tests green without touching them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)