### PR TITLE
#276: AppleContainersUploader + engine-aware uploader dispatch

### DIFF
--- a/docs/architecture/image-management.md
+++ b/docs/architecture/image-management.md
@@ -84,6 +84,27 @@ Implementations:
 - **`CodeBuildBackend`** (Phase 3) — AWS CodeBuild project.
 - **`BuildKitOnClusterBackend`** (Phase 3) — rootless BuildKit pod with `--frontend dockerfile`. Covers "no Docker daemon on dev laptops" customer policies.
 
+### `IRegistryUploader`
+
+`IRegistryAdapter.PushAsync` reads the digest authoritatively from the registry's HTTP API. The bytes themselves are uploaded by an `IRegistryUploader`:
+
+```csharp
+public interface IRegistryUploader
+{
+    Task PushAsync(string localReference, string remoteReference, CancellationToken ct);
+}
+```
+
+The split exists because *which CLI can push a built image* depends on *which engine built it*. Apple Containers and Docker maintain separate local image stores; an image built with `container build` is invisible to `docker push` and vice-versa.
+
+Implementations:
+
+- **`DockerCliUploader`** (IM6) — shells `docker tag` then `docker push`. Used when the build engine is Docker BuildKit.
+- **`AppleContainersUploader`** (P1F3, rivoli-ai/andy-containers#276) — shells `container images tag` then `container images push`. Used when the build engine is Apple Containers (macOS 26+).
+- **`EngineAwareRegistryUploader`** — the composite registered as `IRegistryUploader` in DI. Resolves `IBuildEngineDetector` on first push, caches the choice, and dispatches to the right concrete uploader. Throws `RegistryUploadException("EngineAwareRegistryUploader.NoEngine")` when no engine is detected.
+
+The adapter never sees the uploader split — it just calls `IRegistryUploader.PushAsync`, gets bytes pushed, and then asks the registry for the digest via HEAD.
+
 ### `IRegistryConfiguration`
 
 ```csharp

--- a/src/Andy.Containers.Infrastructure/Registries/Local/AppleContainersUploader.cs
+++ b/src/Andy.Containers.Infrastructure/Registries/Local/AppleContainersUploader.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Containers.Infrastructure.Registries.Local;
+
+/// <summary>
+/// Push images to a registry by shelling out to Apple's
+/// <c>container</c> CLI. Used on macOS 26+ where
+/// <see cref="BuildEngineDetector"/> selects Apple Containers ahead
+/// of Docker BuildKit and the produced image lives in Apple
+/// Containers' own image store — distinct from the Docker daemon's
+/// cache, so <see cref="DockerCliUploader"/> cannot find it.
+/// </summary>
+/// <remarks>
+/// P1F3 (rivoli-ai/andy-containers#276). Mirrors the
+/// <see cref="DockerCliUploader"/> two-step retag-then-push shape:
+/// <list type="number">
+///   <item><c>container images tag &lt;local&gt; &lt;remote&gt;</c></item>
+///   <item><c>container images push &lt;remote&gt;</c></item>
+/// </list>
+/// The digest is resolved authoritatively by
+/// <see cref="LocalZotAdapter"/> via a post-push
+/// <c>HEAD /v2/.../manifests/{tag}</c>; we never parse it out of the
+/// CLI output.
+/// </remarks>
+public sealed class AppleContainersUploader : IRegistryUploader
+{
+    private readonly ILogger<AppleContainersUploader> _logger;
+    private readonly AppleContainersUploaderOptions _options;
+
+    public AppleContainersUploader(
+        ILogger<AppleContainersUploader> logger,
+        AppleContainersUploaderOptions? options = null)
+    {
+        _logger = logger;
+        _options = options ?? new AppleContainersUploaderOptions();
+    }
+
+    public async Task PushAsync(
+        string localReference,
+        string remoteReference,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localReference);
+        ArgumentException.ThrowIfNullOrWhiteSpace(remoteReference);
+
+        // 1) Retag under the remote ref so the push target is
+        //    unambiguous. Apple's `images tag` is idempotent — same
+        //    contract as `docker tag`.
+        await RunAsync(
+            "AppleContainersUploader.Tag",
+            new[] { "images", "tag", localReference, remoteReference },
+            ct);
+
+        // 2) Push by remote ref. ArgumentList bypasses Win32-style
+        //    tokenising so any metacharacter in the spec-derived
+        //    local tag can't smuggle extra `container` flags.
+        await RunAsync(
+            "AppleContainersUploader.Push",
+            new[] { "images", "push", remoteReference },
+            ct);
+    }
+
+    private async Task RunAsync(
+        string operationCode,
+        string[] arguments,
+        CancellationToken ct)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = _options.ContainerExecutablePath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var arg in arguments)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        _logger.LogDebug(
+            "{OpCode} starting container {Args}",
+            operationCode, string.Join(' ', arguments));
+
+        using var process = new Process { StartInfo = psi };
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            // Most common cause: Apple `container` CLI not on PATH
+            // (e.g., the engine detector picked Apple Containers but
+            // the binary is stale or shadowed). Stable code so IM10
+            // maps it to a 503 with an actionable message.
+            throw new RegistryUploadException(
+                code: $"{operationCode}.LaunchFailed",
+                message: $"failed to launch '{_options.ContainerExecutablePath}' — is Apple's `container` CLI installed and on PATH? (macOS 26+)",
+                innerException: ex);
+        }
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(ct);
+        var stderrTask = process.StandardError.ReadToEndAsync(ct);
+
+        await process.WaitForExitAsync(ct);
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
+
+        if (process.ExitCode != 0)
+        {
+            var combined = stdout + (string.IsNullOrWhiteSpace(stderr) ? string.Empty : Environment.NewLine + stderr);
+            throw new RegistryUploadException(
+                code: $"{operationCode}.NonZeroExit{process.ExitCode}",
+                message: $"container exited with code {process.ExitCode} during {operationCode.ToLowerInvariant()}: {Truncate(stderr, 200)}",
+                capturedOutput: combined);
+        }
+
+        _logger.LogDebug("{OpCode} succeeded.", operationCode);
+    }
+
+    private static string Truncate(string s, int max)
+        => string.IsNullOrEmpty(s) || s.Length <= max ? s : s[..max] + "…";
+}
+
+/// <summary>
+/// Configuration knobs for <see cref="AppleContainersUploader"/>.
+/// Default resolves <c>container</c> from PATH; tests override the
+/// path to point at a stub script.
+/// </summary>
+public sealed class AppleContainersUploaderOptions
+{
+    public string ContainerExecutablePath { get; init; } = "container";
+}

--- a/src/Andy.Containers.Infrastructure/Registries/Local/EngineAwareRegistryUploader.cs
+++ b/src/Andy.Containers.Infrastructure/Registries/Local/EngineAwareRegistryUploader.cs
@@ -1,0 +1,86 @@
+using Andy.Containers.Infrastructure.Build;
+
+namespace Andy.Containers.Infrastructure.Registries.Local;
+
+/// <summary>
+/// Routes <see cref="IRegistryUploader.PushAsync"/> calls to the
+/// uploader matching the host's detected build engine. Production
+/// composition root for the embedded-mode push path so the
+/// orchestrator never has to know which engine is in play.
+/// </summary>
+/// <remarks>
+/// P1F3 (rivoli-ai/andy-containers#276). Engine detection is async
+/// and one-shot per process; we cache the choice after the first
+/// PushAsync so subsequent pushes don't re-probe.
+/// <para>
+/// <see cref="BuildEngineKind.None"/> is treated as an explicit
+/// configuration error (build never ran or detector returned an
+/// indeterminate result). <see cref="BuildEngineKind.DockerBuildKit"/>
+/// dispatches to <see cref="DockerCliUploader"/>;
+/// <see cref="BuildEngineKind.AppleContainers"/> to
+/// <see cref="AppleContainersUploader"/>.
+/// </para>
+/// </remarks>
+public sealed class EngineAwareRegistryUploader : IRegistryUploader
+{
+    private readonly IBuildEngineDetector _detector;
+    private readonly DockerCliUploader _docker;
+    private readonly AppleContainersUploader _apple;
+
+    private IRegistryUploader? _resolved;
+    private readonly SemaphoreSlim _resolveGate = new(1, 1);
+
+    public EngineAwareRegistryUploader(
+        IBuildEngineDetector detector,
+        DockerCliUploader docker,
+        AppleContainersUploader apple)
+    {
+        _detector = detector;
+        _docker = docker;
+        _apple = apple;
+    }
+
+    public async Task PushAsync(
+        string localReference,
+        string remoteReference,
+        CancellationToken ct)
+    {
+        var inner = await ResolveAsync(ct).ConfigureAwait(false);
+        await inner.PushAsync(localReference, remoteReference, ct).ConfigureAwait(false);
+    }
+
+    private async Task<IRegistryUploader> ResolveAsync(CancellationToken ct)
+    {
+        if (_resolved is not null)
+        {
+            return _resolved;
+        }
+
+        await _resolveGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_resolved is not null)
+            {
+                return _resolved;
+            }
+
+            var engine = await _detector.DetectAsync(ct).ConfigureAwait(false);
+            _resolved = engine.Kind switch
+            {
+                BuildEngineKind.DockerBuildKit => _docker,
+                BuildEngineKind.AppleContainers => _apple,
+                BuildEngineKind.None => throw new RegistryUploadException(
+                    code: "EngineAwareRegistryUploader.NoEngine",
+                    message: "no container build engine detected on host; cannot push — install Apple Containers (macOS 26+) or Docker Desktop."),
+                _ => throw new RegistryUploadException(
+                    code: "EngineAwareRegistryUploader.UnknownEngine",
+                    message: $"detected engine kind '{engine.Kind}' has no IRegistryUploader implementation."),
+            };
+            return _resolved;
+        }
+        finally
+        {
+            _resolveGate.Release();
+        }
+    }
+}

--- a/src/Andy.Containers.Infrastructure/Registries/Local/LocalZotRegistryServiceCollectionExtensions.cs
+++ b/src/Andy.Containers.Infrastructure/Registries/Local/LocalZotRegistryServiceCollectionExtensions.cs
@@ -37,7 +37,17 @@ public static class LocalZotRegistryServiceCollectionExtensions
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(registryId);
 
-        services.TryAddSingleton<IRegistryUploader, DockerCliUploader>();
+        // P1F3 (rivoli-ai/andy-containers#276). Register both concrete
+        // uploaders + an engine-aware composite. The composite resolves
+        // IBuildEngineDetector on first push, caches the choice, and
+        // dispatches to DockerCliUploader (Docker BuildKit) or
+        // AppleContainersUploader (Apple Containers, macOS 26+).
+        // Without this dispatch the uploader was hard-wired to Docker
+        // and Apple Containers users hit "No such image" because the
+        // built image lives in Apple's separate store.
+        services.TryAddSingleton<DockerCliUploader>();
+        services.TryAddSingleton<AppleContainersUploader>();
+        services.TryAddSingleton<IRegistryUploader, EngineAwareRegistryUploader>();
 
         services.AddHttpClient<LocalZotAdapter>((sp, client) =>
         {

--- a/tests/Andy.Containers.Integration.Tests/RoundTrip/LocalZotAdapterRoundTripTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/RoundTrip/LocalZotAdapterRoundTripTests.cs
@@ -184,6 +184,101 @@ public class LocalZotAdapterRoundTripTests : IClassFixture<ZotContainerFixture>
         }
     }
 
+    /// <summary>
+    /// P1F3 (rivoli-ai/andy-containers#276). Parallel to
+    /// <see cref="PushPath_DockerCliUploaderToRealZot"/> but exercises
+    /// the Apple Containers path: build via <c>container build</c>,
+    /// then push via <see cref="AppleContainersUploader"/>. Gated on
+    /// the `container` CLI being on PATH (macOS 26+). Also needs zot
+    /// available for the registry side — when Docker isn't running
+    /// the test short-circuits like its docker sibling.
+    /// </summary>
+    [AppleContainerCliFact]
+    public async Task PushPath_AppleContainersUploaderToRealZot()
+    {
+        if (!_zot.IsAvailable)
+        {
+            return;
+        }
+
+        var contextDir = Directory.CreateTempSubdirectory("p1f3-pushpath-").FullName;
+        var localTag = $"andy-containers-p1f3-push-{Guid.NewGuid():N}";
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(contextDir, "Dockerfile"),
+                "FROM hello-world\n");
+
+            await RunContainerCliAsync([
+                "build",
+                "-t", localTag,
+                contextDir,
+            ]);
+
+            using var http = new HttpClient { BaseAddress = new Uri(_zot.BaseUrl) };
+            var adapter = new LocalZotAdapter(
+                http,
+                new AppleContainersUploader(NullLogger<AppleContainersUploader>.Instance),
+                NullLogger<LocalZotAdapter>.Instance,
+                registryId: "test-zot");
+
+            var artifact = new BuildArtifact(
+                Digest: string.Empty,
+                MediaType: "application/vnd.oci.image.manifest.v1+json",
+                SizeBytes: 0,
+                SpecHash: "sha256:test-spec-apple-pushpath",
+                LocalReference: localTag);
+
+            var reference = await adapter.PushAsync(
+                artifact,
+                repoPath: "p1f3-push",
+                tag: "v1",
+                CancellationToken.None);
+
+            reference.Digest.Should().StartWith("sha256:",
+                "the post-push HEAD must yield Docker-Content-Digest from zot when pushing via Apple Containers too.");
+
+            (await adapter.ExistsAsync("p1f3-push", reference.Digest, CancellationToken.None))
+                .Should().BeTrue("the manifest just pushed must be reachable by digest.");
+
+            // Best-effort cleanup; Apple's `container images delete`
+            // is the rough equivalent of `docker rmi -f`. Ignore the
+            // exit code so a stale image left behind from a prior run
+            // doesn't fail the test.
+            try { await RunContainerCliAsync(["images", "delete", localTag]); }
+            catch { /* best-effort */ }
+        }
+        finally
+        {
+            try { Directory.Delete(contextDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    private static async Task RunContainerCliAsync(string[] args)
+    {
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "container",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+        using var proc = new System.Diagnostics.Process { StartInfo = psi };
+        proc.Start();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+        await proc.StandardOutput.ReadToEndAsync();
+        await proc.WaitForExitAsync();
+        if (proc.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"container {string.Join(' ', args)} exited {proc.ExitCode}: {await stderrTask}");
+        }
+    }
+
     private static async Task RunDockerCliAsync(string[] args)
     {
         var psi = new System.Diagnostics.ProcessStartInfo

--- a/tests/Andy.Containers.Tests/Infrastructure/Registries/AppleContainersUploaderTests.cs
+++ b/tests/Andy.Containers.Tests/Infrastructure/Registries/AppleContainersUploaderTests.cs
@@ -1,0 +1,74 @@
+using Andy.Containers.Infrastructure.Registries;
+using Andy.Containers.Infrastructure.Registries.Local;
+using Andy.Containers.Tests.TestSupport;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Containers.Tests.Infrastructure.Registries;
+
+// P1F3 (rivoli-ai/andy-containers#276). Mirrors DockerCliUploaderTests
+// — the `container` executable is substituted with a bash stub that
+// records its invocation. macOS / Linux only.
+public class AppleContainersUploaderTests
+{
+    public static bool RunsBashStubs => !OperatingSystem.IsWindows();
+
+    [Fact]
+    public async Task PushAsync_RunsImagesTagThenImagesPushAndCapturesArguments()
+    {
+        if (!RunsBashStubs) { return; }
+
+        using var stub = new StubScript(exitCode: 0, stderr: "");
+        var uploader = MakeUploader(stub);
+
+        await uploader.PushAsync("andy-build:tmp", "localhost:5050/foo:v1", CancellationToken.None);
+
+        stub.Invocations.Should().HaveCount(2,
+            "PushAsync runs `container images tag` then `container images push` — two child processes.");
+        stub.Invocations[0].Should().Equal(["images", "tag", "andy-build:tmp", "localhost:5050/foo:v1"]);
+        stub.Invocations[1].Should().Equal(["images", "push", "localhost:5050/foo:v1"]);
+    }
+
+    [Fact]
+    public async Task PushAsync_ThrowsWithCapturedOutput_OnNonZeroExit()
+    {
+        if (!RunsBashStubs) { return; }
+
+        using var stub = new StubScript(
+            exitCode: 1,
+            stderr: "Error: manifest invalid: provenance attestation rejected");
+        var uploader = MakeUploader(stub);
+
+        var act = async () => await uploader.PushAsync(
+            "andy-build:tmp", "localhost:5050/foo:v1", CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<RegistryUploadException>();
+        ex.Which.Code.Should().StartWith("AppleContainersUploader.Tag.NonZeroExit");
+        ex.Which.CapturedOutput.Should().Contain("manifest invalid");
+    }
+
+    [Fact]
+    public async Task PushAsync_SurfacesLaunchFailureWithStableCode_WhenContainerBinaryMissing()
+    {
+        if (!RunsBashStubs) { return; }
+
+        var uploader = new AppleContainersUploader(
+            NullLogger<AppleContainersUploader>.Instance,
+            new AppleContainersUploaderOptions
+            {
+                ContainerExecutablePath = "/nonexistent/path/to/container-not-installed",
+            });
+
+        var act = async () => await uploader.PushAsync(
+            "andy-build:tmp", "localhost:5050/foo:v1", CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<RegistryUploadException>();
+        ex.Which.Code.Should().Be("AppleContainersUploader.Tag.LaunchFailed",
+            "missing `container` CLI is the macOS-26+-without-runtime operator pain — the code must be greppable so IM10 maps it to a 503 with an actionable message.");
+    }
+
+    private static AppleContainersUploader MakeUploader(StubScript stub)
+        => new(NullLogger<AppleContainersUploader>.Instance,
+            new AppleContainersUploaderOptions { ContainerExecutablePath = stub.Path });
+}

--- a/tests/Andy.Containers.Tests/Infrastructure/Registries/EngineAwareRegistryUploaderTests.cs
+++ b/tests/Andy.Containers.Tests/Infrastructure/Registries/EngineAwareRegistryUploaderTests.cs
@@ -1,0 +1,100 @@
+using Andy.Containers.Infrastructure.Build;
+using Andy.Containers.Infrastructure.Registries;
+using Andy.Containers.Infrastructure.Registries.Local;
+using Andy.Containers.Tests.TestSupport;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Tests.Infrastructure.Registries;
+
+// P1F3 (rivoli-ai/andy-containers#276). The composite dispatches to
+// the right uploader based on detected engine, caches the choice, and
+// surfaces a clear error when no engine is detected.
+public class EngineAwareRegistryUploaderTests
+{
+    public static bool RunsBashStubs => !OperatingSystem.IsWindows();
+
+    [Fact]
+    public async Task PushAsync_DispatchesToDocker_WhenEngineIsDockerBuildKit()
+    {
+        if (!RunsBashStubs) { return; }
+
+        using var dockerStub = new StubScript(exitCode: 0, stderr: "");
+        using var appleStub = new StubScript(exitCode: 0, stderr: "");
+        var (composite, _) = MakeComposite(BuildEngineKind.DockerBuildKit, dockerStub, appleStub);
+
+        await composite.PushAsync("andy-build:tmp", "localhost:5050/foo:v1", CancellationToken.None);
+
+        dockerStub.Invocations.Should().HaveCount(2,
+            "Docker engine selected — DockerCliUploader's tag+push (2 invocations) must run.");
+        appleStub.Invocations.Should().BeEmpty(
+            "AppleContainersUploader must not run when the engine is Docker.");
+    }
+
+    [Fact]
+    public async Task PushAsync_DispatchesToApple_WhenEngineIsAppleContainers()
+    {
+        if (!RunsBashStubs) { return; }
+
+        using var dockerStub = new StubScript(exitCode: 0, stderr: "");
+        using var appleStub = new StubScript(exitCode: 0, stderr: "");
+        var (composite, _) = MakeComposite(BuildEngineKind.AppleContainers, dockerStub, appleStub);
+
+        await composite.PushAsync("andy-build:tmp", "localhost:5050/foo:v1", CancellationToken.None);
+
+        appleStub.Invocations.Should().HaveCount(2,
+            "Apple Containers engine selected — AppleContainersUploader's tag+push (2 invocations) must run.");
+        dockerStub.Invocations.Should().BeEmpty(
+            "DockerCliUploader must not run when the engine is Apple Containers.");
+    }
+
+    [Fact]
+    public async Task PushAsync_ThrowsRegistryUploadException_WhenNoEngineDetected()
+    {
+        using var dockerStub = new StubScript(exitCode: 0, stderr: "");
+        using var appleStub = new StubScript(exitCode: 0, stderr: "");
+        var (composite, _) = MakeComposite(BuildEngineKind.None, dockerStub, appleStub);
+
+        var act = async () => await composite.PushAsync(
+            "andy-build:tmp", "localhost:5050/foo:v1", CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<RegistryUploadException>();
+        ex.Which.Code.Should().Be("EngineAwareRegistryUploader.NoEngine");
+    }
+
+    [Fact]
+    public async Task PushAsync_CallsDetectorOnce_AcrossRepeatedPushes()
+    {
+        if (!RunsBashStubs) { return; }
+
+        using var dockerStub = new StubScript(exitCode: 0, stderr: "");
+        using var appleStub = new StubScript(exitCode: 0, stderr: "");
+        var (composite, detector) = MakeComposite(BuildEngineKind.DockerBuildKit, dockerStub, appleStub);
+
+        await composite.PushAsync("a:tmp", "localhost:5050/a:1", CancellationToken.None);
+        await composite.PushAsync("b:tmp", "localhost:5050/b:1", CancellationToken.None);
+        await composite.PushAsync("c:tmp", "localhost:5050/c:1", CancellationToken.None);
+
+        detector.Verify(d => d.DetectAsync(It.IsAny<CancellationToken>()), Times.Once,
+            "Detection result is cached for the composite's lifetime — three pushes must share one detection.");
+    }
+
+    private static (EngineAwareRegistryUploader composite, Mock<IBuildEngineDetector> detector) MakeComposite(
+        BuildEngineKind kind, StubScript dockerStub, StubScript appleStub)
+    {
+        var detector = new Mock<IBuildEngineDetector>();
+        detector.Setup(d => d.DetectAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DetectedBuildEngine(kind, kind == BuildEngineKind.None ? string.Empty : "stub", "stub"));
+
+        var docker = new DockerCliUploader(
+            NullLogger<DockerCliUploader>.Instance,
+            new DockerCliUploaderOptions { DockerExecutablePath = dockerStub.Path });
+        var apple = new AppleContainersUploader(
+            NullLogger<AppleContainersUploader>.Instance,
+            new AppleContainersUploaderOptions { ContainerExecutablePath = appleStub.Path });
+
+        return (new EngineAwareRegistryUploader(detector.Object, docker, apple), detector);
+    }
+}


### PR DESCRIPTION
## Summary

The build-engine detector prefers Apple Containers over Docker on macOS 26+, but the only registered `IRegistryUploader` was `DockerCliUploader`. Apple Containers maintains its own image store separate from the Docker daemon's cache, so `docker tag <localTag>` fails with "No such image: …" — every M1.9 build on macOS 26+ dies at the push step even after #275 and conductor#1028 land.

This PR adds:

- **`AppleContainersUploader`** — shells `container images tag` then `container images push`, mirroring `DockerCliUploader`'s two-step shape. Stable `RegistryUploadException` codes for IM10 error mapping.
- **`EngineAwareRegistryUploader`** — composite registered as `IRegistryUploader` in DI. Resolves `IBuildEngineDetector` on first push, caches the choice, dispatches to the matching concrete uploader. Throws `EngineAwareRegistryUploader.NoEngine` when none detected.
- **DI wiring** in `LocalZotRegistryServiceCollectionExtensions` registers both concrete uploaders + the composite.
- **Docs**: new `IRegistryUploader` subsection in `docs/architecture/image-management.md` describing the engine-aware split — the IM6/IM7 Apple-Containers path is no longer theoretical.

Closes rivoli-ai/andy-containers#276. M1.9 BLOCKER on macOS 26+ (P1F3 follow-up to Epic IM #249).

## Test plan

- [x] Unit tests — 7/7 pass:
  - `AppleContainersUploaderTests` (3): argv shape, non-zero exit error mapping, missing-binary launch failure
  - `EngineAwareRegistryUploaderTests` (4): Docker dispatch, Apple dispatch, no-engine error, detection cached across pushes
- [x] Full unit-test sweep: `Andy.Containers.Tests` 467/467 pass
- [x] Integration test `PushPath_AppleContainersUploaderToRealZot` parallel to the existing docker test, gated on `[AppleContainerCliFact]` — skips cleanly on this machine (no `container` CLI); will exercise the real end-to-end path on macOS 26+ CI runners
- [ ] Manual run on macOS 26+ with Apple Containers installed — deferred to whoever first stands up that runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)