### PR TITLE
test: clean up two pre-existing test-suite failures (tmux assertion + Apple CLI skip)

### DIFF
--- a/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
@@ -603,13 +603,15 @@ public class TerminalControllerTests : IDisposable
     public void ShellCommand_TmuxInvocationCreatesTheProbedSession()
     {
         // Specifically check the tmux invocation form, not just
-        // session-name-presence. `new-session -A` is the form that
-        // "attaches if exists OR creates if not" — the right semantic
-        // for first-attach + reattach. Other forms would create a
-        // NEW session every time and break persistence.
+        // session-name-presence. `new-session -A -D` is the form that
+        // "attaches if exists OR creates if not, and detaches any
+        // stale clients first" — the right semantic for first-attach
+        // + reattach. Without -A, a second attach would create a NEW
+        // session and break persistence; without -D, stale clients
+        // from a previous tab linger and steal input (see #220).
         var cmd = TerminalController.BuildContainerShellCommand(rows: 40, cols: 120);
-        cmd.Should().Contain($"new-session -A -s {TerminalController.TmuxSessionName} bash -i",
-            "must use `new-session -A` for attach-or-create");
+        cmd.Should().Contain($"new-session -A -D -s {TerminalController.TmuxSessionName} bash -i",
+            "must use `new-session -A -D` — `-A` for attach-or-create, `-D` to detach stale clients (#220).");
     }
 
     // MARK: - Reattach-without-banner end-to-end contract

--- a/tests/Andy.Containers.Integration.Tests/AppleContainerCliFactAttribute.cs
+++ b/tests/Andy.Containers.Integration.Tests/AppleContainerCliFactAttribute.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Diagnostics;
+using Xunit;
+
+namespace Andy.Containers.Integration.Tests;
+
+// Fact attribute that skips when Apple's `container` CLI is not
+// installed on PATH. AppleContainerProvider integration tests spawn
+// the CLI directly; without it they fail with a Win32Exception ("No
+// such file or directory") rather than a clean skip. Mirrors
+// NatsFactAttribute's env-var gate pattern.
+//
+// Detection is `which container` on Unix-like systems. Cached at
+// process scope so a developer running `dotnet test` repeatedly
+// doesn't pay the probe cost on every fact.
+public sealed class AppleContainerCliFactAttribute : FactAttribute
+{
+    private static readonly Lazy<bool> _cliPresent = new(ProbeForCli);
+
+    public AppleContainerCliFactAttribute()
+    {
+        if (!_cliPresent.Value)
+        {
+            Skip = "Apple `container` CLI not on PATH; skipping integration test that requires it. " +
+                   "Install Apple's container runtime (https://github.com/apple/container) and run " +
+                   "`container system start` to enable these tests.";
+        }
+    }
+
+    private static bool ProbeForCli()
+    {
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "/usr/bin/which",
+                Arguments = "container",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            });
+            if (process is null) return false;
+            process.WaitForExit(milliseconds: 1000);
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            // Anything goes wrong (no `which`, no /usr/bin/which on
+            // Windows, etc.) → treat as "not present" and skip rather
+            // than crashing the test infra.
+            return false;
+        }
+    }
+}

--- a/tests/Andy.Containers.Integration.Tests/AppleContainerProviderTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/AppleContainerProviderTests.cs
@@ -40,7 +40,7 @@ public class AppleContainerProviderTests : IAsyncLifetime
         }
     }
 
-    [Fact]
+    [AppleContainerCliFact]
     public async Task HealthCheck_WhenServiceRunning_ShouldReturnHealthy()
     {
         var health = await _provider.HealthCheckAsync(CancellationToken.None);
@@ -48,7 +48,7 @@ public class AppleContainerProviderTests : IAsyncLifetime
         health.Should().Be(ProviderHealth.Healthy);
     }
 
-    [Fact]
+    [AppleContainerCliFact]
     public async Task FullLifecycle_CreateStartExecStopDestroy()
     {
         // 1. Create container
@@ -96,7 +96,7 @@ public class AppleContainerProviderTests : IAsyncLifetime
         _externalId = null; // already cleaned up
     }
 
-    [Fact]
+    [AppleContainerCliFact]
     public async Task TmuxSession_SurvivesDisconnectAndReattach()
     {
         // Setup: create a container with tmux installed
@@ -161,7 +161,7 @@ public class AppleContainerProviderTests : IAsyncLifetime
         reconnectMarker.StdOut.Should().Contain("RECONNECT_TEST", "state written in tmux session should persist across reconnects");
     }
 
-    [Fact]
+    [AppleContainerCliFact]
     public async Task GetCapabilities_ShouldReturnAppleContainerCapabilities()
     {
         var caps = await _provider.GetCapabilitiesAsync(CancellationToken.None);


### PR DESCRIPTION
## Summary

\`dotnet test\` on a fresh dev machine reports 4 failures unrelated to any recent feature work. Both root causes are fixed here so the suite is green on a clean checkout.

## 1. \`TerminalControllerTests.ShellCommand_TmuxInvocationCreatesTheProbedSession\`

Commit 1f18bcd (\"fix(terminal): detach stale tmux clients on each attach (-A -D) (#220)\") added \`-D\` to the tmux \`new-session\` invocation but did not update this assertion, which still expected the pre-#220 form (\`new-session -A -s …\`).

Updated the expected substring to \`new-session -A -D -s …\` and refreshed the explanation comment so both flags' semantics are documented in the assertion message.

## 2. \`AppleContainerProviderTests\` × 3 (HealthCheck, FullLifecycle, TmuxSession_SurvivesDisconnectAndReattach)

These tests spawn Apple's \`container\` CLI. On a dev machine without the Apple container runtime installed, they fail with \`Win32Exception(\"No such file or directory\")\` instead of cleanly skipping. The class docstring already documents the requirement (macOS + \`container\` CLI + \`container system start\`).

Adds \`AppleContainerCliFactAttribute\` — a custom \`FactAttribute\` that probes for the CLI on PATH (\`/usr/bin/which container\`) at first use and sets \`Skip\` when absent. Mirrors the existing \`NatsFactAttribute\` pattern at \`tests/.../Messaging/NatsFactAttribute.cs\`. Result is cached at process scope so \`dotnet test\` doesn't pay the probe cost per fact.

All 4 \`[Fact]\`s in \`AppleContainerProviderTests\` swap to \`[AppleContainerCliFact]\`.

## Test plan

- [x] Before: 4 failures (1 in Api.Tests, 3 in Integration.Tests)
- [x] After:
  - \`Passed! - Failed: 0, Passed: 1010, Skipped:  1, Total: 1011\` (Api.Tests)
  - \`Passed! - Failed: 0, Passed:   43, Skipped:  7, Total:   50\` (Integration.Tests)
- [x] The 8 cleanly-skipped tests reflect missing optional infrastructure on a dev machine (Apple \`container\` CLI + NATS) — same gating pattern as before, just consistently applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)