### PR TITLE
#275: LocalBuildBackend strips provenance + SBOM on docker buildx

### DIFF
--- a/src/Andy.Containers.Infrastructure/Build/Local/LocalBuildBackend.cs
+++ b/src/Andy.Containers.Infrastructure/Build/Local/LocalBuildBackend.cs
@@ -199,6 +199,12 @@ public sealed class LocalBuildBackend : IBuildBackend
                 psi.ArgumentList.Add("buildx");
                 psi.ArgumentList.Add("build");
                 psi.ArgumentList.Add("--load"); // load result into local cache so the registry uploader can find it
+                // Strip provenance + SBOM attestations. Modern buildx attaches them by default,
+                // producing auxiliary manifests that zot v2.1+ (even with docker2s2 compat) rejects
+                // as `manifest invalid`. The IM11 round-trip fixture already passes these flags;
+                // production must match. See rivoli-ai/andy-containers#275.
+                psi.ArgumentList.Add("--provenance=false");
+                psi.ArgumentList.Add("--sbom=false");
                 psi.ArgumentList.Add("-t");
                 psi.ArgumentList.Add(localTag);
                 psi.ArgumentList.Add("-f");

--- a/tests/Andy.Containers.Tests/Infrastructure/Build/LocalBuildBackendTests.cs
+++ b/tests/Andy.Containers.Tests/Infrastructure/Build/LocalBuildBackendTests.cs
@@ -73,7 +73,10 @@ public class LocalBuildBackendTests
 
         // Verify the engine was invoked with the docker buildx flavour.
         stub.Invocations.Should().ContainSingle();
-        stub.Invocations[0].Should().Equal(["buildx", "build", "--load", "-t", artifact.LocalReference, "-f", "Dockerfile", "."]);
+        stub.Invocations[0].Should().Equal(
+            ["buildx", "build", "--load", "--provenance=false", "--sbom=false",
+             "-t", artifact.LocalReference, "-f", "Dockerfile", "."],
+            "BuildKit must strip provenance + SBOM attestations so zot accepts the manifest (see #275).");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Adds `--provenance=false --sbom=false` to the DockerBuildKit branch of `LocalBuildBackend`. Modern buildx attaches provenance + SBOM by default; the auxiliary manifests cause zot v2.1+ to reject the push as `manifest invalid` even when `docker2s2` compat is enabled.
- The IM11 round-trip fixture (`LocalZotAdapterRoundTripTests.PushPath_DockerCliUploaderToRealZot`) already passes these flags and its comment claims "production uses these flags too" — that's now true.
- Apple Containers path untouched: already emits clean manifests.

Closes rivoli-ai/andy-containers#275. M1.9 BLOCKER (P1F2 follow-up to Epic IM #249).

## Test plan

- [x] `dotnet test --filter LocalBuildBackendTests` — 5/5 pass; argv assertion updated to require the two flags
- [ ] Manual: real Docker daemon + zot end-to-end push (deferred — IM11 round-trip on the test side already exercises the identical wire format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)