### PR TITLE
#277 PR B: StagedBuildContext surfaces uploaded files to the build backend

### DIFF
--- a/src/Andy.Containers.Infrastructure/Build/ImageBuildOrchestrator.cs
+++ b/src/Andy.Containers.Infrastructure/Build/ImageBuildOrchestrator.cs
@@ -176,7 +176,16 @@ public sealed class ImageBuildOrchestrator : IImageBuildOrchestrator
             var spec = MapToSpec(template);
             var contextDir = Path.Combine(Path.GetTempPath(), $"andy-orchestrator-{Guid.NewGuid():N}");
             Directory.CreateDirectory(contextDir);
-            var context = new EmptyBuildContext(contextDir);
+            // P1F4 Part B (rivoli-ai/andy-containers#277). When the
+            // multipart register path staged files into
+            // template.UploadedFilesPath, enumerate them and surface
+            // each as IBuildContext.Files. The build backend's
+            // StageBuildContextAsync already copies context.Files into
+            // the build dir under their LogicalName, so this single
+            // wiring change is all that's needed for the M1.9
+            // `conductor-terminal-claude-code` template's
+            // `install-assistants.sh` to land in the build context.
+            var context = StagedBuildContext.ForTemplate(contextDir, template.UploadedFilesPath, _logger);
 
             try
             {
@@ -417,16 +426,71 @@ public sealed class ImageBuildOrchestrator : IImageBuildOrchestrator
     }
 
     /// <summary>
-    /// Empty <see cref="IBuildContext"/> for orchestrator-managed builds.
-    /// IM8 doesn't yet plumb multipart-uploaded files through the
-    /// orchestrator (the JSON-only register endpoint doesn't accept
-    /// them); files-on-disk staging will land alongside the multipart
-    /// register variant.
+    /// P1F4 Part B (rivoli-ai/andy-containers#277).
+    /// <see cref="IBuildContext"/> for orchestrator-managed builds.
+    /// When <see cref="ContainerTemplate.UploadedFilesPath"/> is set
+    /// (multipart register path, PR A), enumerates the staging
+    /// directory recursively and exposes each file as an
+    /// <see cref="UploadedFile"/> with <c>LogicalName</c> equal to
+    /// the file's path relative to the staging root — preserving any
+    /// nested subdirectories the uploader created. When the property
+    /// is null (JSON register path, or legacy rows) or the directory
+    /// has vanished, falls back to an empty file list — equivalent to
+    /// the pre-#277 behaviour.
     /// </summary>
-    private sealed class EmptyBuildContext : IBuildContext
+    internal sealed class StagedBuildContext : IBuildContext
     {
-        public EmptyBuildContext(string dir) { ContextDirectoryPath = dir; }
         public string ContextDirectoryPath { get; }
-        public IReadOnlyList<UploadedFile> Files => Array.Empty<UploadedFile>();
+        public IReadOnlyList<UploadedFile> Files { get; }
+
+        private StagedBuildContext(string contextDirectoryPath, IReadOnlyList<UploadedFile> files)
+        {
+            ContextDirectoryPath = contextDirectoryPath;
+            Files = files;
+        }
+
+        public static StagedBuildContext ForTemplate(
+            string contextDirectoryPath,
+            string? uploadedFilesPath,
+            ILogger logger)
+        {
+            if (string.IsNullOrWhiteSpace(uploadedFilesPath))
+            {
+                return new StagedBuildContext(contextDirectoryPath, Array.Empty<UploadedFile>());
+            }
+
+            if (!Directory.Exists(uploadedFilesPath))
+            {
+                // The staging dir is expected to outlive every build
+                // until the PR C cleanup pass — its absence usually
+                // means a manual /tmp wipe between API restarts. Warn
+                // (so operators can spot it) and proceed without
+                // uploaded files; the build will fail later when the
+                // Dockerfile references a missing source, with a
+                // clearer engine-side error than we could synthesise
+                // here.
+                logger.LogWarning(
+                    "Template's UploadedFilesPath '{Path}' is missing on disk; building without uploaded files.",
+                    uploadedFilesPath);
+                return new StagedBuildContext(contextDirectoryPath, Array.Empty<UploadedFile>());
+            }
+
+            var stagingRoot = Path.GetFullPath(uploadedFilesPath);
+            var files = new List<UploadedFile>();
+            foreach (var absolute in Directory.EnumerateFiles(stagingRoot, "*", SearchOption.AllDirectories))
+            {
+                var relative = Path.GetRelativePath(stagingRoot, absolute);
+                // Normalise to forward slashes so LogicalName matches
+                // the spec's `files[].source` value (which is always
+                // POSIX-style regardless of host OS) and the build
+                // backend's destination path inside the Linux build
+                // context.
+                var logical = relative.Replace(Path.DirectorySeparatorChar, '/');
+                var size = new FileInfo(absolute).Length;
+                files.Add(new UploadedFile(logical, absolute, size));
+            }
+
+            return new StagedBuildContext(contextDirectoryPath, files);
+        }
     }
 }

--- a/tests/Andy.Containers.Integration.Tests/Build/ImageBuildOrchestratorTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/Build/ImageBuildOrchestratorTests.cs
@@ -261,6 +261,140 @@ public class ImageBuildOrchestratorTests : IAsyncLifetime
         result.ErrorCode.Should().Be("registry.not_configured");
     }
 
+    // P1F4 Part B (rivoli-ai/andy-containers#277). When the multipart
+    // register path stamped UploadedFilesPath on the template (PR A),
+    // the orchestrator must enumerate that staging dir and surface
+    // each file via IBuildContext.Files — including files nested in
+    // subdirectories, whose LogicalName is the POSIX-style path
+    // relative to the staging root.
+    [Fact]
+    public async Task BuildAsync_WhenTemplateHasUploadedFilesPath_SurfacesFilesViaBuildContext()
+    {
+        var stagingDir = Directory.CreateTempSubdirectory("p1f4-partb-staging-").FullName;
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(stagingDir, "install-assistants.sh"),
+                "#!/usr/bin/env bash\nexit 0\n");
+            Directory.CreateDirectory(Path.Combine(stagingDir, "bin"));
+            await File.WriteAllTextAsync(
+                Path.Combine(stagingDir, "bin", "nested.sh"),
+                "echo nested\n");
+
+            var template = await _db.Templates.FindAsync(_templateId);
+            template!.UploadedFilesPath = stagingDir;
+            await _db.SaveChangesAsync();
+
+            SetupBackendBuilds("andy-build:tmp", "sha256:test-hash");
+            SetupAdapterPush("local-zot", "test", "sha256-test-hash", returnedDigest: "sha256:abc");
+
+            IBuildContext? captured = null;
+            _backend.Setup(b => b.BuildAsync(
+                    It.IsAny<TemplateSpec>(),
+                    It.IsAny<IBuildContext>(),
+                    It.IsAny<IProgress<BuildProgressEvent>>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<TemplateSpec, IBuildContext, IProgress<BuildProgressEvent>, CancellationToken>(
+                    (_, ctx, _, _) => captured = ctx)
+                .ReturnsAsync(new BuildArtifact(
+                    Digest: string.Empty,
+                    MediaType: "application/vnd.oci.image.manifest.v1+json",
+                    SizeBytes: 1000,
+                    SpecHash: "sha256:test-hash",
+                    LocalReference: "andy-build:tmp"));
+
+            await _orchestrator.BuildAsync(
+                new ImageBuildRequest(_templateId, null, false, "user"),
+                new Progress<BuildProgressEvent>(_ => { }),
+                CancellationToken.None);
+
+            captured.Should().NotBeNull();
+            captured!.Files.Should().HaveCount(2);
+            captured.Files.Should().Contain(f => f.LogicalName == "install-assistants.sh"
+                && f.AbsolutePath == Path.Combine(stagingDir, "install-assistants.sh"));
+            captured.Files.Should().Contain(f => f.LogicalName == "bin/nested.sh"
+                && f.AbsolutePath == Path.Combine(stagingDir, "bin", "nested.sh"),
+                "nested files must use POSIX-style LogicalName so the build backend writes them at the same relative path inside the Linux build context.");
+        }
+        finally
+        {
+            try { Directory.Delete(stagingDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    // P1F4 Part B back-compat: JSON register path (or legacy rows
+    // pre-#277) leaves UploadedFilesPath null. The orchestrator must
+    // still build, with an empty Files collection — exactly the
+    // pre-PR-B behaviour.
+    [Fact]
+    public async Task BuildAsync_WhenUploadedFilesPathIsNull_BuildContextHasNoFiles()
+    {
+        SetupBackendBuilds("andy-build:tmp", "sha256:test-hash");
+        SetupAdapterPush("local-zot", "test", "sha256-test-hash", returnedDigest: "sha256:abc");
+
+        IBuildContext? captured = null;
+        _backend.Setup(b => b.BuildAsync(
+                It.IsAny<TemplateSpec>(),
+                It.IsAny<IBuildContext>(),
+                It.IsAny<IProgress<BuildProgressEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<TemplateSpec, IBuildContext, IProgress<BuildProgressEvent>, CancellationToken>(
+                (_, ctx, _, _) => captured = ctx)
+            .ReturnsAsync(new BuildArtifact(
+                Digest: string.Empty,
+                MediaType: "application/vnd.oci.image.manifest.v1+json",
+                SizeBytes: 1000,
+                SpecHash: "sha256:test-hash",
+                LocalReference: "andy-build:tmp"));
+
+        await _orchestrator.BuildAsync(
+            new ImageBuildRequest(_templateId, null, false, "user"),
+            new Progress<BuildProgressEvent>(_ => { }),
+            CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.Files.Should().BeEmpty();
+    }
+
+    // P1F4 Part B graceful fallback: a stale UploadedFilesPath
+    // (manual /tmp wipe between API restarts) must not crash the
+    // build — the orchestrator surfaces an empty Files list and lets
+    // the build fail downstream with the engine's own error if the
+    // Dockerfile references the missing source.
+    [Fact]
+    public async Task BuildAsync_WhenUploadedFilesPathMissingOnDisk_BuildContextHasNoFiles()
+    {
+        var template = await _db.Templates.FindAsync(_templateId);
+        template!.UploadedFilesPath = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}");
+        await _db.SaveChangesAsync();
+
+        SetupBackendBuilds("andy-build:tmp", "sha256:test-hash");
+        SetupAdapterPush("local-zot", "test", "sha256-test-hash", returnedDigest: "sha256:abc");
+
+        IBuildContext? captured = null;
+        _backend.Setup(b => b.BuildAsync(
+                It.IsAny<TemplateSpec>(),
+                It.IsAny<IBuildContext>(),
+                It.IsAny<IProgress<BuildProgressEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<TemplateSpec, IBuildContext, IProgress<BuildProgressEvent>, CancellationToken>(
+                (_, ctx, _, _) => captured = ctx)
+            .ReturnsAsync(new BuildArtifact(
+                Digest: string.Empty,
+                MediaType: "application/vnd.oci.image.manifest.v1+json",
+                SizeBytes: 1000,
+                SpecHash: "sha256:test-hash",
+                LocalReference: "andy-build:tmp"));
+
+        await _orchestrator.BuildAsync(
+            new ImageBuildRequest(_templateId, null, false, "user"),
+            new Progress<BuildProgressEvent>(_ => { }),
+            CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.Files.Should().BeEmpty();
+    }
+
     private void SetupBackendBuilds(string localTag, string specHash)
     {
         _backend.Setup(b => b.BuildAsync(


### PR DESCRIPTION
## Summary

PR A landed the controller half of #277 — multipart from-yaml stages files under `template.UploadedFilesPath`. The orchestrator was still passing `EmptyBuildContext` to the build backend, so those staged files never made it into the build dir at build time. Templates whose YAML had `files:` entries could be registered but not built.

This PR replaces the private `EmptyBuildContext` with `StagedBuildContext` that, when `template.UploadedFilesPath` is set, enumerates the staging directory recursively and exposes each file as an `UploadedFile`. `LogicalName` is the POSIX-style path relative to the staging root, which matches both the spec's `files[].source` value and the destination path the build backend writes into the Linux build context. `LocalBuildBackend.StageBuildContextAsync` already copies `context.Files` into the build dir under their `LogicalName` — this single wiring change lights up the rest of the path automatically.

After this PR lands, M1.9's `conductor-terminal-claude-code` template can register + build + push end-to-end.

## Back-compat / failure modes

- `UploadedFilesPath` null (JSON register path, or legacy pre-#277 rows) → empty Files collection, identical to pre-PR-B behaviour.
- `UploadedFilesPath` set but the directory has vanished (manual `/tmp` wipe between API restarts) → warn-and-fall-back-to-empty. The build then fails downstream with the engine's own "missing source" error rather than crashing here.

## Test plan

- [x] 3 new tests in `ImageBuildOrchestratorTests`:
  - `BuildAsync_WhenTemplateHasUploadedFilesPath_SurfacesFilesViaBuildContext` — files-on-disk → context.Files populated, including a nested subdirectory file whose `LogicalName` uses `/` not the host separator
  - `BuildAsync_WhenUploadedFilesPathIsNull_BuildContextHasNoFiles` — back-compat
  - `BuildAsync_WhenUploadedFilesPathMissingOnDisk_BuildContextHasNoFiles` — graceful fallback
- [x] All 6 pre-existing orchestrator tests still pass (9/9 total)
- [x] Full solution test pass: Api.Tests 1072/1073 (1 pre-existing skip), Integration.Tests 46/54 (env-gated skips)

## What this completes

Issue #277 acceptance after PR A + PR B:

- [x] `POST /api/templates/from-yaml` accepts `multipart/form-data` (PR A)
- [x] Files referenced by `files:` in YAML are copied into the build context at build time (this PR)
- [x] Existing JSON path keeps working (PR A + back-compat test in this PR)
- [x] Multipart variant has its own integration test (PR A)
- [x] `RequestSizeLimit` capped sensibly (PR A — 32 MiB per file, 256 MiB total)

PR C (TTL / post-build cleanup of staging dirs) remains a separate follow-up; it isn't required by #277's acceptance.

Closes rivoli-ai/andy-containers#277. Last open Phase-1 follow-up of Epic IM #249 — after this lands, Phases 2–5 can be filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)