### PR TITLE
fix(rivoli-ai/conductor#944): drop `scp:` prefix from token-request scope

### DIFF
--- a/src/Andy.Containers.Api/Services/ServiceTokenService.cs
+++ b/src/Andy.Containers.Api/Services/ServiceTokenService.cs
@@ -108,7 +108,15 @@ public sealed class ServiceTokenService : IServiceTokenService, IDisposable
         };
         if (!string.IsNullOrWhiteSpace(opts.Audience))
         {
-            form["scope"] = $"scp:{opts.Audience}";
+            // The `scope` request parameter takes the unprefixed scope
+            // name (== the audience, the way andy-auth's seeder
+            // registers it via `OpenIddictScopeDescriptor.Name = audience`).
+            // The `scp:` prefix is reserved for the client-side
+            // *permission* on the OpenIddict application descriptor
+            // (`Permissions.Add("scp:urn:andy-containers-api")`), not
+            // the request body. Sending `scp:urn:…` here gets
+            // rejected as `invalid_scope` (OpenIddict ID2052).
+            form["scope"] = opts.Audience;
         }
 
         using var request = new HttpRequestMessage(HttpMethod.Post, opts.TokenEndpoint)

--- a/tests/Andy.Containers.Api.Tests/Services/ServiceTokenServiceTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ServiceTokenServiceTests.cs
@@ -59,8 +59,9 @@ public class ServiceTokenServiceTests
         body.Should().Contain("grant_type=client_credentials");
         body.Should().Contain("client_id=andy-containers-api");
         body.Should().Contain("client_secret=s3cret");
-        body.Should().Contain("scope=scp%3Aurn%3Aandy-containers-api",
-            "audience-as-scope is the OpenIddict shape this codebase uses for service tokens.");
+        body.Should().Contain("scope=urn%3Aandy-containers-api",
+            "request scope is the unprefixed audience; the `scp:` prefix is for client-side permissions only. " +
+            "Sending `scp:` in the request body returns `invalid_scope` (OpenIddict ID2052).");
     }
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

`ServiceTokenService.MintAsync` was sending `scope=scp:urn:andy-containers-api` in the `client_credentials` request body. andy-auth (OpenIddict) rejected it with `invalid_scope` (ID2052). Containers started with `ANDY_SERVICE_TOKEN=""` — the warning was logged but the empty env var was indistinguishable from "not configured" to anything reading inside the container.

**Root cause**: the `scp:` prefix is reserved for the **client-side permission** in the OpenIddict application descriptor (`Permissions.Add("scp:urn:andy-containers-api")` = "this client may request the urn:andy-containers-api scope"). The **request scope name** is the unprefixed audience, the way andy-auth seeds it: `OpenIddictScopeDescriptor.Name = audience`.

**Fix**: send `scope=urn:andy-containers-api`. OpenIddict matches against the seeded scope name AND the client's own permission and mints the token.

## Verified end-to-end

After the fix, a freshly-launched container has:

```
PROXY=http://host.docker.internal:9100
TOKEN_LEN=925
TOKEN_HEAD=eyJhbGciOiJSUzI1NiIsImtpZCI6Ij…
```

…and from inside the container:

```
$ curl -H "Authorization: Bearer $ANDY_SERVICE_TOKEN" $ANDY_PROXY_BASE_URL/models/health
HTTP/1.1 200 No Error
{"status":"healthy", …}
```

The assistant runtime path (#944 + #285 + conductor#1050) is fully working end-to-end with this fix.

## Test plan

- [x] 8/8 tests in `ServiceTokenServiceTests` pass after the assertion was updated from `scope=scp%3A…` to `scope=urn%3A…`.
- [x] Live smoke test (above) confirms a real token mint + bearer-auth request through the unified proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)