### PR TITLE
fix(rivoli-ai/conductor#944): drop `scp:` prefix from token-request scope

### DIFF
--- a/src/Andy.Containers.Api/Services/ServiceTokenService.cs
+++ b/src/Andy.Containers.Api/Services/ServiceTokenService.cs
@@ -108,7 +108,15 @@ public sealed class ServiceTokenService : IServiceTokenService, IDisposable
         };
         if (!string.IsNullOrWhiteSpace(opts.Audience))
         {
-            form["scope"] = $"scp:{opts.Audience}";
+            // The `scope` request parameter takes the unprefixed scope
+            // name (== the audience, the way andy-auth's seeder
+            // registers it via `OpenIddictScopeDescriptor.Name = audience`).
+            // The `scp:` prefix is reserved for the client-side
+            // *permission* on the OpenIddict application descriptor
+            // (`Permissions.Add("scp:urn:andy-containers-api")`), not
+            // the request body. Sending `scp:urn:…` here gets
+            // rejected as `invalid_scope` (OpenIddict ID2052).
+            form["scope"] = opts.Audience;
         }
 
         using var request = new HttpRequestMessage(HttpMethod.Post, opts.TokenEndpoint)

--- a/tests/Andy.Containers.Api.Tests/Services/ServiceTokenServiceTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ServiceTokenServiceTests.cs
@@ -59,8 +59,9 @@ public class ServiceTokenServiceTests
         body.Should().Contain("grant_type=client_credentials");
         body.Should().Contain("client_id=andy-containers-api");
         body.Should().Contain("client_secret=s3cret");
-        body.Should().Contain("scope=scp%3Aurn%3Aandy-containers-api",
-            "audience-as-scope is the OpenIddict shape this codebase uses for service tokens.");
+        body.Should().Contain("scope=urn%3Aandy-containers-api",
+            "request scope is the unprefixed audience; the `scp:` prefix is for client-side permissions only. " +
+            "Sending `scp:` in the request body returns `invalid_scope` (OpenIddict ID2052).");
     }
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `ServiceTokenService.MintAsync` was sending `scope=scp:urn:andy-containers-api`; OpenIddict rejected as `invalid_scope` (ID2052). Containers started with `ANDY_SERVICE_TOKEN=""`.
- The `scp:` prefix is for the client-side **permission** descriptor (`Permissions.Add("scp:urn:andy-containers-api")`), not the request body. The request scope is the unprefixed audience, the way andy-auth seeds it (`OpenIddictScopeDescriptor.Name = audience`).
- Fix: send `scope=urn:andy-containers-api`. Token mints, container env var is populated, bearer calls through unified proxy succeed.

## Verified end-to-end

After the fix, a freshly-launched container has a 925-char bearer in `ANDY_SERVICE_TOKEN`, and from inside the container:

```
$ curl -H "Authorization: Bearer \$ANDY_SERVICE_TOKEN" \$ANDY_PROXY_BASE_URL/models/health
HTTP/1.1 200
{"status":"healthy", …}
```

The assistant runtime path (rivoli-ai/conductor#944 + #285 + rivoli-ai/conductor#1050) is fully working end-to-end with this fix.

## Test plan

- [x] 8/8 `ServiceTokenServiceTests` pass after assertion update from `scope=scp%3A…` to `scope=urn%3A…`
- [x] Live smoke: real token mint + bearer-auth request through unified proxy returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)