### PR TITLE
#274: ContainerOrchestrationService resolves BuildArtifact digest at create time

### DIFF
--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -1,11 +1,13 @@
 using System.Diagnostics;
 using System.Text.Json;
 using Andy.Containers.Abstractions;
+using Andy.Containers.Abstractions.Images;
 using Andy.Containers.Api.Telemetry;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Infrastructure.Messaging;
 using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
+using Andy.Containers.Storage;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -27,6 +29,8 @@ public class ContainerOrchestrationService : IContainerService
     private readonly IServiceTokenService? _serviceTokenService;
     private readonly IProxyTokenService? _proxyTokenService;
     private readonly IDataProtector? _proxyTokenProtector;
+    private readonly IBuildArtifactStore? _buildArtifactStore;
+    private readonly IRegistryConfiguration? _registryConfiguration;
 
     /// <summary>
     /// rivoli-ai/conductor#943. Data-protection purpose for encrypting
@@ -56,7 +60,9 @@ public class ContainerOrchestrationService : IContainerService
         ILogger<ContainerOrchestrationService> logger,
         IServiceTokenService? serviceTokenService = null,
         IProxyTokenService? proxyTokenService = null,
-        IDataProtectionProvider? dataProtection = null)
+        IDataProtectionProvider? dataProtection = null,
+        IBuildArtifactStore? buildArtifactStore = null,
+        IRegistryConfiguration? registryConfiguration = null)
     {
         _db = db;
         _routing = routing;
@@ -75,6 +81,12 @@ public class ContainerOrchestrationService : IContainerService
         // per-container token, env-var injection runs unmodified).
         _proxyTokenService = proxyTokenService;
         _proxyTokenProtector = dataProtection?.CreateProtector(ProxyTokenProtectorPurpose);
+        // #274 (P1F1). Optional so unit tests that don't exercise the
+        // image-management pipeline don't need to construct stubs.
+        // When either is null we fall back to template.BaseImage —
+        // pre-IM behaviour. Live DI always supplies both.
+        _buildArtifactStore = buildArtifactStore;
+        _registryConfiguration = registryConfiguration;
     }
 
     /// <summary>
@@ -127,6 +139,16 @@ public class ContainerOrchestrationService : IContainerService
         if (template is null)
             throw new ArgumentException("Template not found");
 
+        // #274 (P1F1). If the IM pipeline has produced a BuildArtifact
+        // for this template in the primary registry, prefer its
+        // digest-pinned ref over the legacy template.BaseImage string.
+        // Falls back to BaseImage when no artifact exists (templates
+        // that haven't been built via IM yet, e.g. andy-desktop-* which
+        // are local-built fixtures, not registry images).
+        var resolvedTemplateImage =
+            await ResolveTemplateImageRefAsync(template.Id, ct)
+            ?? template.BaseImage;
+
         // X4 (rivoli-ai/andy-containers#93). Resolve the bound profile
         // (if any). When set, the profile's BaseImageRef and Kind
         // override the template's image and GUI behaviour: Headless /
@@ -177,7 +199,7 @@ public class ContainerOrchestrationService : IContainerService
         {
             var spec = new ContainerSpec
             {
-                ImageReference = template.BaseImage,
+                ImageReference = resolvedTemplateImage,
                 Name = request.Name,
                 Resources = request.Resources,
                 Gpu = request.Gpu
@@ -560,7 +582,7 @@ public class ContainerOrchestrationService : IContainerService
         // sidecar GuiType is derived from profile.Kind (Desktop → "vnc",
         // Headless / Terminal → "none"). Without a profile, fall back
         // to the template's existing values for full back-compat.
-        var effectiveImage = profile?.BaseImageRef ?? template.BaseImage;
+        var effectiveImage = profile?.BaseImageRef ?? resolvedTemplateImage;
         var effectiveGuiType = profile is null
             ? template.GuiType
             : (profile.Kind == EnvironmentKind.Desktop ? "vnc" : "none");
@@ -614,6 +636,75 @@ public class ContainerOrchestrationService : IContainerService
         Meters.ContainersCreated.Add(1, new KeyValuePair<string, object?>("provider", container.Provider));
 
         return container;
+    }
+
+    /// <summary>
+    /// #274 (P1F1). Resolves the most-recent IM-produced
+    /// <see cref="Andy.Containers.Models.ImageManagement.BuildArtifactEntity"/>
+    /// for <paramref name="templateId"/> in the primary registry into a
+    /// fully-qualified digest-pinned image reference of the form
+    /// <c>{authority}/{repoPath}@{digest}</c>. Returns <c>null</c> when:
+    /// (a) the store/config aren't wired (unit-test back-compat path);
+    /// (b) no artifact exists for this template;
+    /// (c) the artifact has no reference in the primary registry
+    ///     (rare — would mean an artifact row was persisted without
+    ///     a successful push, which the orchestrator doesn't currently
+    ///     do, but we guard anyway);
+    /// (d) the primary registry's URL can't be parsed (config error).
+    /// The caller falls back to <c>template.BaseImage</c> on null.
+    /// </summary>
+    private async Task<string?> ResolveTemplateImageRefAsync(Guid templateId, CancellationToken ct)
+    {
+        if (_buildArtifactStore is null || _registryConfiguration is null)
+        {
+            return null;
+        }
+
+        string primaryRegistryId;
+        try
+        {
+            primaryRegistryId = _registryConfiguration.PrimaryRegistryId;
+        }
+        catch (InvalidOperationException)
+        {
+            // No registries configured — pre-IM deployment. Legitimate
+            // fall-back to BaseImage.
+            return null;
+        }
+
+        var (items, _) = await _buildArtifactStore.ListAsync(
+            templateId: templateId,
+            registryId: primaryRegistryId,
+            skip: 0,
+            take: 1,
+            ct: ct).ConfigureAwait(false);
+        if (items.Count == 0)
+        {
+            return null;
+        }
+
+        var artifact = items[0];
+        var reference = artifact.References
+            .FirstOrDefault(r => r.RegistryId == primaryRegistryId);
+        if (reference is null)
+        {
+            _logger.LogWarning(
+                "BuildArtifact {ArtifactId} for template {TemplateId} has no RegistryReference in primary registry {RegistryId}; falling back to template.BaseImage.",
+                artifact.Id, templateId, primaryRegistryId);
+            return null;
+        }
+
+        var registryEntry = _registryConfiguration.GetByIdOrThrow(primaryRegistryId);
+        if (!Uri.TryCreate(registryEntry.Url, UriKind.Absolute, out var url))
+        {
+            _logger.LogWarning(
+                "Primary registry {RegistryId} has unparseable URL '{Url}'; falling back to template.BaseImage.",
+                primaryRegistryId, registryEntry.Url);
+            return null;
+        }
+
+        var authority = url.IsDefaultPort ? url.Host : $"{url.Host}:{url.Port}";
+        return $"{authority}/{reference.RepoPath}@{artifact.Digest}";
     }
 
     public async Task<Container> GetContainerAsync(Guid containerId, CancellationToken ct)

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTests.cs
@@ -1,9 +1,12 @@
 using System.Text.Json;
 using Andy.Containers.Abstractions;
+using Andy.Containers.Abstractions.Images;
 using Andy.Containers.Api.Services;
 using Andy.Containers.Api.Tests.Helpers;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Models;
+using Andy.Containers.Models.ImageManagement;
+using Andy.Containers.Storage;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -138,6 +141,107 @@ public class ContainerOrchestrationServiceTests : IDisposable
         var act = () => _service.CreateContainerAsync(request, CancellationToken.None);
 
         await act.Should().ThrowAsync<ArgumentException>().WithMessage("*Provider not found*");
+    }
+
+    // #274 (P1F1). When the IM pipeline has produced a BuildArtifact
+    // for the template, the orchestrator must consume the digest-pinned
+    // ref instead of template.BaseImage — otherwise the workspace pulls
+    // from the legacy base image and the whole Phase-1 pipeline is dead
+    // code at launch time.
+    [Fact]
+    public async Task CreateContainer_WhenBuildArtifactExists_UsesDigestPinnedImageReference()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+
+        var digest = "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+        var artifact = new BuildArtifactEntity
+        {
+            Id = Guid.NewGuid(),
+            Digest = digest,
+            MediaType = "application/vnd.oci.image.manifest.v1+json",
+            SpecHash = "sha256:deadbeef",
+            TemplateId = template.Id,
+            BuildBackendId = "local-docker",
+            BuiltBy = "test",
+            BuiltAt = DateTime.UtcNow,
+        };
+        artifact.References.Add(new RegistryReferenceEntity
+        {
+            Id = Guid.NewGuid(),
+            BuildArtifactId = artifact.Id,
+            RegistryId = "local-zot",
+            RepoPath = "test-template",
+            Tag = "sha256-11111111",
+            PushedAt = DateTime.UtcNow,
+            PushedBy = "test",
+        });
+
+        var store = new Mock<IBuildArtifactStore>();
+        store.Setup(s => s.ListAsync(template.Id, "local-zot", 0, 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<BuildArtifactEntity>)new[] { artifact }, 1));
+
+        var registries = new Mock<IRegistryConfiguration>();
+        registries.SetupGet(r => r.PrimaryRegistryId).Returns("local-zot");
+        registries.Setup(r => r.GetByIdOrThrow("local-zot"))
+            .Returns(new RegistryConfigEntry { Id = "local-zot", Kind = "zot", Url = "http://localhost:5050", IsPrimary = true });
+
+        var service = new ContainerOrchestrationService(
+            _db, _mockRouting.Object, _mockFactory.Object, _queue,
+            _mockProbeService.Object, new Mock<IApiKeyService>().Object,
+            _configuration, new Mock<ILogger<ContainerOrchestrationService>>().Object,
+            buildArtifactStore: store.Object,
+            registryConfiguration: registries.Object);
+
+        var request = new CreateContainerRequest
+        {
+            Name = "digest-pinned",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+        };
+
+        await service.CreateContainerAsync(request, CancellationToken.None);
+
+        _queue.Reader.TryRead(out var job).Should().BeTrue();
+        job!.TemplateBaseImage.Should().Be(
+            $"localhost:5050/test-template@{digest}",
+            "the BuildArtifact's digest-pinned ref must win over the legacy template.BaseImage string.");
+    }
+
+    // #274 (P1F1). Back-compat: when no BuildArtifact exists for the
+    // template (templates that haven't been built through the IM
+    // pipeline, e.g. andy-desktop-* fixtures), fall back to
+    // template.BaseImage — the pre-IM behaviour.
+    [Fact]
+    public async Task CreateContainer_WhenNoBuildArtifactForTemplate_FallsBackToBaseImage()
+    {
+        var (template, provider) = await SeedTemplateAndProvider();
+
+        var store = new Mock<IBuildArtifactStore>();
+        store.Setup(s => s.ListAsync(template.Id, "local-zot", 0, 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<BuildArtifactEntity>)Array.Empty<BuildArtifactEntity>(), 0));
+
+        var registries = new Mock<IRegistryConfiguration>();
+        registries.SetupGet(r => r.PrimaryRegistryId).Returns("local-zot");
+
+        var service = new ContainerOrchestrationService(
+            _db, _mockRouting.Object, _mockFactory.Object, _queue,
+            _mockProbeService.Object, new Mock<IApiKeyService>().Object,
+            _configuration, new Mock<ILogger<ContainerOrchestrationService>>().Object,
+            buildArtifactStore: store.Object,
+            registryConfiguration: registries.Object);
+
+        var request = new CreateContainerRequest
+        {
+            Name = "fallback",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+        };
+
+        await service.CreateContainerAsync(request, CancellationToken.None);
+
+        _queue.Reader.TryRead(out var job).Should().BeTrue();
+        job!.TemplateBaseImage.Should().Be(template.BaseImage,
+            "with no BuildArtifact persisted, the orchestrator must keep using the template's BaseImage (pre-IM back-compat).");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- The Phase-1 IM pipeline persists a digest-pinned image in zot for every built template, but `ContainerOrchestrationService.CreateContainerAsync` still set `ImageReference = template.BaseImage` at the two sites that flow into the provisioning job. M1.9 containers would pull the original `ghcr.io/...` base instead of the just-built `localhost:5050/<repo>@sha256:...`, and `Containers:Image:RequireDigestPin` (#125) fails closed because `BaseImage` isn't pinned.
- Now resolves the most-recent `BuildArtifact` for `(template.Id, primaryRegistryId)` via `IBuildArtifactStore` + `IRegistryConfiguration`, formats it as `{authority}/{repoPath}@{digest}`, and uses that everywhere `template.BaseImage` was used. Falls back to `BaseImage` when no artifact exists — `andy-desktop-*` fixtures and any pre-IM template stay on the old path.
- Both new deps are constructor-optional, matching the file's existing `IServiceTokenService` / `IProxyTokenService` back-compat pattern. No existing test needs to change.

Closes rivoli-ai/andy-containers#274. M1.9 BLOCKER (P1F1 follow-up to Epic IM #249).

## Test plan

- [x] `dotnet test ContainerOrchestrationServiceTests` — 51/51 pass, including two new tests:
  - `CreateContainer_WhenBuildArtifactExists_UsesDigestPinnedImageReference` — wires up the store + registry config, asserts the enqueued `ContainerProvisionJob.TemplateBaseImage == "localhost:5050/test-template@sha256:..."`
  - `CreateContainer_WhenNoBuildArtifactForTemplate_FallsBackToBaseImage` — back-compat
- [x] Full solution test pass: Api.Tests 1074/1075 (1 pre-existing skip), Integration.Tests 43/50 (skips are docker/zot-gated)
- [ ] End-to-end integration test (register → build → create → assert pull URL hits zot) — deferred; `LocalZotAdapterRoundTripTests` already exercises the build-and-push half, and this PR's unit test exercises the lookup-and-format half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)