### PR TITLE
feat(rivoli-ai/conductor#943): ContainerOrchestrationService mints per-container proxy token

### DIFF
--- a/config/registration.json
+++ b/config/registration.json
@@ -26,7 +26,13 @@
       "displayName": "Andy Containers API",
       "description": "Service-to-service client for Andy Containers (M2M token consumer for #944).",
       "grantTypes": ["authorization_code", "refresh_token", "client_credentials"],
-      "scopes": ["email", "profile", "roles", "scp:urn:andy-containers-api"]
+      "scopes": [
+        "email",
+        "profile",
+        "roles",
+        "scp:urn:andy-containers-api",
+        "scp:urn:andy-models-api"
+      ]
     },
     "webClient": {
       "clientId": "andy-containers-web",

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -104,6 +104,18 @@ try
     builder.Services.AddHttpClient(ServiceTokenService.HttpClientName);
     builder.Services.AddSingleton<IServiceTokenService, ServiceTokenService>();
 
+    // rivoli-ai/conductor#943 (M1.5.1). Per-container proxy-token
+    // consumer. Talks to andy-models'
+    // `POST /api/proxy/tokens` (M1.3.3) using the M2M bearer from
+    // IServiceTokenService and returns a JWT scoped to the container's
+    // requested model slugs. ContainerOrchestrationService injects that
+    // JWT into the container as ANDY_SERVICE_TOKEN — narrower than the
+    // M2M bearer the orchestrator carries itself.
+    builder.Services.Configure<AndyModelsOptions>(
+        builder.Configuration.GetSection(AndyModelsOptions.SectionName));
+    builder.Services.AddHttpClient(AndyModelsProxyTokenService.HttpClientName);
+    builder.Services.AddSingleton<IProxyTokenService, AndyModelsProxyTokenService>();
+
     // Container provisioning queue + background worker
     builder.Services.AddSingleton<ContainerProvisioningQueue>();
     builder.Services.AddHostedService<ContainerProvisioningWorker>();

--- a/src/Andy.Containers.Api/Services/AndyModelsProxyTokenService.cs
+++ b/src/Andy.Containers.Api/Services/AndyModelsProxyTokenService.cs
@@ -1,0 +1,265 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// rivoli-ai/conductor#943 (M1.5.1). <see cref="IProxyTokenService"/>
+/// implementation that talks to andy-models'
+/// <c>POST /api/proxy/tokens</c> (M1.3.3) and
+/// <c>DELETE /api/proxy/tokens/{id}</c> via an authenticated
+/// <see cref="HttpClient"/> using the M2M bearer from
+/// <see cref="IServiceTokenService"/>.
+/// </summary>
+public sealed class AndyModelsProxyTokenService : IProxyTokenService
+{
+    /// <summary>Named HttpClient registered in DI. Tests can override.</summary>
+    public const string HttpClientName = "AndyModelsProxyTokensClient";
+
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly IServiceTokenService _serviceTokens;
+    private readonly IOptions<AndyModelsOptions> _options;
+    private readonly ILogger<AndyModelsProxyTokenService> _logger;
+
+    public AndyModelsProxyTokenService(
+        IHttpClientFactory httpFactory,
+        IServiceTokenService serviceTokens,
+        IOptions<AndyModelsOptions> options,
+        ILogger<AndyModelsProxyTokenService> logger)
+    {
+        _httpFactory = httpFactory;
+        _serviceTokens = serviceTokens;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task<MintedProxyToken?> MintForContainerAsync(
+        string containerId,
+        string subjectId,
+        IReadOnlyList<string> allowedSlugs,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(containerId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subjectId);
+        ArgumentNullException.ThrowIfNull(allowedSlugs);
+
+        if (allowedSlugs.Count == 0)
+        {
+            // No slugs → no proxy token. Caller (orchestration service)
+            // treats this as "this container does its own auth".
+            return null;
+        }
+
+        var opts = _options.Value;
+        if (string.IsNullOrWhiteSpace(opts.BaseUrl))
+        {
+            throw new ProxyTokenException(
+                "AndyModels:BaseUrl is not configured. Cannot mint per-container proxy tokens.");
+        }
+
+        var bearer = await GetBearerAsync(ct).ConfigureAwait(false);
+        var http = _httpFactory.CreateClient(HttpClientName);
+
+        // Resolve against the configured base. Path matches the
+        // controller's [Route("api/proxy/tokens")] in andy-models.
+        var url = CombinePathStrict(opts.BaseUrl!, "api/proxy/tokens");
+        using var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = JsonContent.Create(new MintProxyTokenRequest(
+                ContainerId: containerId,
+                SubjectId: subjectId,
+                AllowedSlugs: allowedSlugs,
+                LifetimeSeconds: opts.TokenLifetimeSeconds)),
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await http.SendAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new ProxyTokenException(
+                $"andy-models unreachable at {url}", ex);
+        }
+        using var _ = response;
+        if (!response.IsSuccessStatusCode)
+        {
+            var preview = await SafeReadPreviewAsync(response, ct).ConfigureAwait(false);
+            throw new ProxyTokenException(
+                $"andy-models returned HTTP {(int)response.StatusCode} for token mint. Body preview: {preview}");
+        }
+
+        MintProxyTokenResponse? parsed;
+        try
+        {
+            parsed = await response.Content
+                .ReadFromJsonAsync<MintProxyTokenResponse>(ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new ProxyTokenException(
+                "andy-models response for token mint was not valid JSON.", ex);
+        }
+        if (parsed is null
+            || string.IsNullOrWhiteSpace(parsed.Jwt)
+            || parsed.TokenId == Guid.Empty)
+        {
+            throw new ProxyTokenException(
+                "andy-models response for token mint is missing tokenId or jwt.");
+        }
+
+        _logger.LogInformation(
+            "Minted proxy token {TokenId} for container {ContainerId} (subject {SubjectId}, slugs {Slugs}, expiresAt {ExpiresAt})",
+            parsed.TokenId, containerId, subjectId, string.Join(",", allowedSlugs), parsed.ExpiresAt);
+
+        return new MintedProxyToken(parsed.TokenId, parsed.Jwt, parsed.ExpiresAt);
+    }
+
+    public async Task RevokeAsync(Guid tokenId, CancellationToken ct = default)
+    {
+        if (tokenId == Guid.Empty)
+        {
+            // Nothing to revoke. Caller should not pass empty but
+            // guard anyway — we don't want to round-trip to andy-models
+            // for a no-op.
+            return;
+        }
+
+        var opts = _options.Value;
+        if (string.IsNullOrWhiteSpace(opts.BaseUrl))
+        {
+            _logger.LogWarning(
+                "AndyModels:BaseUrl is not configured; cannot revoke proxy token {TokenId}.",
+                tokenId);
+            return;
+        }
+
+        string bearer;
+        try
+        {
+            bearer = await GetBearerAsync(ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to obtain service bearer for revoke of proxy token {TokenId}; token will expire naturally.",
+                tokenId);
+            return;
+        }
+
+        var http = _httpFactory.CreateClient(HttpClientName);
+        var url = CombinePathStrict(opts.BaseUrl!, $"api/proxy/tokens/{tokenId}");
+        using var request = new HttpRequestMessage(HttpMethod.Delete, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+
+        try
+        {
+            using var response = await http.SendAsync(request, ct).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                var preview = await SafeReadPreviewAsync(response, ct).ConfigureAwait(false);
+                _logger.LogWarning(
+                    "andy-models returned HTTP {Status} for revoke of proxy token {TokenId}. Body preview: {Body}",
+                    (int)response.StatusCode, tokenId, preview);
+            }
+            else
+            {
+                _logger.LogInformation("Revoked proxy token {TokenId}", tokenId);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Transport error revoking proxy token {TokenId}; token will expire naturally.",
+                tokenId);
+        }
+    }
+
+    private async Task<string> GetBearerAsync(CancellationToken ct)
+    {
+        try
+        {
+            return await _serviceTokens.GetAccessTokenAsync(ct).ConfigureAwait(false);
+        }
+        catch (ServiceTokenException ex)
+        {
+            throw new ProxyTokenException(
+                "Could not obtain andy-containers service bearer to call andy-models. " +
+                "Check ServiceAuth:* configuration.", ex);
+        }
+    }
+
+    /// <summary>
+    /// Combine <paramref name="baseUrl"/> + <paramref name="path"/>
+    /// without losing a path prefix on the base (e.g. embedded mode
+    /// where the base is <c>http://localhost:9100/models</c>). The
+    /// out-of-the-box <see cref="Uri"/> constructor with a relative
+    /// path drops the base path; we use an explicit join instead.
+    /// </summary>
+    private static string CombinePathStrict(string baseUrl, string relativePath)
+    {
+        var b = baseUrl.TrimEnd('/');
+        var p = relativePath.TrimStart('/');
+        return $"{b}/{p}";
+    }
+
+    private static async Task<string> SafeReadPreviewAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            var raw = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            return raw.Length <= 200 ? raw : raw[..200] + "…";
+        }
+        catch
+        {
+            return "<failed to read response body>";
+        }
+    }
+
+    // Wire shapes — names match andy-models'
+    // Andy.Models.Api.Controllers.ProxyTokensController. Kept private
+    // and JSON-only; we do not depend on a shared package.
+
+    private sealed record MintProxyTokenRequest(
+        [property: JsonPropertyName("containerId")] string ContainerId,
+        [property: JsonPropertyName("subjectId")] string SubjectId,
+        [property: JsonPropertyName("allowedSlugs")] IReadOnlyList<string> AllowedSlugs,
+        [property: JsonPropertyName("lifetimeSeconds")] int? LifetimeSeconds);
+
+    private sealed record MintProxyTokenResponse(
+        [property: JsonPropertyName("tokenId")] Guid TokenId,
+        [property: JsonPropertyName("jwt")] string Jwt,
+        [property: JsonPropertyName("expiresAt")] DateTimeOffset ExpiresAt);
+}
+
+/// <summary>
+/// Bound from <c>AndyModels:</c> in configuration. Conductor injects
+/// these via <c>ContainersServiceConfig.environmentOverrides</c>.
+/// </summary>
+public sealed class AndyModelsOptions
+{
+    public const string SectionName = "AndyModels";
+
+    /// <summary>
+    /// Base URL of the andy-models API — e.g.
+    /// <c>http://localhost:9100/models</c> in embedded mode or
+    /// <c>https://andy-models.example.com</c> in server deployments.
+    /// May include a path prefix; <see cref="AndyModelsProxyTokenService"/>
+    /// joins paths strictly (no <see cref="Uri"/> base-relative reset).
+    /// </summary>
+    public string? BaseUrl { get; set; }
+
+    /// <summary>
+    /// Default token lifetime hint. <c>null</c> lets andy-models
+    /// apply its own default (currently 24h per M1.3.3). Set this to
+    /// a smaller number for short-lived workloads — andy-models clamps
+    /// to its configured maximum either way.
+    /// </summary>
+    public int? TokenLifetimeSeconds { get; set; }
+}

--- a/src/Andy.Containers.Api/Services/AndyModelsProxyTokenService.cs
+++ b/src/Andy.Containers.Api/Services/AndyModelsProxyTokenService.cs
@@ -193,15 +193,34 @@ public sealed class AndyModelsProxyTokenService : IProxyTokenService
     {
         try
         {
-            return await _serviceTokens.GetAccessTokenAsync(ct).ConfigureAwait(false);
+            // rivoli-ai/conductor#1055. andy-models's [Authorize]
+            // attribute requires audience `urn:andy-models-api` —
+            // distinct from the default `urn:andy-containers-api` the
+            // M2M client identifies as. Request a cross-audience token
+            // explicitly so andy-models accepts the bearer. The client
+            // must have `scp:urn:andy-models-api` in its manifest
+            // scopes (see andy-containers/config/registration.json).
+            return await _serviceTokens
+                .GetAccessTokenAsync(AndyModelsApiAudience, ct)
+                .ConfigureAwait(false);
         }
         catch (ServiceTokenException ex)
         {
             throw new ProxyTokenException(
                 "Could not obtain andy-containers service bearer to call andy-models. " +
-                "Check ServiceAuth:* configuration.", ex);
+                "Check ServiceAuth:* configuration and that the andy-containers-api " +
+                $"OAuth client is permitted to request scope '{AndyModelsApiAudience}' " +
+                "(see andy-containers/config/registration.json apiClient.scopes).", ex);
         }
     }
+
+    /// <summary>
+    /// rivoli-ai/conductor#1055. Audience that andy-models'
+    /// <c>[Authorize]</c>-protected endpoints (including
+    /// <c>POST /api/proxy/tokens</c>) require — see
+    /// <c>andy-models/src/Andy.Models.Api/Program.cs:31</c>.
+    /// </summary>
+    private const string AndyModelsApiAudience = "urn:andy-models-api";
 
     /// <summary>
     /// Combine <paramref name="baseUrl"/> + <paramref name="path"/>

--- a/src/Andy.Containers.Api/Services/AndyModelsProxyTokenService.cs
+++ b/src/Andy.Containers.Api/Services/AndyModelsProxyTokenService.cs
@@ -66,13 +66,21 @@ public sealed class AndyModelsProxyTokenService : IProxyTokenService
         // Resolve against the configured base. Path matches the
         // controller's [Route("api/proxy/tokens")] in andy-models.
         var url = CombinePathStrict(opts.BaseUrl!, "api/proxy/tokens");
+        // Normalise the lifetime hint: 0 / negative means "omit"
+        // (let andy-models apply its own default). The controller
+        // already coerces null + non-positive to null, but being
+        // explicit here keeps the wire shape clean for ops who tail
+        // the request bodies.
+        var lifetimeHint = opts.TokenLifetimeSeconds is { } seconds && seconds > 0
+            ? (int?)seconds
+            : null;
         using var request = new HttpRequestMessage(HttpMethod.Post, url)
         {
             Content = JsonContent.Create(new MintProxyTokenRequest(
                 ContainerId: containerId,
                 SubjectId: subjectId,
                 AllowedSlugs: allowedSlugs,
-                LifetimeSeconds: opts.TokenLifetimeSeconds)),
+                LifetimeSeconds: lifetimeHint)),
         };
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
 
@@ -247,6 +255,14 @@ public sealed class AndyModelsOptions
     public const string SectionName = "AndyModels";
 
     /// <summary>
+    /// rivoli-ai/conductor#943. 7 days. Long-lived containers normally
+    /// outlive the OAuth default of 1 hour, so the token mint requests
+    /// a week up front; andy-models clamps to its configured maximum
+    /// if the deployment policy is shorter.
+    /// </summary>
+    public const int DefaultTokenLifetimeSeconds = 7 * 24 * 60 * 60;
+
+    /// <summary>
     /// Base URL of the andy-models API — e.g.
     /// <c>http://localhost:9100/models</c> in embedded mode or
     /// <c>https://andy-models.example.com</c> in server deployments.
@@ -256,10 +272,12 @@ public sealed class AndyModelsOptions
     public string? BaseUrl { get; set; }
 
     /// <summary>
-    /// Default token lifetime hint. <c>null</c> lets andy-models
-    /// apply its own default (currently 24h per M1.3.3). Set this to
-    /// a smaller number for short-lived workloads — andy-models clamps
-    /// to its configured maximum either way.
+    /// Token lifetime hint sent on the mint request. Defaults to
+    /// <see cref="DefaultTokenLifetimeSeconds"/> (7 days per
+    /// rivoli-ai/conductor#943 AC). Set to a smaller number for
+    /// short-lived workloads — andy-models clamps to its configured
+    /// maximum either way. Set to <c>0</c> or a negative number to
+    /// omit the hint and accept andy-models' own default.
     /// </summary>
-    public int? TokenLifetimeSeconds { get; set; }
+    public int? TokenLifetimeSeconds { get; set; } = DefaultTokenLifetimeSeconds;
 }

--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -6,6 +6,7 @@ using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Infrastructure.Messaging;
 using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -24,6 +25,16 @@ public class ContainerOrchestrationService : IContainerService
     private readonly IConfiguration _configuration;
     private readonly ILogger<ContainerOrchestrationService> _logger;
     private readonly IServiceTokenService? _serviceTokenService;
+    private readonly IProxyTokenService? _proxyTokenService;
+    private readonly IDataProtector? _proxyTokenProtector;
+
+    /// <summary>
+    /// rivoli-ai/conductor#943. Data-protection purpose for encrypting
+    /// the JWT persisted in <c>Container.ProxyServiceToken</c>. Scoped
+    /// to this column so a future purpose-string change (e.g. for a
+    /// key rotation) only re-encrypts proxy tokens, not every secret.
+    /// </summary>
+    private const string ProxyTokenProtectorPurpose = "Container.ProxyServiceToken";
 
     /// <summary>
     /// Conductor #878. Default per-user simultaneous-container
@@ -43,7 +54,9 @@ public class ContainerOrchestrationService : IContainerService
         IApiKeyService apiKeyService,
         IConfiguration configuration,
         ILogger<ContainerOrchestrationService> logger,
-        IServiceTokenService? serviceTokenService = null)
+        IServiceTokenService? serviceTokenService = null,
+        IProxyTokenService? proxyTokenService = null,
+        IDataProtectionProvider? dataProtection = null)
     {
         _db = db;
         _routing = routing;
@@ -57,6 +70,11 @@ public class ContainerOrchestrationService : IContainerService
         // keep working; live DI always supplies the registered impl.
         // When null, the per-container token-injection step is a no-op.
         _serviceTokenService = serviceTokenService;
+        // rivoli-ai/conductor#943. Optional for the same reason. When
+        // both are null we fall back to the pre-#943 behaviour (no
+        // per-container token, env-var injection runs unmodified).
+        _proxyTokenService = proxyTokenService;
+        _proxyTokenProtector = dataProtection?.CreateProtector(ProxyTokenProtectorPurpose);
     }
 
     /// <summary>
@@ -451,14 +469,77 @@ public class ContainerOrchestrationService : IContainerService
                     UrlRedactor.Redact(containerFacingProxyUrl));
             }
         }
-        if (_serviceTokenService is not null && (envVars is null || !envVars.ContainsKey("ANDY_SERVICE_TOKEN")))
+        // rivoli-ai/conductor#943 (M1.5.1). Per-container proxy token.
+        // When the chosen code assistant requires proxy access (non-
+        // empty slug list — see ToolSlugDefaults), call andy-models to
+        // mint a JWT scoped to {containerId, allowedSlugs[]} and inject
+        // THAT as ANDY_SERVICE_TOKEN — narrower than the M2M bearer
+        // we'd otherwise hand the container.
+        //
+        // No code assistant or empty slug list → fall back to the
+        // shared M2M token below (pre-#943 behaviour). That covers
+        // Ollama, OpenAI-compatible self-hosted, and "no assistant
+        // pre-installed" templates.
+        var requiredSlugs = codeAssistant is null
+            ? Array.Empty<string>()
+            : ToolSlugDefaults.Resolve(codeAssistant);
+        var injectedProxyToken = false;
+        if (_proxyTokenService is not null
+            && requiredSlugs.Count > 0
+            && (envVars is null || !envVars.ContainsKey("ANDY_SERVICE_TOKEN")))
+        {
+            MintedProxyToken? minted;
+            try
+            {
+                minted = await _proxyTokenService.MintForContainerAsync(
+                    container.Id.ToString(),
+                    container.OwnerId,
+                    requiredSlugs,
+                    ct);
+            }
+            catch (ProxyTokenException ex)
+            {
+                // Hard fail. The assistant inside the container would
+                // otherwise start with no working credential and the
+                // user would see opaque 401s from the model surface
+                // long after the create call returned success. Better
+                // to surface the andy-models health problem now.
+                throw new InvalidOperationException(
+                    $"Container creation failed: could not mint per-container proxy token from andy-models for assistant " +
+                    $"'{codeAssistant?.Tool}'. Check andy-models health and AndyModels:BaseUrl configuration. " +
+                    $"Underlying error: {ex.Message}",
+                    ex);
+            }
+            if (minted is not null)
+            {
+                container.ProxyServiceTokenId = minted.TokenId;
+                container.ProxyTokenIssuedAt = DateTime.UtcNow;
+                container.ProxyServiceToken = _proxyTokenProtector is not null
+                    ? _proxyTokenProtector.Protect(minted.Jwt)
+                    : minted.Jwt;
+                envVars ??= new Dictionary<string, string>();
+                envVars["ANDY_SERVICE_TOKEN"] = minted.Jwt;
+                injectedProxyToken = true;
+                _logger.LogInformation(
+                    "Injected per-container ANDY_SERVICE_TOKEN (tokenId={TokenId}, slugs={Slugs}, length={Length}) into container env",
+                    minted.TokenId, string.Join(",", requiredSlugs), minted.Jwt.Length);
+            }
+        }
+
+        // Fall back to the shared M2M bearer when no per-container
+        // token was minted. Tests + assistant-less containers + Ollama
+        // / OpenAI-compatible self-hosted setups all hit this path.
+        if (!injectedProxyToken
+            && _serviceTokenService is not null
+            && (envVars is null || !envVars.ContainsKey("ANDY_SERVICE_TOKEN")))
         {
             try
             {
                 var serviceToken = await _serviceTokenService.GetAccessTokenAsync(ct);
                 envVars ??= new Dictionary<string, string>();
                 envVars["ANDY_SERVICE_TOKEN"] = serviceToken;
-                _logger.LogInformation("Injected ANDY_SERVICE_TOKEN (length={Length}) into container env",
+                _logger.LogInformation(
+                    "Injected shared ANDY_SERVICE_TOKEN (length={Length}) into container env (no per-container slugs required)",
                     serviceToken.Length);
             }
             catch (Exception tokenEx)
@@ -469,7 +550,7 @@ public class ContainerOrchestrationService : IContainerService
                 // and the user can still configure a personal API
                 // key via the existing apiKey resolution path.
                 _logger.LogWarning(tokenEx,
-                    "Failed to mint service token for container {ContainerName}; container will start without ANDY_SERVICE_TOKEN.",
+                    "Failed to mint shared service token for container {ContainerName}; container will start without ANDY_SERVICE_TOKEN.",
                     container.Name);
             }
         }
@@ -632,6 +713,19 @@ public class ContainerOrchestrationService : IContainerService
         {
             var infra = _providerFactory.GetProvider(container.Provider!);
             await infra.DestroyContainerAsync(container.ExternalId, ct);
+        }
+
+        // rivoli-ai/conductor#943 (M1.5.1). Revoke the per-container
+        // proxy token if we minted one. AndyModelsProxyTokenService
+        // swallows transport errors itself so a slow / down andy-models
+        // can't wedge container destroy — the token's `exp` claim is
+        // the backstop.
+        if (_proxyTokenService is not null && container.ProxyServiceTokenId is { } tokenId)
+        {
+            await _proxyTokenService.RevokeAsync(tokenId, ct);
+            container.ProxyServiceToken = null;
+            container.ProxyServiceTokenId = null;
+            container.ProxyTokenIssuedAt = null;
         }
 
         container.Status = ContainerStatus.Destroyed;

--- a/src/Andy.Containers.Api/Services/IProxyTokenService.cs
+++ b/src/Andy.Containers.Api/Services/IProxyTokenService.cs
@@ -1,0 +1,62 @@
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// rivoli-ai/conductor#943 (M1.5.1). Per-container service-token consumer.
+///
+/// At container creation time we call <see cref="MintForContainerAsync"/>
+/// to ask andy-models for a JWT scoped to <c>{containerId, allowedSlugs[]}</c>.
+/// That JWT is injected into the container as <c>ANDY_SERVICE_TOKEN</c> so
+/// the code assistant inside can authenticate against the unified proxy
+/// for exactly the slugs we minted it for — narrower than the user's full
+/// RBAC grant. On destroy we call <see cref="RevokeAsync"/> to invalidate
+/// the JWT (denylist enforcement).
+///
+/// Distinct from <see cref="IServiceTokenService"/>: that one mints the
+/// single, process-wide M2M bearer that andy-containers itself uses to
+/// authenticate as a service against andy-auth (and indirectly to call
+/// this very endpoint on andy-models). Container-facing injection used
+/// to leak that broad token; with #943 it's replaced with the narrowly
+/// scoped per-container JWT minted by andy-models.
+/// </summary>
+public interface IProxyTokenService
+{
+    /// <summary>
+    /// Ask andy-models to mint a fresh proxy token. Returns <c>null</c>
+    /// when <paramref name="allowedSlugs"/> is empty — that signals
+    /// "this container talks to its model surface directly" (Ollama,
+    /// OpenAI-compatible self-hosted) and no proxy token is needed.
+    /// </summary>
+    /// <exception cref="ProxyTokenException">
+    /// Thrown when andy-models is unreachable, returns a non-2xx, or
+    /// returns a body the client can't parse. Container creation should
+    /// fail fast on this — the assistant inside would otherwise start
+    /// without working credentials and produce confusing 401s.
+    /// </exception>
+    Task<MintedProxyToken?> MintForContainerAsync(
+        string containerId,
+        string subjectId,
+        IReadOnlyList<string> allowedSlugs,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Revoke a previously minted token by its andy-models row id.
+    /// Idempotent — andy-models returns 204 for unknown ids too. Logs
+    /// and swallows transport errors so container destroy never wedges
+    /// on a slow / down andy-models; the token will expire naturally
+    /// at its <c>exp</c> claim anyway.
+    /// </summary>
+    Task RevokeAsync(Guid tokenId, CancellationToken ct = default);
+}
+
+/// <summary>Return shape of <see cref="IProxyTokenService.MintForContainerAsync"/>.</summary>
+public sealed record MintedProxyToken(Guid TokenId, string Jwt, DateTimeOffset ExpiresAt);
+
+/// <summary>
+/// Surfaced when minting fails. Carries enough context for triage; the
+/// JWT itself is never written to <see cref="Exception.Message"/>.
+/// </summary>
+public sealed class ProxyTokenException : Exception
+{
+    public ProxyTokenException(string message) : base(message) { }
+    public ProxyTokenException(string message, Exception inner) : base(message, inner) { }
+}

--- a/src/Andy.Containers.Api/Services/IServiceTokenService.cs
+++ b/src/Andy.Containers.Api/Services/IServiceTokenService.cs
@@ -30,9 +30,10 @@ namespace Andy.Containers.Api.Services;
 public interface IServiceTokenService
 {
     /// <summary>
-    /// Returns a valid bearer token. Mints a new one if no cached
-    /// token is available or if the cached token is within the
-    /// refresh skew of expiring.
+    /// Returns a valid bearer token for the default audience
+    /// (<see cref="ServiceAuthOptions.Audience"/>). Mints a new one if
+    /// no cached token is available or if the cached token is within
+    /// the refresh skew of expiring.
     /// </summary>
     /// <exception cref="ServiceTokenException">
     /// Thrown when the token endpoint is unreachable, returns a
@@ -41,6 +42,40 @@ public interface IServiceTokenService
     /// at the next opportunity (per-call mint, with cache).
     /// </exception>
     Task<string> GetAccessTokenAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns a valid bearer token scoped to an explicit audience.
+    /// Use this for inter-service calls where the target service's
+    /// <c>aud</c> claim differs from <see cref="ServiceAuthOptions.Audience"/>
+    /// — e.g. andy-containers calling andy-models (audience
+    /// <c>urn:andy-models-api</c>) for rivoli-ai/conductor#943.
+    ///
+    /// <para>
+    /// The client must be permitted to request the requested scope —
+    /// add <c>scp:&lt;audience&gt;</c> to the client's
+    /// <c>apiClient.scopes</c> in the registration manifest. Without
+    /// that, andy-auth rejects with <c>invalid_scope</c> (OpenIddict
+    /// ID2052).
+    /// </para>
+    ///
+    /// <para>
+    /// Per-audience cache: each audience has its own cached token +
+    /// expiry, so concurrent calls for different audiences do not
+    /// thrash a single slot.
+    /// </para>
+    /// </summary>
+    /// <param name="audience">
+    /// Unprefixed audience name (e.g. <c>urn:andy-models-api</c>). The
+    /// implementation sends this as the OAuth <c>scope</c> request
+    /// parameter unprefixed — the <c>scp:</c> prefix is reserved for
+    /// the client-side permission, never the request body.
+    /// </param>
+    /// <exception cref="ServiceTokenException">
+    /// Same surface as <see cref="GetAccessTokenAsync(CancellationToken)"/>;
+    /// additionally fires when <paramref name="audience"/> is
+    /// empty or whitespace.
+    /// </exception>
+    Task<string> GetAccessTokenAsync(string audience, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Andy.Containers.Api/Services/ServiceTokenService.cs
+++ b/src/Andy.Containers.Api/Services/ServiceTokenService.cs
@@ -30,9 +30,13 @@ public sealed class ServiceTokenService : IServiceTokenService, IDisposable
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<ServiceTokenService> _logger;
 
+    // rivoli-ai/conductor#1055. Per-audience cache. Each audience the
+    // process talks to (urn:andy-containers-api, urn:andy-models-api,
+    // future others) gets its own slot. A single shared gate is fine
+    // for the dev/embedded volume — the critical section is just a
+    // dictionary lookup + an HTTP mint behind the cache miss.
     private readonly SemaphoreSlim _gate = new(initialCount: 1, maxCount: 1);
-    private string? _cachedToken;
-    private DateTimeOffset _cachedExpiry = DateTimeOffset.MinValue;
+    private readonly Dictionary<string, CacheEntry> _cache = new(StringComparer.Ordinal);
 
     /// <summary>HttpClient name registered in DI; tests can override.</summary>
     public const string HttpClientName = "ServiceTokenClient";
@@ -49,12 +53,34 @@ public sealed class ServiceTokenService : IServiceTokenService, IDisposable
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
-    public async Task<string> GetAccessTokenAsync(CancellationToken ct = default)
+    public Task<string> GetAccessTokenAsync(CancellationToken ct = default)
     {
-        // Fast path: token cached + comfortably ahead of expiry.
-        if (_cachedToken is not null && _timeProvider.GetUtcNow() + RefreshSkew < _cachedExpiry)
+        // Default-audience path — preserves the existing contract for
+        // callers that don't care about cross-service audiences.
+        var defaultAudience = _options.Value.Audience;
+        if (string.IsNullOrWhiteSpace(defaultAudience))
         {
-            return _cachedToken;
+            throw new ServiceTokenException(
+                "ServiceAuth:Audience is not configured. Cannot mint service-to-service tokens without an audience.");
+        }
+        return GetAccessTokenAsync(defaultAudience, ct);
+    }
+
+    public async Task<string> GetAccessTokenAsync(string audience, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(audience))
+        {
+            throw new ServiceTokenException(
+                "Audience is required for inter-service token requests.");
+        }
+
+        // Fast path: token cached for this audience + comfortably ahead
+        // of expiry. Dictionary reads of a single slot are safe under
+        // .NET's memory model when concurrent writers serialise behind
+        // the gate, which they do (only the lock'd block below writes).
+        if (TryGetFreshCached(audience, out var fast))
+        {
+            return fast;
         }
 
         await _gate.WaitAsync(ct).ConfigureAwait(false);
@@ -62,18 +88,18 @@ public sealed class ServiceTokenService : IServiceTokenService, IDisposable
         {
             // Double-check inside the lock — another caller may have
             // refreshed while we were waiting.
-            if (_cachedToken is not null && _timeProvider.GetUtcNow() + RefreshSkew < _cachedExpiry)
+            if (TryGetFreshCached(audience, out var current))
             {
-                return _cachedToken;
+                return current;
             }
 
-            var fresh = await MintAsync(ct).ConfigureAwait(false);
+            var fresh = await MintAsync(audience, ct).ConfigureAwait(false);
             // MintAsync throws on a null/empty access_token, so the
             // null-forgiving operator is sound here — the only way
             // we're past the throw above is if AccessToken is set.
-            _cachedToken = fresh.AccessToken!;
-            _cachedExpiry = _timeProvider.GetUtcNow() + TimeSpan.FromSeconds(fresh.ExpiresInSeconds);
-            return _cachedToken;
+            var expiry = _timeProvider.GetUtcNow() + TimeSpan.FromSeconds(fresh.ExpiresInSeconds);
+            _cache[audience] = new CacheEntry(fresh.AccessToken!, expiry);
+            return fresh.AccessToken!;
         }
         finally
         {
@@ -81,7 +107,19 @@ public sealed class ServiceTokenService : IServiceTokenService, IDisposable
         }
     }
 
-    private async Task<TokenResponse> MintAsync(CancellationToken ct)
+    private bool TryGetFreshCached(string audience, out string token)
+    {
+        if (_cache.TryGetValue(audience, out var entry)
+            && _timeProvider.GetUtcNow() + RefreshSkew < entry.Expiry)
+        {
+            token = entry.Token;
+            return true;
+        }
+        token = string.Empty;
+        return false;
+    }
+
+    private async Task<TokenResponse> MintAsync(string audience, CancellationToken ct)
     {
         var opts = _options.Value;
         if (string.IsNullOrWhiteSpace(opts.TokenEndpoint))
@@ -105,9 +143,6 @@ public sealed class ServiceTokenService : IServiceTokenService, IDisposable
             ["grant_type"] = "client_credentials",
             ["client_id"] = opts.ClientId,
             ["client_secret"] = opts.ClientSecret ?? string.Empty,
-        };
-        if (!string.IsNullOrWhiteSpace(opts.Audience))
-        {
             // The `scope` request parameter takes the unprefixed scope
             // name (== the audience, the way andy-auth's seeder
             // registers it via `OpenIddictScopeDescriptor.Name = audience`).
@@ -116,8 +151,8 @@ public sealed class ServiceTokenService : IServiceTokenService, IDisposable
             // (`Permissions.Add("scp:urn:andy-containers-api")`), not
             // the request body. Sending `scp:urn:…` here gets
             // rejected as `invalid_scope` (OpenIddict ID2052).
-            form["scope"] = opts.Audience;
-        }
+            ["scope"] = audience,
+        };
 
         using var request = new HttpRequestMessage(HttpMethod.Post, opts.TokenEndpoint)
         {
@@ -163,10 +198,13 @@ public sealed class ServiceTokenService : IServiceTokenService, IDisposable
         }
 
         _logger.LogInformation(
-            "Minted service token (clientId={ClientId} expiresInSeconds={ExpiresInSeconds})",
-            opts.ClientId, parsed.ExpiresInSeconds);
+            "Minted service token (clientId={ClientId} audience={Audience} expiresInSeconds={ExpiresInSeconds})",
+            opts.ClientId, audience, parsed.ExpiresInSeconds);
         return parsed;
     }
+
+    /// <summary>Per-audience cache slot.</summary>
+    private readonly record struct CacheEntry(string Token, DateTimeOffset Expiry);
 
     private static async Task<string> SafeReadPreviewAsync(HttpResponseMessage response, CancellationToken ct)
     {

--- a/src/Andy.Containers.Api/Services/ToolSlugDefaults.cs
+++ b/src/Andy.Containers.Api/Services/ToolSlugDefaults.cs
@@ -1,0 +1,51 @@
+using Andy.Containers.Models;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// rivoli-ai/conductor#943 (M1.5.1). Default mapping from a
+/// <see cref="CodeAssistantType"/> to the model slugs a per-container
+/// proxy token should grant access to.
+///
+/// Used when <see cref="CodeAssistantConfig.RequiredModelSlugs"/> is
+/// <c>null</c> — callers can override the default by setting that
+/// field explicitly. An empty result means "no proxy token needed"
+/// (the container talks to its model surface directly, e.g. Ollama or
+/// an OpenAI-compatible self-hosted endpoint).
+/// </summary>
+public static class ToolSlugDefaults
+{
+    public static IReadOnlyList<string> Resolve(CodeAssistantConfig config)
+    {
+        if (config.RequiredModelSlugs is not null)
+        {
+            // Explicit override wins, including an explicit empty list
+            // which signals "this container handles its own auth".
+            return config.RequiredModelSlugs;
+        }
+
+        return config.Tool switch
+        {
+            // Claude Code's only sensible target is Anthropic-dialect;
+            // pin to the current default Sonnet so the token is usable
+            // out of the box. Users wanting Opus or a pinned earlier
+            // version set RequiredModelSlugs explicitly.
+            CodeAssistantType.ClaudeCode
+                => new[] { "anthropic/claude-sonnet-4-6" },
+
+            // OpenCode is multi-provider. Without an explicit slug
+            // list we can't guess which provider the user actually
+            // wants — return empty (no proxy token) and let the API
+            // key resolution path handle credentials. Users routing
+            // OpenCode through the proxy should set
+            // RequiredModelSlugs (e.g. ["openai/gpt-4o"]).
+            CodeAssistantType.OpenCode
+                => Array.Empty<string>(),
+
+            // Other tools — extend the map as concrete defaults
+            // become clear. Returning empty keeps behaviour safe by
+            // default (no proxy token rather than a wrongly-scoped one).
+            _ => Array.Empty<string>(),
+        };
+    }
+}

--- a/src/Andy.Containers.Infrastructure/Migrations/20260511173704_AddContainerProxyServiceToken.Designer.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260511173704_AddContainerProxyServiceToken.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Andy.Containers.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Containers.Infrastructure.Migrations
 {
     [DbContext(typeof(ContainersDbContext))]
-    partial class ContainersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260511173704_AddContainerProxyServiceToken")]
+    partial class AddContainerProxyServiceToken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Containers.Infrastructure/Migrations/20260511173704_AddContainerProxyServiceToken.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260511173704_AddContainerProxyServiceToken.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Containers.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddContainerProxyServiceToken : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ProxyServiceToken",
+                table: "Containers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProxyServiceTokenId",
+                table: "Containers",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ProxyTokenIssuedAt",
+                table: "Containers",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProxyServiceToken",
+                table: "Containers");
+
+            migrationBuilder.DropColumn(
+                name: "ProxyServiceTokenId",
+                table: "Containers");
+
+            migrationBuilder.DropColumn(
+                name: "ProxyTokenIssuedAt",
+                table: "Containers");
+        }
+    }
+}

--- a/src/Andy.Containers/Models/CodeAssistant.cs
+++ b/src/Andy.Containers/Models/CodeAssistant.cs
@@ -26,4 +26,14 @@ public class CodeAssistantConfig
     public string? ApiBaseUrlEnvVar { get; set; }
     public string? ModelName { get; set; }
     public string? ModelEnvVar { get; set; }
+
+    /// <summary>
+    /// rivoli-ai/conductor#943 (M1.5.1). Model slugs the per-container
+    /// proxy token should grant access to. When null, the orchestration
+    /// service falls back to <see cref="ToolSlugDefaults"/> for this
+    /// tool. When set to an empty list, no proxy token is minted — the
+    /// container is presumed to talk to its model surface directly
+    /// (Ollama, OpenAI-compatible self-hosted, etc.).
+    /// </summary>
+    public List<string>? RequiredModelSlugs { get; set; }
 }

--- a/src/Andy.Containers/Models/Container.cs
+++ b/src/Andy.Containers/Models/Container.cs
@@ -66,6 +66,33 @@ public class Container
     /// </summary>
     public string? ThemeId { get; set; }
 
+    /// <summary>
+    /// rivoli-ai/conductor#943 (M1.5.1). Andy-models row id of the
+    /// per-container proxy token; carried so destroy can call
+    /// <c>DELETE /api/proxy/tokens/{id}</c> for revocation. Null when
+    /// the container's code assistant doesn't require proxy access
+    /// (Ollama, OpenAI-compatible self-hosted) or when no code
+    /// assistant is configured.
+    /// </summary>
+    public Guid? ProxyServiceTokenId { get; set; }
+
+    /// <summary>
+    /// rivoli-ai/conductor#943 (M1.5.1). The signed JWT issued by
+    /// andy-models, encrypted at rest via <see cref="Microsoft.AspNetCore.DataProtection.IDataProtector"/>.
+    /// Read back at container start (or by future M1.5.2 in-container
+    /// refresh) to repopulate <c>ANDY_SERVICE_TOKEN</c>. Never logged
+    /// or surfaced over the API.
+    /// </summary>
+    public string? ProxyServiceToken { get; set; }
+
+    /// <summary>
+    /// rivoli-ai/conductor#943 (M1.5.1). Wall-clock UTC at which the
+    /// proxy token in <see cref="ProxyServiceToken"/> was minted by
+    /// andy-models. Diagnostic / audit field — the canonical expiry is
+    /// in the JWT's <c>exp</c> claim.
+    /// </summary>
+    public DateTime? ProxyTokenIssuedAt { get; set; }
+
     public ICollection<ContainerSession> Sessions { get; set; } = new List<ContainerSession>();
     public ICollection<ContainerEvent> Events { get; set; } = new List<ContainerEvent>();
     public ICollection<ContainerGitRepository> GitRepositories { get; set; } = new List<ContainerGitRepository>();

--- a/tests/Andy.Containers.Api.Tests/Services/AndyModelsProxyTokenServiceTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/AndyModelsProxyTokenServiceTests.cs
@@ -74,6 +74,27 @@ public class AndyModelsProxyTokenServiceTests
         handler.LastRequestUri.Should().Be(new Uri("http://andy-models.test/api/proxy/tokens"));
     }
 
+    [Fact]
+    public async Task Mint_RequestsCrossAudienceBearerForAndyModels()
+    {
+        // rivoli-ai/conductor#1055. andy-models's [Authorize] requires
+        // audience `urn:andy-models-api` — distinct from the M2M
+        // client's own `urn:andy-containers-api`. Without the
+        // cross-audience request, the bearer is rejected with 401
+        // before any controller logic runs.
+        var bearer = new StubTokenService("cross-aud-jwt");
+        var (service, handler, _) = MakeService(
+            opts => opts.BaseUrl = "http://andy-models.test",
+            bearerProvider: bearer);
+        handler.SetSuccessJsonResponse(
+            "{\"tokenId\":\"44444444-4444-4444-4444-444444444444\",\"jwt\":\"j.w.t\",\"expiresAt\":\"2026-12-01T00:00:00Z\"}");
+
+        _ = await service.MintForContainerAsync("ctr", "user", new[] { "anthropic/claude-sonnet-4-6" });
+
+        bearer.LastRequestedAudience.Should().Be("urn:andy-models-api",
+            "the consumer must ask IServiceTokenService for a token whose `aud` claim andy-models will accept.");
+    }
+
     // -----------------------------------------------------------------
     // Lifetime hint (#943 AC: 7-day default)
     // -----------------------------------------------------------------
@@ -310,8 +331,18 @@ public class AndyModelsProxyTokenServiceTests
     private sealed class StubTokenService : IServiceTokenService
     {
         private readonly string _token;
+        public string? LastRequestedAudience { get; private set; }
         public StubTokenService(string token) { _token = token; }
-        public Task<string> GetAccessTokenAsync(CancellationToken ct = default) => Task.FromResult(_token);
+        public Task<string> GetAccessTokenAsync(CancellationToken ct = default)
+        {
+            LastRequestedAudience = null;
+            return Task.FromResult(_token);
+        }
+        public Task<string> GetAccessTokenAsync(string audience, CancellationToken ct = default)
+        {
+            LastRequestedAudience = audience;
+            return Task.FromResult(_token);
+        }
     }
 
     private sealed class ThrowingTokenService : IServiceTokenService
@@ -319,6 +350,8 @@ public class AndyModelsProxyTokenServiceTests
         private readonly Exception _ex;
         public ThrowingTokenService(Exception ex) { _ex = ex; }
         public Task<string> GetAccessTokenAsync(CancellationToken ct = default)
+            => Task.FromException<string>(_ex);
+        public Task<string> GetAccessTokenAsync(string audience, CancellationToken ct = default)
             => Task.FromException<string>(_ex);
     }
 

--- a/tests/Andy.Containers.Api.Tests/Services/AndyModelsProxyTokenServiceTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/AndyModelsProxyTokenServiceTests.cs
@@ -1,0 +1,312 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Andy.Containers.Api.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+/// <summary>
+/// rivoli-ai/conductor#943 (M1.5.1). Covers mint + revoke request
+/// shape, the empty-slugs short-circuit, error mapping, and bearer
+/// propagation from <see cref="IServiceTokenService"/>.
+/// </summary>
+public class AndyModelsProxyTokenServiceTests
+{
+    // -----------------------------------------------------------------
+    // Mint — happy path
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task Mint_HappyPath_ReturnsTokenIdAndJwt()
+    {
+        var tokenId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var (service, handler, _) = MakeService(opts =>
+        {
+            opts.BaseUrl = "http://andy-models.test";
+        });
+        handler.SetSuccessJsonResponse(
+            $"{{\"tokenId\":\"{tokenId}\",\"jwt\":\"eyJhbGc.test.jwt\",\"expiresAt\":\"2026-12-01T00:00:00Z\"}}");
+
+        var minted = await service.MintForContainerAsync(
+            containerId: "ctr-abc",
+            subjectId: "user-42",
+            allowedSlugs: new[] { "anthropic/claude-sonnet-4-6" });
+
+        minted.Should().NotBeNull();
+        minted!.TokenId.Should().Be(tokenId);
+        minted.Jwt.Should().Be("eyJhbGc.test.jwt");
+        minted.ExpiresAt.Should().Be(DateTimeOffset.Parse("2026-12-01T00:00:00Z"));
+    }
+
+    [Fact]
+    public async Task Mint_PostsToCorrectUrlWithBearerAndJsonBody()
+    {
+        var (service, handler, _) = MakeService(opts => opts.BaseUrl = "http://andy-models.test/models");
+        handler.SetSuccessJsonResponse(
+            "{\"tokenId\":\"22222222-2222-2222-2222-222222222222\",\"jwt\":\"j.w.t\",\"expiresAt\":\"2026-12-01T00:00:00Z\"}");
+
+        _ = await service.MintForContainerAsync("ctr-xyz", "user-1", new[] { "openai/gpt-4o" });
+
+        handler.LastMethod.Should().Be(HttpMethod.Post);
+        handler.LastRequestUri.Should().Be(
+            new Uri("http://andy-models.test/models/api/proxy/tokens"),
+            "base path prefix must be preserved when joining api/proxy/tokens.");
+        handler.LastRequest!.Headers.Authorization.Should().Be(
+            new AuthenticationHeaderValue("Bearer", "m2m-bearer-stub"));
+        handler.LastBody.Should().Contain("\"containerId\":\"ctr-xyz\"");
+        handler.LastBody.Should().Contain("\"subjectId\":\"user-1\"");
+        handler.LastBody.Should().Contain("\"allowedSlugs\":[\"openai/gpt-4o\"]");
+    }
+
+    [Fact]
+    public async Task Mint_BaseUrlWithoutPath_StillJoinsCorrectly()
+    {
+        var (service, handler, _) = MakeService(opts => opts.BaseUrl = "http://andy-models.test");
+        handler.SetSuccessJsonResponse(
+            "{\"tokenId\":\"33333333-3333-3333-3333-333333333333\",\"jwt\":\"j.w.t\",\"expiresAt\":\"2026-12-01T00:00:00Z\"}");
+
+        _ = await service.MintForContainerAsync("ctr", "user", new[] { "anthropic/claude-sonnet-4-6" });
+
+        handler.LastRequestUri.Should().Be(new Uri("http://andy-models.test/api/proxy/tokens"));
+    }
+
+    // -----------------------------------------------------------------
+    // Mint — short-circuits
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task Mint_EmptyAllowedSlugs_ReturnsNullWithoutCallingAndyModels()
+    {
+        var (service, handler, _) = MakeService(opts => opts.BaseUrl = "http://andy-models.test");
+
+        var minted = await service.MintForContainerAsync("ctr", "user", Array.Empty<string>());
+
+        minted.Should().BeNull();
+        handler.RequestCount.Should().Be(0,
+            "empty slugs is the documented 'this container does its own auth' signal — no round trip needed.");
+    }
+
+    // -----------------------------------------------------------------
+    // Mint — failure modes (all throw ProxyTokenException so caller
+    // can fail container creation fast)
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task Mint_MissingBaseUrl_ThrowsProxyTokenException()
+    {
+        var (service, _, _) = MakeService(opts => opts.BaseUrl = null);
+
+        await FluentActions.Awaiting(() =>
+                service.MintForContainerAsync("ctr", "user", new[] { "anthropic/claude-sonnet-4-6" }))
+            .Should().ThrowAsync<ProxyTokenException>()
+            .WithMessage("*AndyModels:BaseUrl is not configured*");
+    }
+
+    [Fact]
+    public async Task Mint_TransportError_ThrowsProxyTokenException()
+    {
+        var (service, handler, _) = MakeService(opts => opts.BaseUrl = "http://andy-models.test");
+        handler.SetSendException(new HttpRequestException("connection refused"));
+
+        await FluentActions.Awaiting(() =>
+                service.MintForContainerAsync("ctr", "user", new[] { "anthropic/claude-sonnet-4-6" }))
+            .Should().ThrowAsync<ProxyTokenException>()
+            .WithMessage("*andy-models unreachable*");
+    }
+
+    [Fact]
+    public async Task Mint_AndyModels500_ThrowsProxyTokenExceptionCarryingStatus()
+    {
+        var (service, handler, _) = MakeService(opts => opts.BaseUrl = "http://andy-models.test");
+        handler.SetResponse(new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent("upstream broke", Encoding.UTF8, "text/plain"),
+        });
+
+        await FluentActions.Awaiting(() =>
+                service.MintForContainerAsync("ctr", "user", new[] { "anthropic/claude-sonnet-4-6" }))
+            .Should().ThrowAsync<ProxyTokenException>()
+            .WithMessage("*HTTP 500*");
+    }
+
+    [Fact]
+    public async Task Mint_AndyModelsResponseMissingFields_ThrowsProxyTokenException()
+    {
+        var (service, handler, _) = MakeService(opts => opts.BaseUrl = "http://andy-models.test");
+        handler.SetSuccessJsonResponse("{\"tokenId\":\"44444444-4444-4444-4444-444444444444\"}");
+
+        await FluentActions.Awaiting(() =>
+                service.MintForContainerAsync("ctr", "user", new[] { "anthropic/claude-sonnet-4-6" }))
+            .Should().ThrowAsync<ProxyTokenException>()
+            .WithMessage("*missing tokenId or jwt*");
+    }
+
+    [Fact]
+    public async Task Mint_ServiceTokenFailure_BubblesAsProxyTokenException()
+    {
+        var (service, _, _) = MakeService(
+            opts => opts.BaseUrl = "http://andy-models.test",
+            bearerProvider: new ThrowingTokenService(new ServiceTokenException("auth down")));
+
+        await FluentActions.Awaiting(() =>
+                service.MintForContainerAsync("ctr", "user", new[] { "anthropic/claude-sonnet-4-6" }))
+            .Should().ThrowAsync<ProxyTokenException>()
+            .WithMessage("*service bearer*");
+    }
+
+    // -----------------------------------------------------------------
+    // Revoke
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task Revoke_HappyPath_PostsDeleteWithTokenIdAndBearer()
+    {
+        var (service, handler, _) = MakeService(opts => opts.BaseUrl = "http://andy-models.test");
+        handler.SetResponse(new HttpResponseMessage(HttpStatusCode.NoContent));
+        var tokenId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+
+        await service.RevokeAsync(tokenId);
+
+        handler.LastMethod.Should().Be(HttpMethod.Delete);
+        handler.LastRequestUri.Should().Be(new Uri($"http://andy-models.test/api/proxy/tokens/{tokenId}"));
+        handler.LastRequest!.Headers.Authorization.Should().Be(
+            new AuthenticationHeaderValue("Bearer", "m2m-bearer-stub"));
+    }
+
+    [Fact]
+    public async Task Revoke_EmptyGuid_IsNoOp()
+    {
+        var (service, handler, _) = MakeService(opts => opts.BaseUrl = "http://andy-models.test");
+
+        await service.RevokeAsync(Guid.Empty);
+
+        handler.RequestCount.Should().Be(0,
+            "Guid.Empty is a sentinel; round-tripping to andy-models for nothing is wasteful.");
+    }
+
+    [Fact]
+    public async Task Revoke_AndyModels4xx_SwallowsError()
+    {
+        var (service, handler, _) = MakeService(opts => opts.BaseUrl = "http://andy-models.test");
+        handler.SetResponse(new HttpResponseMessage(HttpStatusCode.NotFound));
+        var tokenId = Guid.Parse("66666666-6666-6666-6666-666666666666");
+
+        // Should not throw — destroy must not wedge on revoke failures.
+        await service.RevokeAsync(tokenId);
+    }
+
+    [Fact]
+    public async Task Revoke_TransportError_SwallowsError()
+    {
+        var (service, handler, _) = MakeService(opts => opts.BaseUrl = "http://andy-models.test");
+        handler.SetSendException(new HttpRequestException("connection refused"));
+        var tokenId = Guid.Parse("77777777-7777-7777-7777-777777777777");
+
+        // Should not throw — token will expire naturally at its exp claim.
+        await service.RevokeAsync(tokenId);
+    }
+
+    [Fact]
+    public async Task Revoke_MissingBaseUrl_IsNoOp()
+    {
+        var (service, handler, _) = MakeService(opts => opts.BaseUrl = null);
+        var tokenId = Guid.Parse("88888888-8888-8888-8888-888888888888");
+
+        await service.RevokeAsync(tokenId);
+
+        handler.RequestCount.Should().Be(0);
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private static (AndyModelsProxyTokenService service, StubHttpHandler handler, IServiceTokenService bearer)
+        MakeService(
+            Action<AndyModelsOptions> configure,
+            IServiceTokenService? bearerProvider = null)
+    {
+        var options = new AndyModelsOptions();
+        configure(options);
+        var handler = new StubHttpHandler();
+        var factory = new SingleClientHttpClientFactory(handler);
+        var bearer = bearerProvider ?? new StubTokenService("m2m-bearer-stub");
+        var service = new AndyModelsProxyTokenService(
+            factory,
+            bearer,
+            Options.Create(options),
+            NullLogger<AndyModelsProxyTokenService>.Instance);
+        return (service, handler, bearer);
+    }
+
+    private sealed class StubTokenService : IServiceTokenService
+    {
+        private readonly string _token;
+        public StubTokenService(string token) { _token = token; }
+        public Task<string> GetAccessTokenAsync(CancellationToken ct = default) => Task.FromResult(_token);
+    }
+
+    private sealed class ThrowingTokenService : IServiceTokenService
+    {
+        private readonly Exception _ex;
+        public ThrowingTokenService(Exception ex) { _ex = ex; }
+        public Task<string> GetAccessTokenAsync(CancellationToken ct = default)
+            => Task.FromException<string>(_ex);
+    }
+
+    private sealed class StubHttpHandler : HttpMessageHandler
+    {
+        private HttpResponseMessage _response = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}"),
+        };
+        private Exception? _sendException;
+
+        public int RequestCount { get; private set; }
+        public HttpRequestMessage? LastRequest { get; private set; }
+        public HttpMethod? LastMethod { get; private set; }
+        public Uri? LastRequestUri { get; private set; }
+        public string LastBody { get; private set; } = string.Empty;
+
+        public void SetSuccessJsonResponse(string json)
+        {
+            _sendException = null;
+            _response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json"),
+            };
+        }
+
+        public void SetResponse(HttpResponseMessage response)
+        {
+            _sendException = null;
+            _response = response;
+        }
+
+        public void SetSendException(Exception ex) { _sendException = ex; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            LastRequest = request;
+            LastMethod = request.Method;
+            LastRequestUri = request.RequestUri;
+            LastBody = request.Content is null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            if (_sendException is not null) throw _sendException;
+            return _response;
+        }
+    }
+
+    private sealed class SingleClientHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+        public SingleClientHttpClientFactory(HttpMessageHandler handler) { _handler = handler; }
+        public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Services/AndyModelsProxyTokenServiceTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/AndyModelsProxyTokenServiceTests.cs
@@ -75,6 +75,70 @@ public class AndyModelsProxyTokenServiceTests
     }
 
     // -----------------------------------------------------------------
+    // Lifetime hint (#943 AC: 7-day default)
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void AndyModelsOptions_DefaultLifetimeIsSevenDays()
+    {
+        // rivoli-ai/conductor#943 spec: "Token lifetime defaults to 7 days."
+        new AndyModelsOptions().TokenLifetimeSeconds
+            .Should().Be(7 * 24 * 60 * 60,
+                "the default token lifetime is contractual — bumping it has billing + revocation-window implications.");
+    }
+
+    [Fact]
+    public async Task Mint_SendsDefaultSevenDayLifetimeHintWhenConfigUntouched()
+    {
+        var (service, handler, _) = MakeService(opts =>
+        {
+            opts.BaseUrl = "http://andy-models.test";
+            // Do NOT override TokenLifetimeSeconds — exercise the default.
+        });
+        handler.SetSuccessJsonResponse(
+            "{\"tokenId\":\"99999999-9999-9999-9999-999999999999\",\"jwt\":\"j.w.t\",\"expiresAt\":\"2026-12-01T00:00:00Z\"}");
+
+        _ = await service.MintForContainerAsync("ctr", "user", new[] { "anthropic/claude-sonnet-4-6" });
+
+        handler.LastBody.Should().Contain("\"lifetimeSeconds\":604800");
+    }
+
+    [Fact]
+    public async Task Mint_ExplicitLifetimeHintIsRespected()
+    {
+        var (service, handler, _) = MakeService(opts =>
+        {
+            opts.BaseUrl = "http://andy-models.test";
+            opts.TokenLifetimeSeconds = 3600;
+        });
+        handler.SetSuccessJsonResponse(
+            "{\"tokenId\":\"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",\"jwt\":\"j.w.t\",\"expiresAt\":\"2026-12-01T00:00:00Z\"}");
+
+        _ = await service.MintForContainerAsync("ctr", "user", new[] { "anthropic/claude-sonnet-4-6" });
+
+        handler.LastBody.Should().Contain("\"lifetimeSeconds\":3600");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task Mint_ZeroOrNegativeLifetime_OmitsHint(int configured)
+    {
+        var (service, handler, _) = MakeService(opts =>
+        {
+            opts.BaseUrl = "http://andy-models.test";
+            opts.TokenLifetimeSeconds = configured;
+        });
+        handler.SetSuccessJsonResponse(
+            "{\"tokenId\":\"11111111-2222-3333-4444-555555555555\",\"jwt\":\"j.w.t\",\"expiresAt\":\"2026-12-01T00:00:00Z\"}");
+
+        _ = await service.MintForContainerAsync("ctr", "user", new[] { "anthropic/claude-sonnet-4-6" });
+
+        handler.LastBody.Should().Contain("\"lifetimeSeconds\":null",
+            "0 / negative configured values are 'omit the hint' — let andy-models apply its own default.");
+    }
+
+    // -----------------------------------------------------------------
     // Mint — short-circuits
     // -----------------------------------------------------------------
 

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceProxyTokenTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceProxyTokenTests.cs
@@ -302,6 +302,7 @@ public class ContainerOrchestrationServiceProxyTokenTests : IDisposable
         private readonly string _token;
         public StubServiceTokenService(string token) { _token = token; }
         public Task<string> GetAccessTokenAsync(CancellationToken ct = default) => Task.FromResult(_token);
+        public Task<string> GetAccessTokenAsync(string audience, CancellationToken ct = default) => Task.FromResult(_token);
     }
 
     /// <summary>

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceProxyTokenTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceProxyTokenTests.cs
@@ -1,0 +1,348 @@
+using Andy.Containers.Abstractions;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+/// <summary>
+/// rivoli-ai/conductor#943 (M1.5.1). Covers the per-container
+/// proxy-token path in
+/// <see cref="ContainerOrchestrationService.CreateContainerAsync"/>
+/// and <see cref="ContainerOrchestrationService.DestroyContainerAsync"/>:
+/// minting, persistence on the <see cref="Container"/> row,
+/// fail-fast on andy-models errors, and revoke-on-destroy.
+/// </summary>
+public class ContainerOrchestrationServiceProxyTokenTests : IDisposable
+{
+    private readonly ContainersDbContext _db;
+    private readonly Mock<IInfrastructureRoutingService> _mockRouting = new();
+    private readonly Mock<IInfrastructureProviderFactory> _mockFactory = new();
+    private readonly Mock<IInfrastructureProvider> _mockInfra = new();
+    private readonly ContainerProvisioningQueue _queue = new();
+    private readonly Mock<IGitRepositoryProbeService> _mockProbe = new();
+    private readonly EphemeralDataProtectionProvider _dataProtection = new();
+
+    public ContainerOrchestrationServiceProxyTokenTests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+        _mockFactory.Setup(f => f.GetProvider(It.IsAny<InfrastructureProvider>()))
+            .Returns(_mockInfra.Object);
+        _mockProbe.Setup(p => p.ProbeRepositoriesAsync(
+                It.IsAny<IReadOnlyList<GitRepositoryConfig>>(),
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<string>());
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    // -----------------------------------------------------------------
+    // Happy path: per-container token wins over shared M2M
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateContainer_WithClaudeCodeAssistant_MintsPerContainerTokenAndPersists()
+    {
+        var (template, provider) = await SeedAsync();
+        var proxyService = new StubProxyTokenService(
+            mintResult: new MintedProxyToken(
+                Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+                "per.container.jwt",
+                DateTimeOffset.Parse("2026-06-01T00:00:00Z")));
+        var sharedTokens = new StubServiceTokenService("shared-m2m-must-not-be-used");
+        var service = MakeService(sharedTokens, proxyService);
+
+        var created = await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "claude-container",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            OwnerId = "user-42",
+            CodeAssistant = new CodeAssistantConfig { Tool = CodeAssistantType.ClaudeCode },
+        }, CancellationToken.None);
+
+        // Persisted on Container row
+        var fromDb = await _db.Containers.FindAsync(created.Id);
+        fromDb.Should().NotBeNull();
+        fromDb!.ProxyServiceTokenId.Should().Be(Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
+        fromDb.ProxyTokenIssuedAt.Should().NotBeNull();
+        fromDb.ProxyServiceToken.Should().NotBeNullOrEmpty();
+        fromDb.ProxyServiceToken.Should().NotBe("per.container.jwt",
+            "the persisted token must be encrypted at rest, not the raw JWT.");
+        // Round-trip through the same protector recovers the JWT
+        var protector = _dataProtection.CreateProtector("Container.ProxyServiceToken");
+        protector.Unprotect(fromDb.ProxyServiceToken!).Should().Be("per.container.jwt");
+
+        // Injected as ANDY_SERVICE_TOKEN, NOT the shared M2M
+        var job = await ReadEnqueuedJobAsync();
+        job.EnvironmentVariables.Should().NotBeNull();
+        job.EnvironmentVariables!["ANDY_SERVICE_TOKEN"].Should().Be("per.container.jwt");
+
+        // Mint call carried the right shape
+        proxyService.LastMintCall.Should().NotBeNull();
+        proxyService.LastMintCall!.Value.containerId.Should().Be(created.Id.ToString());
+        proxyService.LastMintCall.Value.subjectId.Should().Be("user-42");
+        proxyService.LastMintCall.Value.slugs.Should().Equal("anthropic/claude-sonnet-4-6");
+    }
+
+    [Fact]
+    public async Task CreateContainer_WithExplicitRequiredSlugs_UsesThemInsteadOfDefault()
+    {
+        var (template, provider) = await SeedAsync();
+        var proxyService = new StubProxyTokenService(
+            mintResult: new MintedProxyToken(
+                Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+                "scoped.jwt",
+                DateTimeOffset.UtcNow.AddHours(1)));
+        var service = MakeService(new StubServiceTokenService("shared-tok"), proxyService);
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "custom-slugs",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            OwnerId = "user-1",
+            CodeAssistant = new CodeAssistantConfig
+            {
+                Tool = CodeAssistantType.ClaudeCode,
+                RequiredModelSlugs = new List<string> { "anthropic/claude-opus-4", "anthropic/claude-haiku-4-5" },
+            },
+        }, CancellationToken.None);
+
+        proxyService.LastMintCall!.Value.slugs.Should().Equal(
+            "anthropic/claude-opus-4", "anthropic/claude-haiku-4-5");
+    }
+
+    // -----------------------------------------------------------------
+    // Fall-through paths: shared M2M still works when no slugs
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateContainer_NoCodeAssistant_FallsBackToSharedM2MToken()
+    {
+        var (template, provider) = await SeedAsync();
+        var proxyService = new StubProxyTokenService();
+        var service = MakeService(new StubServiceTokenService("shared-m2m-token"), proxyService);
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "no-assistant",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+        }, CancellationToken.None);
+
+        var job = await ReadEnqueuedJobAsync();
+        job.EnvironmentVariables!["ANDY_SERVICE_TOKEN"].Should().Be("shared-m2m-token");
+        proxyService.MintCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CreateContainer_AssistantWithExplicitEmptySlugs_FallsBackToSharedM2MToken()
+    {
+        var (template, provider) = await SeedAsync();
+        var proxyService = new StubProxyTokenService();
+        var service = MakeService(new StubServiceTokenService("shared-tok"), proxyService);
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "ollama-style",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            CodeAssistant = new CodeAssistantConfig
+            {
+                Tool = CodeAssistantType.OpenCode,
+                // Explicit empty: "I'm doing my own auth (e.g. Ollama)"
+                RequiredModelSlugs = new List<string>(),
+            },
+        }, CancellationToken.None);
+
+        var job = await ReadEnqueuedJobAsync();
+        job.EnvironmentVariables!["ANDY_SERVICE_TOKEN"].Should().Be("shared-tok");
+        proxyService.MintCallCount.Should().Be(0);
+    }
+
+    // -----------------------------------------------------------------
+    // Fail-fast: andy-models down for a container that needs a token
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateContainer_AndyModelsUnreachable_ThrowsInvalidOperationException()
+    {
+        var (template, provider) = await SeedAsync();
+        var proxyService = new StubProxyTokenService(
+            mintException: new ProxyTokenException("andy-models unreachable at http://andy-models.test"));
+        var service = MakeService(new StubServiceTokenService("shared-tok"), proxyService);
+
+        await FluentActions.Awaiting(() => service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "fail-fast",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            CodeAssistant = new CodeAssistantConfig { Tool = CodeAssistantType.ClaudeCode },
+        }, CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*could not mint per-container proxy token*andy-models*");
+    }
+
+    // -----------------------------------------------------------------
+    // Revoke on destroy
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task DestroyContainer_WhenTokenWasMinted_RevokesIt()
+    {
+        var (template, provider) = await SeedAsync();
+        var tokenId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        var proxyService = new StubProxyTokenService(
+            mintResult: new MintedProxyToken(tokenId, "j.w.t", DateTimeOffset.UtcNow.AddHours(1)));
+        var service = MakeService(new StubServiceTokenService("shared-tok"), proxyService);
+
+        var created = await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "destroyable",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            CodeAssistant = new CodeAssistantConfig { Tool = CodeAssistantType.ClaudeCode },
+        }, CancellationToken.None);
+
+        await service.DestroyContainerAsync(created.Id, CancellationToken.None);
+
+        proxyService.RevokeCalls.Should().ContainSingle().Which.Should().Be(tokenId);
+
+        var afterDestroy = await _db.Containers.FindAsync(created.Id);
+        afterDestroy!.ProxyServiceTokenId.Should().BeNull(
+            "the Container row's token ref clears on destroy so a future query can't surface a revoked id.");
+        afterDestroy.ProxyServiceToken.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DestroyContainer_WhenNoTokenWasMinted_DoesNotCallRevoke()
+    {
+        var (template, provider) = await SeedAsync();
+        var proxyService = new StubProxyTokenService();
+        var service = MakeService(new StubServiceTokenService("shared-tok"), proxyService);
+
+        var created = await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "no-token-destroy",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+        }, CancellationToken.None);
+
+        await service.DestroyContainerAsync(created.Id, CancellationToken.None);
+
+        proxyService.RevokeCalls.Should().BeEmpty();
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private async Task<(ContainerTemplate template, InfrastructureProvider provider)> SeedAsync()
+    {
+        var template = new ContainerTemplate
+        {
+            Code = "proxy-tok-test",
+            Name = "Proxy token test",
+            Version = "1.0.0",
+            BaseImage = "ubuntu:24.04",
+        };
+        var provider = new InfrastructureProvider
+        {
+            Code = "tok-provider",
+            Name = "Provider",
+            Type = ProviderType.Docker,
+            IsEnabled = true,
+        };
+        _db.Templates.Add(template);
+        _db.Providers.Add(provider);
+        await _db.SaveChangesAsync();
+        return (template, provider);
+    }
+
+    private ContainerOrchestrationService MakeService(
+        IServiceTokenService sharedTokens,
+        IProxyTokenService proxyTokens)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+        return new ContainerOrchestrationService(
+            _db,
+            _mockRouting.Object,
+            _mockFactory.Object,
+            _queue,
+            _mockProbe.Object,
+            new Mock<IApiKeyService>().Object,
+            config,
+            NullLogger<ContainerOrchestrationService>.Instance,
+            serviceTokenService: sharedTokens,
+            proxyTokenService: proxyTokens,
+            dataProtection: _dataProtection);
+    }
+
+    private async Task<ContainerProvisionJob> ReadEnqueuedJobAsync()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        return await _queue.Reader.ReadAsync(cts.Token);
+    }
+
+    private sealed class StubServiceTokenService : IServiceTokenService
+    {
+        private readonly string _token;
+        public StubServiceTokenService(string token) { _token = token; }
+        public Task<string> GetAccessTokenAsync(CancellationToken ct = default) => Task.FromResult(_token);
+    }
+
+    /// <summary>
+    /// Configurable stub: mint returns a fixed result (or null), or
+    /// throws a fixed exception. Records every mint call's args + every
+    /// revoke call's tokenId for assertions.
+    /// </summary>
+    private sealed class StubProxyTokenService : IProxyTokenService
+    {
+        private readonly MintedProxyToken? _mintResult;
+        private readonly ProxyTokenException? _mintException;
+
+        public List<Guid> RevokeCalls { get; } = new();
+        public int MintCallCount { get; private set; }
+        public (string containerId, string subjectId, IReadOnlyList<string> slugs)? LastMintCall { get; private set; }
+
+        public StubProxyTokenService(MintedProxyToken? mintResult = null, ProxyTokenException? mintException = null)
+        {
+            _mintResult = mintResult;
+            _mintException = mintException;
+        }
+
+        public Task<MintedProxyToken?> MintForContainerAsync(
+            string containerId,
+            string subjectId,
+            IReadOnlyList<string> allowedSlugs,
+            CancellationToken ct = default)
+        {
+            MintCallCount++;
+            LastMintCall = (containerId, subjectId, allowedSlugs);
+            if (_mintException is not null)
+            {
+                return Task.FromException<MintedProxyToken?>(_mintException);
+            }
+            return Task.FromResult(_mintResult);
+        }
+
+        public Task RevokeAsync(Guid tokenId, CancellationToken ct = default)
+        {
+            RevokeCalls.Add(tokenId);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTokenInjectionTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTokenInjectionTests.cs
@@ -248,5 +248,8 @@ public class ContainerOrchestrationServiceTokenInjectionTests : IDisposable
             => _exception is not null
                 ? Task.FromException<string>(_exception)
                 : Task.FromResult(_token!);
+
+        public Task<string> GetAccessTokenAsync(string audience, CancellationToken ct = default)
+            => GetAccessTokenAsync(ct);
     }
 }

--- a/tests/Andy.Containers.Api.Tests/Services/ServiceTokenServiceTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ServiceTokenServiceTests.cs
@@ -171,6 +171,88 @@ public class ServiceTokenServiceTests
     }
 
     // -----------------------------------------------------------------
+    // Per-audience tokens (rivoli-ai/conductor#1055)
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAccessToken_WithExplicitAudience_SendsThatAudienceInScope()
+    {
+        var (service, handler) = MakeService(opts =>
+        {
+            opts.TokenEndpoint = "http://auth.test/connect/token";
+            opts.ClientId = "andy-containers-api";
+            opts.ClientSecret = "s3cret";
+            opts.Audience = "urn:andy-containers-api";
+        });
+        handler.SetSuccessJsonResponse(@"{""access_token"":""cross-aud-tok"",""token_type"":""Bearer"",""expires_in"":3600}");
+
+        var token = await service.GetAccessTokenAsync("urn:andy-models-api");
+
+        token.Should().Be("cross-aud-tok");
+        handler.LastBody.Should().Contain("scope=urn%3Aandy-models-api",
+            "explicit audience must take precedence over ServiceAuth:Audience for inter-service calls.");
+    }
+
+    [Fact]
+    public async Task GetAccessToken_PerAudienceCache_DoesNotCrossPollinate()
+    {
+        var (service, handler) = MakeService(opts => opts.TokenEndpoint = "http://auth.test/connect/token");
+        // The stub returns the same body for every call — we're
+        // asserting the call COUNT and request shape, not distinct
+        // bodies, because we want to know whether the service mints
+        // twice (correct: once per audience) vs. once (wrong: would
+        // mean it returned the cached default-audience token when
+        // asked for a different audience).
+        handler.SetSuccessJsonResponse(@"{""access_token"":""tok"",""token_type"":""Bearer"",""expires_in"":3600}");
+
+        _ = await service.GetAccessTokenAsync("urn:andy-containers-api");
+        _ = await service.GetAccessTokenAsync("urn:andy-models-api");
+        _ = await service.GetAccessTokenAsync("urn:andy-containers-api");
+        _ = await service.GetAccessTokenAsync("urn:andy-models-api");
+
+        handler.RequestCount.Should().Be(2,
+            "each distinct audience mints exactly once; repeat calls per audience hit the per-slot cache.");
+    }
+
+    [Fact]
+    public async Task GetAccessToken_ParameterlessOverload_UsesConfiguredDefaultAudience()
+    {
+        var (service, handler) = MakeService(opts =>
+        {
+            opts.TokenEndpoint = "http://auth.test/connect/token";
+            opts.Audience = "urn:andy-containers-api";
+        });
+        handler.SetSuccessJsonResponse(@"{""access_token"":""tok"",""token_type"":""Bearer"",""expires_in"":3600}");
+
+        _ = await service.GetAccessTokenAsync();
+
+        handler.LastBody.Should().Contain("scope=urn%3Aandy-containers-api",
+            "the parameterless overload preserves pre-#1055 behaviour for callers that don't care about audience.");
+    }
+
+    [Fact]
+    public async Task GetAccessToken_EmptyAudienceArg_ThrowsServiceTokenException()
+    {
+        var (service, _) = MakeService();
+
+        Func<Task> call = () => service.GetAccessTokenAsync("", CancellationToken.None);
+
+        await call.Should().ThrowAsync<ServiceTokenException>()
+            .WithMessage("*Audience is required*");
+    }
+
+    [Fact]
+    public async Task GetAccessToken_DefaultOverload_WithUnconfiguredAudience_ThrowsServiceTokenException()
+    {
+        var (service, _) = MakeService(opts => opts.Audience = string.Empty);
+
+        Func<Task> call = () => service.GetAccessTokenAsync();
+
+        await call.Should().ThrowAsync<ServiceTokenException>()
+            .WithMessage("*ServiceAuth:Audience is not configured*");
+    }
+
+    // -----------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------
 
@@ -199,8 +281,15 @@ public class ServiceTokenServiceTests
 
     private sealed class StubHttpHandler : HttpMessageHandler
     {
-        private HttpResponseMessage _response =
-            new(HttpStatusCode.OK) { Content = new StringContent("{}") };
+        // Store the JSON template separately from any built
+        // HttpResponseMessage so multi-call tests (e.g. per-audience
+        // cache) get fresh content per call. HttpClient disposes the
+        // response content after each request, so reusing a single
+        // StringContent across calls throws ObjectDisposedException
+        // on the second call.
+        private string? _jsonBody;
+        private HttpStatusCode _statusCode = HttpStatusCode.OK;
+        private HttpResponseMessage? _fixedResponse;
         private Exception? _sendException;
 
         public int RequestCount { get; private set; }
@@ -212,16 +301,16 @@ public class ServiceTokenServiceTests
         public void SetSuccessJsonResponse(string json)
         {
             _sendException = null;
-            _response = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(json, Encoding.UTF8, "application/json"),
-            };
+            _fixedResponse = null;
+            _jsonBody = json;
+            _statusCode = HttpStatusCode.OK;
         }
 
         public void SetResponse(HttpResponseMessage response)
         {
             _sendException = null;
-            _response = response;
+            _jsonBody = null;
+            _fixedResponse = response;
         }
 
         public void SetSendException(Exception ex)
@@ -243,7 +332,14 @@ public class ServiceTokenServiceTests
                 ? string.Empty
                 : await request.Content.ReadAsStringAsync(cancellationToken);
             if (_sendException is not null) throw _sendException;
-            return _response;
+            if (_fixedResponse is not null) return _fixedResponse;
+            // Fresh content per call so consecutive SendAsyncs work.
+            return new HttpResponseMessage(_statusCode)
+            {
+                Content = _jsonBody is null
+                    ? new StringContent("{}")
+                    : new StringContent(_jsonBody, Encoding.UTF8, "application/json"),
+            };
         }
     }
 

--- a/tests/Andy.Containers.Api.Tests/Services/ToolSlugDefaultsTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ToolSlugDefaultsTests.cs
@@ -1,0 +1,92 @@
+using Andy.Containers.Api.Services;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+/// <summary>
+/// rivoli-ai/conductor#943. Covers the Tool → default slug map and the
+/// override rules (null = use default; non-null = use explicit value
+/// including explicit empty).
+/// </summary>
+public class ToolSlugDefaultsTests
+{
+    [Fact]
+    public void Resolve_WhenRequiredModelSlugsIsSet_ReturnsExplicitOverride()
+    {
+        var config = new CodeAssistantConfig
+        {
+            Tool = CodeAssistantType.ClaudeCode,
+            RequiredModelSlugs = new List<string> { "anthropic/claude-opus-4" },
+        };
+
+        var slugs = ToolSlugDefaults.Resolve(config);
+
+        slugs.Should().Equal("anthropic/claude-opus-4");
+    }
+
+    [Fact]
+    public void Resolve_WhenRequiredModelSlugsIsExplicitlyEmpty_ReturnsEmpty()
+    {
+        var config = new CodeAssistantConfig
+        {
+            Tool = CodeAssistantType.ClaudeCode,
+            // Explicit empty: "I know the default but I want no proxy token."
+            RequiredModelSlugs = new List<string>(),
+        };
+
+        var slugs = ToolSlugDefaults.Resolve(config);
+
+        slugs.Should().BeEmpty(
+            "explicit empty list means the caller knows they don't need a proxy token (e.g. local-only setup).");
+    }
+
+    [Fact]
+    public void Resolve_WhenRequiredModelSlugsIsNull_ClaudeCode_FallsBackToAnthropicSonnetDefault()
+    {
+        var config = new CodeAssistantConfig
+        {
+            Tool = CodeAssistantType.ClaudeCode,
+            RequiredModelSlugs = null,
+        };
+
+        var slugs = ToolSlugDefaults.Resolve(config);
+
+        slugs.Should().Equal("anthropic/claude-sonnet-4-6");
+    }
+
+    [Fact]
+    public void Resolve_WhenRequiredModelSlugsIsNull_OpenCode_FallsBackToEmpty()
+    {
+        var config = new CodeAssistantConfig
+        {
+            Tool = CodeAssistantType.OpenCode,
+            RequiredModelSlugs = null,
+        };
+
+        var slugs = ToolSlugDefaults.Resolve(config);
+
+        slugs.Should().BeEmpty(
+            "OpenCode is multi-provider; without an explicit slug list we don't guess.");
+    }
+
+    [Theory]
+    [InlineData(CodeAssistantType.Aider)]
+    [InlineData(CodeAssistantType.CodexCli)]
+    [InlineData(CodeAssistantType.Continue)]
+    [InlineData(CodeAssistantType.QwenCoder)]
+    [InlineData(CodeAssistantType.GeminiCode)]
+    [InlineData(CodeAssistantType.GitHubCopilot)]
+    [InlineData(CodeAssistantType.AmazonQ)]
+    [InlineData(CodeAssistantType.Cline)]
+    public void Resolve_UnmappedTools_FallBackToEmpty(CodeAssistantType tool)
+    {
+        var config = new CodeAssistantConfig { Tool = tool };
+
+        var slugs = ToolSlugDefaults.Resolve(config);
+
+        slugs.Should().BeEmpty(
+            "tools without a concrete default must fall back to empty rather than a wrongly-scoped guess.");
+    }
+}


### PR DESCRIPTION
## Summary

Close the loop on M1.5.1: at container creation time, andy-containers now calls andy-models' `POST /api/proxy/tokens` (M1.3.3) to mint a JWT scoped to `{containerId, allowedSlugs[]}` and injects **that** as `ANDY_SERVICE_TOKEN` — narrower than the shared M2M bearer the orchestrator carries itself. The container's code assistant calls the unified proxy with a token that can only use the model slugs we declared at provision time.

Pairs with the M1.3.3 / M1.3.4 work already shipped in andy-models (`ProxyTokensController`, `ContainerTokenService`, slug-scoped `IProxyAccessGuard`).

## What's new

- `CodeAssistantConfig.RequiredModelSlugs: List<string>?` — explicit per-template override of the default slug list.
- `ToolSlugDefaults` — static fallback: ClaudeCode → `anthropic/claude-sonnet-4-6`; everything else → empty (no proxy token).
- `IProxyTokenService` + `AndyModelsProxyTokenService` — mint + revoke client to andy-models, authenticated with the existing M2M bearer from `IServiceTokenService`.
- `Container.ProxyServiceTokenId` + `ProxyServiceToken` (encrypted via `IDataProtector`, purpose `"Container.ProxyServiceToken"`) + `ProxyTokenIssuedAt` — persisted on the row. EF migration `AddContainerProxyServiceToken`.
- `AndyModelsOptions` bound from `AndyModels:` (`BaseUrl`, `TokenLifetimeSeconds`).

## Behaviour change

**Create path** — when the chosen code assistant has a non-empty slug list:
- Mint per-container token, persist (encrypted) on row, inject as `ANDY_SERVICE_TOKEN`.
- On `ProxyTokenException` (andy-models unreachable / 5xx / malformed): throw `InvalidOperationException`. The user gets a clear error pointing at andy-models health instead of a container whose assistant fails opaquely with 401s later.

When there's no code assistant or slugs are explicitly empty (Ollama / OpenAI-compatible self-hosted):
- Fall back to the previous shared M2M bearer path — best-effort, logged-on-failure, never blocks create.

**Destroy path** — revokes the per-container token via `DELETE /api/proxy/tokens/{id}` when one was minted. Transport / 4xx failures are swallowed; the JWT's `exp` claim is the backstop, so destroy never wedges.

## Test plan

- [x] `ToolSlugDefaultsTests` — 12 cases. Explicit override, explicit empty, null fallback, every unmapped tool.
- [x] `AndyModelsProxyTokenServiceTests` — 14 cases. Mint happy path, bearer + URL + body shape, base-URL-with-path joining, every error class (transport, 5xx, missing fields, ServiceTokenException bubble, missing config). Revoke happy, 4xx swallow, transport swallow, empty-guid no-op, missing-config no-op.
- [x] `ContainerOrchestrationServiceProxyTokenTests` — 7 cases. Persists encrypted token on Container row + round-trips through `IDataProtector`; injects per-container JWT (not M2M); uses explicit slugs when supplied; falls back to M2M with no assistant / empty slugs; throws InvalidOperationException on `ProxyTokenException`; revokes on `DestroyContainerAsync`.
- [x] All 95 related tests pass (orchestration / token / proxy areas).
- [x] No regressions: pre-existing Postgres-connectivity failures (`TerminalControllerTests`, integration tests probing `127.0.0.1:1`) are unchanged by this PR.

## Acceptance criteria checklist

- [x] `CodeAssistantConfig` extended with `RequiredModelSlugs: List<string>?`; null falls back to Tool→slugs default map
- [x] EF migration adds `Container.ProxyServiceToken` (encrypted) + `Container.ProxyServiceTokenId` + `Container.ProxyTokenIssuedAt`
- [x] `ContainerOrchestrationService.CreateContainerAsync` calls andy-models to mint before returning
- [x] Token persisted on the row
- [x] On destroy, token revoked via `DELETE /api/proxy/tokens/{id}`
- [x] If andy-models unreachable at create time, container creation fails fast with a structured error pointing at andy-models health
- [ ] Token lifetime defaults to 7 days; renewed automatically on next start — deferred to M1.5.2 (rivoli-ai/conductor#1052 tracks in-container refresh)

Closes rivoli-ai/conductor#943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)