### PR TITLE
feat(rivoli-ai/conductor#945): surface code-assistant install outcome on Container row + retry endpoint

### DIFF
--- a/src/Andy.Containers.Api/Controllers/ContainersController.cs
+++ b/src/Andy.Containers.Api/Controllers/ContainersController.cs
@@ -234,6 +234,88 @@ public class ContainersController : ControllerBase
         return Ok(result);
     }
 
+    /// <summary>
+    /// rivoli-ai/conductor#945 (M1.5.3). Re-run the code-assistant
+    /// install for a container that surfaced a Failed or Skipped
+    /// status. The container must be Running (the install script
+    /// execs inside it) and have a code assistant configured (we read
+    /// the config back from <c>Container.CodeAssistant</c>'s JSON
+    /// blob — same source the worker uses).
+    /// </summary>
+    [HttpPost("{id:guid}/retry-code-assistant-install")]
+    [RequirePermission("container:execute")]
+    public async Task<IActionResult> RetryCodeAssistantInstall(
+        Guid id,
+        [FromServices] ICodeAssistantInstallExecutor executor,
+        CancellationToken ct)
+    {
+        var container = await _containerService.GetContainerAsync(id, ct);
+        if (!CanAccess(container)) return Forbid();
+
+        if (container.Status != ContainerStatus.Running)
+        {
+            return UnprocessableEntity(new
+            {
+                error = new
+                {
+                    type = "container_not_running",
+                    message = $"Container is {container.Status}; retry requires Running."
+                }
+            });
+        }
+
+        if (string.IsNullOrWhiteSpace(container.CodeAssistant))
+        {
+            return UnprocessableEntity(new
+            {
+                error = new
+                {
+                    type = "no_code_assistant_configured",
+                    message = "Container has no code assistant configured; nothing to retry."
+                }
+            });
+        }
+
+        CodeAssistantConfig? codeAssistant;
+        try
+        {
+            codeAssistant = System.Text.Json.JsonSerializer.Deserialize<CodeAssistantConfig>(container.CodeAssistant);
+        }
+        catch (Exception ex)
+        {
+            return UnprocessableEntity(new
+            {
+                error = new
+                {
+                    type = "code_assistant_config_unreadable",
+                    message = $"Could not parse Container.CodeAssistant: {ex.GetType().Name}: {ex.Message}"
+                }
+            });
+        }
+        if (codeAssistant is null)
+        {
+            return UnprocessableEntity(new
+            {
+                error = new
+                {
+                    type = "code_assistant_config_unreadable",
+                    message = "Container.CodeAssistant deserialised to null."
+                }
+            });
+        }
+
+        await executor.RunAsync(container, codeAssistant, ct);
+        await _db.SaveChangesAsync(ct);
+
+        return Ok(new
+        {
+            container.Id,
+            container.CodeAssistantStatus,
+            container.CodeAssistantStatusReason,
+            container.CodeAssistantStatusAt,
+        });
+    }
+
     [HttpGet("{id:guid}/connection")]
     [RequirePermission("container:read")]
     public async Task<IActionResult> GetConnectionInfo(Guid id, CancellationToken ct)

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -154,6 +154,10 @@ try
     builder.Services.AddScoped<IGitCloneService, GitCloneService>();
     builder.Services.AddScoped<IGitRepositoryProbeService, GitRepositoryProbeService>();
     builder.Services.AddSingleton<ICodeAssistantInstallService, CodeAssistantInstallService>();
+    // rivoli-ai/conductor#945 (M1.5.3). Scoped so it pulls a fresh
+    // IContainerService per call (which is itself scoped because it
+    // takes ContainersDbContext).
+    builder.Services.AddScoped<ICodeAssistantInstallExecutor, CodeAssistantInstallExecutor>();
     builder.Services.AddScoped<IApiKeyService, ApiKeyService>();
     builder.Services.AddScoped<IApiKeyValidationService, ApiKeyValidationService>();
     builder.Services.AddHttpClient("ApiKeyValidation");

--- a/src/Andy.Containers.Api/Services/CodeAssistantInstallExecutor.cs
+++ b/src/Andy.Containers.Api/Services/CodeAssistantInstallExecutor.cs
@@ -1,0 +1,144 @@
+using Andy.Containers.Abstractions;
+using Andy.Containers.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// rivoli-ai/conductor#945 (M1.5.3). Default
+/// <see cref="ICodeAssistantInstallExecutor"/>: generate script via
+/// <see cref="ICodeAssistantInstallService"/>, exec via
+/// <see cref="IContainerService"/>, capture outcome on the
+/// <see cref="Container"/> row.
+/// </summary>
+public sealed class CodeAssistantInstallExecutor : ICodeAssistantInstallExecutor
+{
+    /// <summary>
+    /// Time budget for the install script. The npm/cargo/pip
+    /// installers some assistants drag in can be slow on first run
+    /// (no cache, dial-up corp networks); 10 minutes covers all
+    /// pre-bake-less variants we ship today.
+    /// </summary>
+    public static readonly TimeSpan InstallTimeout = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// Cap on the captured stderr / exception summary persisted in
+    /// <see cref="Container.CodeAssistantStatusReason"/>. The UI
+    /// renders this in a banner; gigabytes of npm output would blow
+    /// the row up and offer the user no actionable signal anyway.
+    /// </summary>
+    public const int StatusReasonMaxLength = 500;
+
+    private readonly ICodeAssistantInstallService _installService;
+    private readonly IContainerService _containerService;
+    private readonly TimeProvider _time;
+    private readonly ILogger<CodeAssistantInstallExecutor> _logger;
+
+    public CodeAssistantInstallExecutor(
+        ICodeAssistantInstallService installService,
+        IContainerService containerService,
+        ILogger<CodeAssistantInstallExecutor> logger,
+        TimeProvider? time = null)
+    {
+        _installService = installService;
+        _containerService = containerService;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task RunAsync(Container container, CodeAssistantConfig codeAssistant, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(container);
+        ArgumentNullException.ThrowIfNull(codeAssistant);
+
+        // Mark Installing immediately. If the caller persists the row
+        // before the script returns, the UI sees the in-progress state.
+        container.CodeAssistantStatus = CodeAssistantInstallStatus.Installing;
+        container.CodeAssistantStatusAt = _time.GetUtcNow().UtcDateTime;
+        container.CodeAssistantStatusReason = null;
+
+        string? installScript;
+        try
+        {
+            installScript = _installService.GenerateInstallScript(codeAssistant);
+        }
+        catch (Exception genEx)
+        {
+            container.CodeAssistantStatus = CodeAssistantInstallStatus.Skipped;
+            container.CodeAssistantStatusReason =
+                $"script-generation: {genEx.GetType().Name}: {SummariseReason(genEx.Message)}";
+            container.CodeAssistantStatusAt = _time.GetUtcNow().UtcDateTime;
+            _logger.LogWarning(genEx,
+                "Code assistant install skipped for container {ContainerId}: script generation failed.",
+                container.Id);
+            return;
+        }
+
+        try
+        {
+            _logger.LogInformation(
+                "Installing code assistant {Tool} for container {ContainerId}",
+                codeAssistant.Tool, container.Id);
+            var installResult = await _containerService
+                .ExecAsync(container.Id, installScript, InstallTimeout, ct)
+                .ConfigureAwait(false);
+            container.CodeAssistantStatusAt = _time.GetUtcNow().UtcDateTime;
+            if (installResult.ExitCode != 0)
+            {
+                container.CodeAssistantStatus = CodeAssistantInstallStatus.Failed;
+                container.CodeAssistantStatusReason =
+                    $"exit-code-{installResult.ExitCode}: {SummariseReason(installResult.StdErr)}";
+                _logger.LogWarning(
+                    "Code assistant install exited with {ExitCode} for container {ContainerId}: {StdErr}",
+                    installResult.ExitCode, container.Id, installResult.StdErr);
+            }
+            else
+            {
+                container.CodeAssistantStatus = CodeAssistantInstallStatus.Installed;
+                container.CodeAssistantStatusReason = null;
+                _logger.LogInformation(
+                    "Code assistant {Tool} installed for container {ContainerId}",
+                    codeAssistant.Tool, container.Id);
+            }
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            // Local timeout from ExecAsync's internal CancelAfter —
+            // not a global shutdown. Treat as install timeout.
+            container.CodeAssistantStatus = CodeAssistantInstallStatus.Failed;
+            container.CodeAssistantStatusReason =
+                $"timeout: install script exceeded the {InstallTimeout.TotalMinutes:F0}-minute budget";
+            container.CodeAssistantStatusAt = _time.GetUtcNow().UtcDateTime;
+            _logger.LogWarning(
+                "Code assistant install timed out for container {ContainerId}",
+                container.Id);
+        }
+        catch (Exception ex)
+        {
+            container.CodeAssistantStatus = CodeAssistantInstallStatus.Failed;
+            container.CodeAssistantStatusReason =
+                $"exception: {ex.GetType().Name}: {SummariseReason(ex.Message)}";
+            container.CodeAssistantStatusAt = _time.GetUtcNow().UtcDateTime;
+            _logger.LogWarning(ex,
+                "Code assistant install failed for container {ContainerId}",
+                container.Id);
+        }
+    }
+
+    /// <summary>
+    /// Compress a multi-line stderr / exception message into a
+    /// single-line UI-friendly summary that fits in the Container
+    /// row's status reason column.
+    /// </summary>
+    public static string SummariseReason(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return "<no detail>";
+        var lines = raw.Split(
+            new[] { '\r', '\n' },
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var joined = string.Join(" | ", lines);
+        return joined.Length <= StatusReasonMaxLength
+            ? joined
+            : joined[..(StatusReasonMaxLength - 1)] + "…";
+    }
+}

--- a/src/Andy.Containers.Api/Services/ContainerProvisioningWorker.cs
+++ b/src/Andy.Containers.Api/Services/ContainerProvisioningWorker.cs
@@ -250,31 +250,17 @@ public class ContainerProvisioningWorker : BackgroundService
                 }
             }
 
-            // Install code assistant after post-create scripts
+            // Install code assistant after post-create scripts.
+            // rivoli-ai/conductor#945 (M1.5.3). The container remains
+            // Running on failure (degraded but reachable so the user
+            // can debug), but the outcome is captured on the row so
+            // the UI surfaces a "Code assistant install failed"
+            // banner instead of attaching the user to a workspace
+            // that silently lacks the assistant they picked.
             if (job.CodeAssistant is not null)
             {
-                try
-                {
-                    var installService = scope.ServiceProvider.GetRequiredService<ICodeAssistantInstallService>();
-                    var installScript = installService.GenerateInstallScript(job.CodeAssistant);
-                    var containerService = scope.ServiceProvider.GetRequiredService<IContainerService>();
-
-                    _logger.LogInformation("Installing code assistant {Tool} for container {ContainerId}",
-                        job.CodeAssistant.Tool, job.ContainerId);
-                    var installResult = await containerService.ExecAsync(job.ContainerId, installScript, TimeSpan.FromMinutes(10), stoppingToken);
-                    if (installResult.ExitCode != 0)
-                        _logger.LogWarning("Code assistant install exited with {ExitCode} for container {ContainerId}: {StdErr}",
-                            installResult.ExitCode, job.ContainerId, installResult.StdErr);
-                    else
-                        _logger.LogInformation("Code assistant {Tool} installed for container {ContainerId}",
-                            job.CodeAssistant.Tool, job.ContainerId);
-                }
-                catch (Exception assistantEx)
-                {
-                    // Failed install does NOT fail the container
-                    _logger.LogWarning(assistantEx, "Code assistant install failed for container {ContainerId}, container remains Running",
-                        job.ContainerId);
-                }
+                var executor = scope.ServiceProvider.GetRequiredService<ICodeAssistantInstallExecutor>();
+                await executor.RunAsync(container, job.CodeAssistant, stoppingToken);
             }
 
             // Clone git repositories after container is running

--- a/src/Andy.Containers.Api/Services/ICodeAssistantInstallExecutor.cs
+++ b/src/Andy.Containers.Api/Services/ICodeAssistantInstallExecutor.cs
@@ -1,0 +1,31 @@
+using Andy.Containers.Models;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// rivoli-ai/conductor#945 (M1.5.3). Runs the code-assistant install
+/// script inside a provisioned container and writes the outcome to
+/// <see cref="Container.CodeAssistantStatus"/> + reason + timestamp.
+///
+/// Used by:
+/// - <c>ContainerProvisioningWorker</c> right after the container's
+///   post-create scripts complete.
+/// - <c>ContainersController</c>'s retry-install endpoint when the
+///   user clicks "Retry install" on a failed/skipped row.
+///
+/// Shared so the status semantics (Installed / Failed / Skipped /
+/// Installing + reason format) stay identical across both call sites
+/// — the UI banner doesn't care which trigger produced the row.
+/// </summary>
+public interface ICodeAssistantInstallExecutor
+{
+    /// <summary>
+    /// Generate the install script for <paramref name="codeAssistant"/>,
+    /// exec it inside <paramref name="container"/>, and mutate the
+    /// container row's <c>CodeAssistantStatus*</c> fields accordingly.
+    /// The caller is responsible for persisting the mutated container
+    /// to its DbContext (so callers can batch the persist with other
+    /// changes).
+    /// </summary>
+    Task RunAsync(Container container, CodeAssistantConfig codeAssistant, CancellationToken ct);
+}

--- a/src/Andy.Containers.Infrastructure/Migrations/20260511212525_AddCodeAssistantInstallStatus.Designer.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260511212525_AddCodeAssistantInstallStatus.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Andy.Containers.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Containers.Infrastructure.Migrations
 {
     [DbContext(typeof(ContainersDbContext))]
-    partial class ContainersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260511212525_AddCodeAssistantInstallStatus")]
+    partial class AddCodeAssistantInstallStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Containers.Infrastructure/Migrations/20260511212525_AddCodeAssistantInstallStatus.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260511212525_AddCodeAssistantInstallStatus.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Containers.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCodeAssistantInstallStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CodeAssistantStatus",
+                table: "Containers",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CodeAssistantStatusAt",
+                table: "Containers",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CodeAssistantStatusReason",
+                table: "Containers",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CodeAssistantStatus",
+                table: "Containers");
+
+            migrationBuilder.DropColumn(
+                name: "CodeAssistantStatusAt",
+                table: "Containers");
+
+            migrationBuilder.DropColumn(
+                name: "CodeAssistantStatusReason",
+                table: "Containers");
+        }
+    }
+}

--- a/src/Andy.Containers/Models/Container.cs
+++ b/src/Andy.Containers/Models/Container.cs
@@ -93,6 +93,31 @@ public class Container
     /// </summary>
     public DateTime? ProxyTokenIssuedAt { get; set; }
 
+    /// <summary>
+    /// rivoli-ai/conductor#945 (M1.5.3). Outcome of the code-assistant
+    /// install step inside the provisioning worker. Surfaces to the
+    /// Conductor UI as a banner when not <see cref="CodeAssistantInstallStatus.Installed"/>
+    /// (or null). Null on rows that pre-date #945 or on containers
+    /// created without a code assistant.
+    /// </summary>
+    public CodeAssistantInstallStatus? CodeAssistantStatus { get; set; }
+
+    /// <summary>
+    /// rivoli-ai/conductor#945 (M1.5.3). Free-text reason paired with
+    /// <see cref="CodeAssistantStatus"/>. For failures: stderr summary
+    /// or the underlying exception type + message. For skips: which
+    /// precondition was missing (e.g. "unknown-tool: QwenCoder",
+    /// "no-template-mapping"). For successes the field is null.
+    /// </summary>
+    public string? CodeAssistantStatusReason { get; set; }
+
+    /// <summary>
+    /// rivoli-ai/conductor#945 (M1.5.3). Wall-clock UTC at which the
+    /// install step completed (success, failure, or skip). Used by the
+    /// UI to disambiguate stale failures from fresh ones after a retry.
+    /// </summary>
+    public DateTime? CodeAssistantStatusAt { get; set; }
+
     public ICollection<ContainerSession> Sessions { get; set; } = new List<ContainerSession>();
     public ICollection<ContainerEvent> Events { get; set; } = new List<ContainerEvent>();
     public ICollection<ContainerGitRepository> GitRepositories { get; set; } = new List<ContainerGitRepository>();
@@ -108,6 +133,27 @@ public enum ContainerStatus
     Failed,
     Destroying,
     Destroyed
+}
+
+/// <summary>
+/// rivoli-ai/conductor#945 (M1.5.3). Captures the outcome of the
+/// code-assistant install step the provisioning worker runs after
+/// the container is up. Surfaces to the Conductor UI so users see a
+/// banner explaining why their picked assistant isn't usable instead
+/// of attaching a terminal and finding the binary missing.
+///
+/// Lifecycle: <c>Installing</c> while the script is running →
+/// <c>Installed</c> on exit code 0 → <c>Failed</c> on non-zero exit
+/// or timeout → <c>Skipped</c> when the install script could not be
+/// generated (unknown tool, missing template mapping). Containers
+/// without a configured assistant leave the field <c>null</c>.
+/// </summary>
+public enum CodeAssistantInstallStatus
+{
+    Installing = 0,
+    Installed = 1,
+    Failed = 2,
+    Skipped = 3,
 }
 
 public enum CreationSource

--- a/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerRetryInstallTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerRetryInstallTests.cs
@@ -1,0 +1,152 @@
+using System.Text.Json;
+using Andy.Containers.Abstractions;
+using Andy.Containers.Api.Controllers;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Controllers;
+
+/// <summary>
+/// rivoli-ai/conductor#945 (M1.5.3). Covers the
+/// <c>POST /api/containers/{id}/retry-code-assistant-install</c>
+/// endpoint's preconditions + happy path.
+/// </summary>
+public class ContainersControllerRetryInstallTests : IDisposable
+{
+    private readonly Mock<IContainerService> _mockService = new();
+    private readonly Mock<ICurrentUserService> _mockCurrentUser = new();
+    private readonly Mock<IGitCloneService> _mockGitClone = new();
+    private readonly Mock<IGitCredentialService> _mockCredentials = new();
+    private readonly Mock<IGitRepositoryProbeService> _mockProbe = new();
+    private readonly Mock<IOrganizationMembershipService> _mockOrgMembership = new();
+    private readonly Mock<ICodeAssistantInstallExecutor> _mockExecutor = new();
+    private readonly ContainersDbContext _db;
+    private readonly ContainersController _controller;
+
+    public ContainersControllerRetryInstallTests()
+    {
+        _mockCurrentUser.Setup(u => u.GetUserId()).Returns("test-user");
+        _mockCurrentUser.Setup(u => u.IsAdmin()).Returns(true);
+        _mockCurrentUser.Setup(u => u.IsAuthenticated()).Returns(true);
+        _mockOrgMembership.Setup(o => o.IsMemberAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _mockOrgMembership.Setup(o => o.HasPermissionAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _db = InMemoryDbHelper.CreateContext();
+        _controller = new ContainersController(
+            _mockService.Object,
+            _mockCurrentUser.Object,
+            _db,
+            _mockGitClone.Object,
+            _mockCredentials.Object,
+            _mockProbe.Object,
+            _mockOrgMembership.Object);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task RetryCodeAssistantInstall_RunningContainerWithConfig_InvokesExecutor_Returns200()
+    {
+        var id = Guid.NewGuid();
+        var container = MakeContainer(id, ContainerStatus.Running,
+            codeAssistantJson: JsonSerializer.Serialize(new CodeAssistantConfig
+            {
+                Tool = CodeAssistantType.ClaudeCode,
+                AutoStart = false,
+            }));
+        _mockService.Setup(s => s.GetContainerAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync(container);
+        _mockExecutor.Setup(e => e.RunAsync(container, It.IsAny<CodeAssistantConfig>(), It.IsAny<CancellationToken>()))
+            .Callback<Container, CodeAssistantConfig, CancellationToken>((c, _, __) =>
+            {
+                c.CodeAssistantStatus = CodeAssistantInstallStatus.Installed;
+                c.CodeAssistantStatusReason = null;
+                c.CodeAssistantStatusAt = DateTime.UtcNow;
+            })
+            .Returns(Task.CompletedTask);
+
+        var result = await _controller.RetryCodeAssistantInstall(id, _mockExecutor.Object, CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.StatusCode.Should().Be(200);
+        _mockExecutor.Verify(e => e.RunAsync(container, It.IsAny<CodeAssistantConfig>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RetryCodeAssistantInstall_NonRunningContainer_Returns422_ContainerNotRunning()
+    {
+        var id = Guid.NewGuid();
+        var container = MakeContainer(id, ContainerStatus.Stopped, codeAssistantJson: JsonSerializer.Serialize(new CodeAssistantConfig { Tool = CodeAssistantType.ClaudeCode }));
+        _mockService.Setup(s => s.GetContainerAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync(container);
+
+        var result = await _controller.RetryCodeAssistantInstall(id, _mockExecutor.Object, CancellationToken.None);
+
+        var unproc = result.Should().BeOfType<UnprocessableEntityObjectResult>().Subject;
+        unproc.StatusCode.Should().Be(422);
+        unproc.Value!.ToString().Should().Contain("container_not_running");
+        _mockExecutor.Verify(e => e.RunAsync(It.IsAny<Container>(), It.IsAny<CodeAssistantConfig>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RetryCodeAssistantInstall_NoCodeAssistantConfigured_Returns422_NoConfig()
+    {
+        var id = Guid.NewGuid();
+        var container = MakeContainer(id, ContainerStatus.Running, codeAssistantJson: null);
+        _mockService.Setup(s => s.GetContainerAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync(container);
+
+        var result = await _controller.RetryCodeAssistantInstall(id, _mockExecutor.Object, CancellationToken.None);
+
+        var unproc = result.Should().BeOfType<UnprocessableEntityObjectResult>().Subject;
+        unproc.Value!.ToString().Should().Contain("no_code_assistant_configured");
+        _mockExecutor.Verify(e => e.RunAsync(It.IsAny<Container>(), It.IsAny<CodeAssistantConfig>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RetryCodeAssistantInstall_UnparseableCodeAssistantJson_Returns422_Unreadable()
+    {
+        var id = Guid.NewGuid();
+        var container = MakeContainer(id, ContainerStatus.Running, codeAssistantJson: "not-json{");
+        _mockService.Setup(s => s.GetContainerAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync(container);
+
+        var result = await _controller.RetryCodeAssistantInstall(id, _mockExecutor.Object, CancellationToken.None);
+
+        var unproc = result.Should().BeOfType<UnprocessableEntityObjectResult>().Subject;
+        unproc.Value!.ToString().Should().Contain("code_assistant_config_unreadable");
+        _mockExecutor.Verify(e => e.RunAsync(It.IsAny<Container>(), It.IsAny<CodeAssistantConfig>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RetryCodeAssistantInstall_DifferentOwner_Forbids()
+    {
+        var id = Guid.NewGuid();
+        var container = MakeContainer(id, ContainerStatus.Running, codeAssistantJson: JsonSerializer.Serialize(new CodeAssistantConfig { Tool = CodeAssistantType.ClaudeCode }));
+        container.OwnerId = "someone-else";
+        _mockService.Setup(s => s.GetContainerAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync(container);
+        // Non-admin + not-a-member → CanAccess returns false.
+        _mockCurrentUser.Setup(u => u.IsAdmin()).Returns(false);
+        _mockOrgMembership.Setup(o => o.IsMemberAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var result = await _controller.RetryCodeAssistantInstall(id, _mockExecutor.Object, CancellationToken.None);
+
+        result.Should().BeOfType<ForbidResult>();
+        _mockExecutor.Verify(e => e.RunAsync(It.IsAny<Container>(), It.IsAny<CodeAssistantConfig>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static Container MakeContainer(Guid id, ContainerStatus status, string? codeAssistantJson)
+    {
+        return new Container
+        {
+            Id = id,
+            Name = "test-ctr",
+            OwnerId = "test-user",
+            TemplateId = Guid.NewGuid(),
+            ProviderId = Guid.NewGuid(),
+            Status = status,
+            CodeAssistant = codeAssistantJson,
+        };
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Services/CodeAssistantInstallExecutorTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/CodeAssistantInstallExecutorTests.cs
@@ -1,0 +1,220 @@
+using Andy.Containers.Abstractions;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+/// <summary>
+/// rivoli-ai/conductor#945 (M1.5.3). Pins the executor's contract:
+/// every outcome (Installed / Failed / Skipped) writes the matching
+/// status + reason + timestamp on the Container row. The UI relies
+/// on this — a missing status means a blank banner.
+/// </summary>
+public class CodeAssistantInstallExecutorTests
+{
+    private readonly Mock<ICodeAssistantInstallService> _installService = new();
+    private readonly Mock<IContainerService> _containerService = new();
+
+    private CodeAssistantInstallExecutor MakeExecutor(DateTimeOffset? now = null)
+    {
+        var time = now is null
+            ? (TimeProvider)TimeProvider.System
+            : new FakeTimeProvider(now.Value);
+        return new CodeAssistantInstallExecutor(
+            _installService.Object,
+            _containerService.Object,
+            NullLogger<CodeAssistantInstallExecutor>.Instance,
+            time);
+    }
+
+    private static Container MakeContainer(Guid? id = null) => new()
+    {
+        Id = id ?? Guid.NewGuid(),
+        Name = "test-ctr",
+        OwnerId = "owner",
+        TemplateId = Guid.NewGuid(),
+        ProviderId = Guid.NewGuid(),
+        Status = ContainerStatus.Running,
+    };
+
+    private static CodeAssistantConfig ClaudeConfig() => new()
+    {
+        Tool = CodeAssistantType.ClaudeCode,
+        AutoStart = false,
+    };
+
+    // -----------------------------------------------------------------
+    // Outcome: Installed
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task RunAsync_ExitCodeZero_WritesInstalledStatus()
+    {
+        _installService.Setup(s => s.GenerateInstallScript(It.IsAny<CodeAssistantConfig>()))
+            .Returns("echo ok");
+        _containerService.Setup(s => s.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExecResult { ExitCode = 0, StdOut = "ok" });
+        var fixedNow = DateTimeOffset.Parse("2026-06-01T12:00:00Z");
+        var executor = MakeExecutor(fixedNow);
+        var container = MakeContainer();
+
+        await executor.RunAsync(container, ClaudeConfig(), CancellationToken.None);
+
+        container.CodeAssistantStatus.Should().Be(CodeAssistantInstallStatus.Installed);
+        container.CodeAssistantStatusReason.Should().BeNull();
+        container.CodeAssistantStatusAt.Should().Be(fixedNow.UtcDateTime);
+    }
+
+    // -----------------------------------------------------------------
+    // Outcome: Failed
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task RunAsync_NonZeroExitCode_WritesFailedStatusWithStderrSummary()
+    {
+        _installService.Setup(s => s.GenerateInstallScript(It.IsAny<CodeAssistantConfig>()))
+            .Returns("echo fail; exit 7");
+        _containerService.Setup(s => s.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExecResult { ExitCode = 7, StdErr = "ENOENT: npm not found\nbash: line 4: command not found" });
+        var executor = MakeExecutor();
+        var container = MakeContainer();
+
+        await executor.RunAsync(container, ClaudeConfig(), CancellationToken.None);
+
+        container.CodeAssistantStatus.Should().Be(CodeAssistantInstallStatus.Failed);
+        container.CodeAssistantStatusReason.Should().StartWith("exit-code-7:");
+        container.CodeAssistantStatusReason.Should().Contain("ENOENT");
+        container.CodeAssistantStatusReason.Should().Contain("|",
+            "multi-line stderr should be flattened to a single line for the UI banner.");
+        container.CodeAssistantStatusAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task RunAsync_ExecAsyncTimeoutOpcodecanceled_WritesFailedTimeoutStatus()
+    {
+        _installService.Setup(s => s.GenerateInstallScript(It.IsAny<CodeAssistantConfig>()))
+            .Returns("sleep 9999");
+        _containerService.Setup(s => s.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException("install timed out"));
+        var executor = MakeExecutor();
+        var container = MakeContainer();
+
+        // Caller's CT is NOT cancelled — the cancellation came from
+        // the executor's internal timeout. That's the path the
+        // executor must classify as a Failed timeout, not as a global
+        // shutdown propagation.
+        await executor.RunAsync(container, ClaudeConfig(), CancellationToken.None);
+
+        container.CodeAssistantStatus.Should().Be(CodeAssistantInstallStatus.Failed);
+        container.CodeAssistantStatusReason.Should().StartWith("timeout:");
+    }
+
+    [Fact]
+    public async Task RunAsync_ExecAsyncThrowsArbitraryException_WritesFailedExceptionStatus()
+    {
+        _installService.Setup(s => s.GenerateInstallScript(It.IsAny<CodeAssistantConfig>()))
+            .Returns("echo");
+        _containerService.Setup(s => s.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("docker daemon unreachable"));
+        var executor = MakeExecutor();
+        var container = MakeContainer();
+
+        await executor.RunAsync(container, ClaudeConfig(), CancellationToken.None);
+
+        container.CodeAssistantStatus.Should().Be(CodeAssistantInstallStatus.Failed);
+        container.CodeAssistantStatusReason.Should().StartWith("exception: InvalidOperationException:");
+        container.CodeAssistantStatusReason.Should().Contain("docker daemon unreachable");
+    }
+
+    // -----------------------------------------------------------------
+    // Outcome: Skipped (script generation failed)
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task RunAsync_GenerateInstallScriptThrows_WritesSkippedStatus()
+    {
+        _installService.Setup(s => s.GenerateInstallScript(It.IsAny<CodeAssistantConfig>()))
+            .Throws(new NotSupportedException("Unknown tool: QwenCoder"));
+        var executor = MakeExecutor();
+        var container = MakeContainer();
+
+        await executor.RunAsync(container, ClaudeConfig(), CancellationToken.None);
+
+        container.CodeAssistantStatus.Should().Be(CodeAssistantInstallStatus.Skipped);
+        container.CodeAssistantStatusReason.Should().StartWith("script-generation: NotSupportedException:");
+        container.CodeAssistantStatusReason.Should().Contain("Unknown tool");
+        // Important: no exec call when script generation fails.
+        _containerService.Verify(s => s.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // -----------------------------------------------------------------
+    // Lifecycle: Installing flag is set before the script runs
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task RunAsync_MarksInstallingBeforeScriptRuns()
+    {
+        // Capture the container's status mid-flight by inspecting it
+        // when ExecAsync is invoked.
+        CodeAssistantInstallStatus? statusDuringExec = null;
+        _installService.Setup(s => s.GenerateInstallScript(It.IsAny<CodeAssistantConfig>()))
+            .Returns("echo");
+        var container = MakeContainer();
+        _containerService.Setup(s => s.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .Callback(() => statusDuringExec = container.CodeAssistantStatus)
+            .ReturnsAsync(new ExecResult { ExitCode = 0 });
+        var executor = MakeExecutor();
+
+        await executor.RunAsync(container, ClaudeConfig(), CancellationToken.None);
+
+        statusDuringExec.Should().Be(CodeAssistantInstallStatus.Installing,
+            "UI should be able to render an 'install in progress' affordance even before the script finishes.");
+    }
+
+    // -----------------------------------------------------------------
+    // SummariseReason
+    // -----------------------------------------------------------------
+
+    [Theory]
+    [InlineData(null, "<no detail>")]
+    [InlineData("", "<no detail>")]
+    [InlineData("   ", "<no detail>")]
+    [InlineData("single line", "single line")]
+    [InlineData("a\nb\nc", "a | b | c")]
+    [InlineData("  a  \r\n  b  \r\n", "a | b")]
+    public void SummariseReason_HandlesCommonInputs(string? input, string expected)
+    {
+        CodeAssistantInstallExecutor.SummariseReason(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void SummariseReason_TruncatesLongInput()
+    {
+        var input = new string('x', CodeAssistantInstallExecutor.StatusReasonMaxLength + 50);
+        var summary = CodeAssistantInstallExecutor.SummariseReason(input);
+        summary.Length.Should().Be(CodeAssistantInstallExecutor.StatusReasonMaxLength);
+        summary.Should().EndWith("…");
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FakeTimeProvider(DateTimeOffset now) { _now = now; }
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerProvisioningWorkerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerProvisioningWorkerTests.cs
@@ -47,6 +47,11 @@ public class ContainerProvisioningWorkerTests : IDisposable
         services.AddScoped<IGitCloneService>(_ => _mockGitCloneService.Object);
         services.AddScoped<IContainerService>(_ => _mockContainerService.Object);
         services.AddScoped<ICodeAssistantInstallService>(_ => _mockCodeAssistantInstallService.Object);
+        // rivoli-ai/conductor#945 (M1.5.3). Worker resolves the
+        // executor from the scope; register the real implementation
+        // so the install-status writes flow through during tests.
+        services.AddScoped<ICodeAssistantInstallExecutor, CodeAssistantInstallExecutor>();
+        services.AddSingleton<ILogger<CodeAssistantInstallExecutor>>(NullLogger<CodeAssistantInstallExecutor>.Instance);
         _serviceProvider = services.BuildServiceProvider();
     }
 


### PR DESCRIPTION
## Summary

M1.5.3 (\`rivoli-ai/conductor#945\`). Backend half — schema + worker writes outcome + retry endpoint + tests.

The provisioning worker already runs \`CodeAssistantInstallService\` inside provisioned containers, but install failures are logged-only. A user who picks Claude Code on a template that doesn't have npm sees the workspace transition to Ready, attaches, and finds the binary missing with no explanation. This closes the gap on the backend; Conductor banner UI follows in a companion PR.

## Schema

\`Container\` gets three nullable columns + a new \`CodeAssistantInstallStatus\` enum (\`Installing\` / \`Installed\` / \`Failed\` / \`Skipped\`):

- \`CodeAssistantStatus\`        — outcome of the install step
- \`CodeAssistantStatusReason\`  — one-line summary (stderr / exception / skip reason)
- \`CodeAssistantStatusAt\`      — wall-clock UTC of the outcome

EF migration: \`AddCodeAssistantInstallStatus\`. Existing rows leave the columns null (no behaviour change for pre-#945 containers).

## Behaviour

\`CodeAssistantInstallExecutor\` is the canonical install runner. The worker calls it after post-create scripts; the new retry endpoint calls it too. Status mapping:

| Outcome | Status | Reason |
|---|---|---|
| exit code 0 | \`Installed\` | null |
| exit code non-zero | \`Failed\` | \`exit-code-N: <stderr summary>\` |
| \`ExecAsync\` \`OperationCanceledException\` while caller's CT not cancelled | \`Failed\` | \`timeout: ...\` |
| any other \`ExecAsync\` throw | \`Failed\` | \`exception: TypeName: <msg summary>\` |
| script-generation throws | \`Skipped\` | \`script-generation: ...\` |

Container stays \`Running\` on any failure (degraded but attachable; user can debug from a terminal). \`SummariseReason\` flattens multi-line stderr / messages into a single line capped at 500 chars so the column can't blow up on a screenful of npm output.

## Retry endpoint

\`POST /api/containers/{id}/retry-code-assistant-install\` re-runs install for a container that hit Failed or Skipped. Preconditions:

- Container must be Running       → 422 \`container_not_running\`
- Must have \`CodeAssistant\` JSON   → 422 \`no_code_assistant_configured\`
- JSON must deserialise            → 422 \`code_assistant_config_unreadable\`
- Caller must pass CanAccess       → 403

Happy path returns \`{ id, status, reason, statusAt }\` so the Conductor banner can refresh inline without a separate fetch.

## Test plan

- [x] \`CodeAssistantInstallExecutorTests\` — 10 cases covering every outcome path, Installing-flag mid-flight visibility, \`SummariseReason\` boundary conditions
- [x] \`ContainersControllerRetryInstallTests\` — 5 cases: happy path, not-running 422, no-config 422, unparseable 422, different-owner 403
- [x] \`ContainerProvisioningWorkerTests\` updated to register the executor; all 20 existing worker tests still pass
- [x] Full Api.Tests run: \`Passed! Failed: 0, Passed: 1072, Skipped: 1, Total: 1073\` (1 skipped = pre-existing NATS-gated test)

## Conductor side

Companion PR will:
- Add the new fields to the Swift \`Container\` DTO
- Render a banner on the workspace detail view when status is Failed / Skipped
- Wire a "Retry install" action to \`POST /api/containers/{id}/retry-code-assistant-install\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)