### PR TITLE
docs(rivoli-ai/conductor#1052): note service-token TTL limitation in IServiceTokenService

### DIFF
--- a/src/Andy.Containers.Api/Services/IServiceTokenService.cs
+++ b/src/Andy.Containers.Api/Services/IServiceTokenService.cs
@@ -6,7 +6,7 @@ namespace Andy.Containers.Api.Services;
 /// <c>/connect/token</c> endpoint via the OAuth 2.0
 /// <c>client_credentials</c> grant.
 ///
-/// Used by future container-side wiring (#944 follow-up) to inject an
+/// Used by container-side wiring (#285) to inject an
 /// <c>ANDY_SERVICE_TOKEN</c> env var into provisioned containers so a
 /// code assistant running inside the container can authenticate
 /// against <c>andy-models</c> (and any other Conductor-backed service)
@@ -15,6 +15,17 @@ namespace Andy.Containers.Api.Services;
 /// The implementation caches the most recently minted token until it
 /// is within <see cref="ServiceTokenService.RefreshSkew"/> of expiry,
 /// at which point the next call mints a fresh one.
+///
+/// <para>
+/// <strong>Known limitation — long-lived containers (rivoli-ai/conductor#1052):</strong>
+/// the token here refreshes inside the andy-containers process, but
+/// the value baked into a container's env at provisioning time
+/// (<c>ANDY_SERVICE_TOKEN</c>) does NOT auto-refresh. Containers
+/// running longer than the OAuth client's <c>AccessTokenLifetime</c>
+/// (OpenIddict default: 1 hour) hold a stale JWT until restart.
+/// rivoli-ai/conductor#1052 tracks the full design for in-container
+/// refresh (sidecar / token-file mount / credential helper).
+/// </para>
 /// </summary>
 public interface IServiceTokenService
 {


### PR DESCRIPTION
## Summary

Pure-doc change. Adds a `<para>` block to `IServiceTokenService`'s docstring noting that the container-side `ANDY_SERVICE_TOKEN` env var is minted once at provisioning and not auto-refreshed — containers running longer than the OAuth client's `AccessTokenLifetime` (OpenIddict default: 1 hour) hold a stale JWT until restart. Links to rivoli-ai/conductor#1052 where the full design options are tracked (sidecar refresh / token-file mount / credential helper / longer client-side TTL).

## Why doc-only

The actual fix is multi-component infrastructure work:
- Either bumping the per-client `AccessTokenLifetime` on andy-auth's manifest (cross-repo, risk-trade-off discussion).
- Or building a refresh worker + bind-mount path on andy-containers (provider-specific testing).
- Or shipping a credential-helper shim alongside every assistant.

rivoli-ai/conductor#1052 captures the design with a recommendation. This PR is the in-code beacon so the limitation is visible to anyone reading the service interface.

## Test plan

- [x] Build clean (`dotnet build src/Andy.Containers.Api/Andy.Containers.Api.csproj`).
- [x] No behaviour change → no test changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)