### PR TITLE
#277 PR C: TTL sweeper for template-uploads staging dirs

### DIFF
--- a/src/Andy.Containers.Api/Controllers/TemplatesController.cs
+++ b/src/Andy.Containers.Api/Controllers/TemplatesController.cs
@@ -331,10 +331,7 @@ public class TemplatesController : ControllerBase
         // the existing template's UploadedFilesPath instead.
         var stagingId = Guid.NewGuid();
         var stagingDir = Path.Combine(
-            Path.GetTempPath(),
-            "andy-containers",
-            "template-uploads",
-            "staging",
+            TemplateUploadStagingPaths.GetStagingRoot(),
             stagingId.ToString("N"));
 
         var fileDigests = new Dictionary<string, string>(StringComparer.Ordinal);

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -138,6 +138,15 @@ try
     builder.Services.AddScoped<ITemplateBuildService, TemplateBuildService>();
     builder.Services.AddHostedService<ImageBuildWorker>();
 
+    // #277 PR C. Reclaim abandoned template-upload staging dirs.
+    // Periodic sweep over <temp>/andy-containers/template-uploads/staging/
+    // that deletes <stagingId> subdirs no longer referenced by any
+    // Template.UploadedFilesPath row and older than the configured
+    // retention (default 7 days).
+    builder.Services.Configure<TemplateUploadStagingCleanupOptions>(
+        builder.Configuration.GetSection(TemplateUploadStagingCleanupOptions.SectionName));
+    builder.Services.AddHostedService<TemplateUploadStagingCleanupWorker>();
+
     // Git credential + clone services
     //
     // RC2 (#200). Persist the Data Protection key ring in the DB

--- a/src/Andy.Containers.Api/Services/TemplateUploadStagingCleanupOptions.cs
+++ b/src/Andy.Containers.Api/Services/TemplateUploadStagingCleanupOptions.cs
@@ -1,0 +1,34 @@
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// #277 PR C. Options for
+/// <see cref="TemplateUploadStagingCleanupWorker"/>. Bound from the
+/// <c>Containers:Image:TemplateUploadStaging</c> config section.
+/// </summary>
+public sealed class TemplateUploadStagingCleanupOptions
+{
+    public const string SectionName = "Containers:Image:TemplateUploadStaging";
+
+    /// <summary>
+    /// How often the sweeper checks for stale staging dirs. Default
+    /// 1 hour — staging dirs are write-once and the cost of scanning
+    /// is bounded by the directory count.
+    /// </summary>
+    public TimeSpan SweepInterval { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Minimum age before an unreferenced staging dir is eligible for
+    /// deletion. Default 7 days — long enough that an operator who
+    /// uploaded files and intends to come back to them inside the
+    /// week doesn't lose their staged content, short enough that
+    /// abandoned uploads from misbehaving clients can't pile up
+    /// indefinitely.
+    /// </summary>
+    /// <remarks>
+    /// Dirs still referenced by some <c>Template.UploadedFilesPath</c>
+    /// row are NEVER deleted regardless of age, so force-rebuilds of
+    /// long-lived templates always have their source files. Only
+    /// orphaned dirs are subject to the retention cutoff.
+    /// </remarks>
+    public TimeSpan Retention { get; set; } = TimeSpan.FromDays(7);
+}

--- a/src/Andy.Containers.Api/Services/TemplateUploadStagingCleanupWorker.cs
+++ b/src/Andy.Containers.Api/Services/TemplateUploadStagingCleanupWorker.cs
@@ -1,0 +1,193 @@
+using Andy.Containers.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// #277 PR C. Periodic sweeper for the multipart-template-upload
+/// staging root. Reclaims abandoned <c>&lt;stagingId&gt;</c>
+/// subdirectories — those whose path is no longer referenced by any
+/// <c>Template.UploadedFilesPath</c> row AND whose last-write
+/// timestamp is older than the configured retention.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Referenced dirs are kept indefinitely — force-rebuilds of a
+/// long-lived template need its uploaded files to be there. Only
+/// orphaned dirs (template was deleted, or the multipart POST
+/// crashed mid-flight in a way that escaped PR A's best-effort
+/// catch) are subject to the retention cutoff.
+/// </para>
+/// <para>
+/// Modeled on <see cref="ProviderHealthCheckWorker"/>: PeriodicTimer
+/// loop, IServiceScopeFactory for scoped DB access, single
+/// testable <see cref="SweepOnceAsync"/> method so unit tests can
+/// run the work without the timer.
+/// </para>
+/// </remarks>
+public sealed class TemplateUploadStagingCleanupWorker : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly TemplateUploadStagingCleanupOptions _options;
+    private readonly ILogger<TemplateUploadStagingCleanupWorker> _logger;
+    private readonly TimeProvider _clock;
+    private readonly string _stagingRoot;
+
+    private static readonly TimeSpan StartupDelay = TimeSpan.FromSeconds(30);
+
+    public TemplateUploadStagingCleanupWorker(
+        IServiceScopeFactory scopeFactory,
+        IOptions<TemplateUploadStagingCleanupOptions> options,
+        ILogger<TemplateUploadStagingCleanupWorker> logger)
+        : this(scopeFactory, options.Value, logger,
+               TemplateUploadStagingPaths.GetStagingRoot(), TimeProvider.System)
+    {
+    }
+
+    /// <summary>
+    /// Test-only constructor. Lets unit tests point the sweeper at a
+    /// scratch directory + virtual clock instead of the real
+    /// <c>Path.GetTempPath()</c>-rooted staging tree.
+    /// </summary>
+    internal TemplateUploadStagingCleanupWorker(
+        IServiceScopeFactory scopeFactory,
+        TemplateUploadStagingCleanupOptions options,
+        ILogger<TemplateUploadStagingCleanupWorker> logger,
+        string stagingRoot,
+        TimeProvider clock)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options;
+        _logger = logger;
+        _stagingRoot = stagingRoot;
+        _clock = clock;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation(
+            "TemplateUploadStagingCleanupWorker started. Interval={Interval} Retention={Retention}",
+            _options.SweepInterval, _options.Retention);
+
+        try { await Task.Delay(StartupDelay, stoppingToken); }
+        catch (OperationCanceledException) { return; }
+
+        using var timer = new PeriodicTimer(_options.SweepInterval);
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await SweepOnceAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                // Swallow per-tick exceptions so a transient FS or DB
+                // error doesn't take the worker down for the lifetime
+                // of the process. Next tick retries.
+                _logger.LogError(ex, "TemplateUploadStagingCleanupWorker sweep failed; will retry next tick.");
+            }
+
+            try { await timer.WaitForNextTickAsync(stoppingToken); }
+            catch (OperationCanceledException) { break; }
+        }
+
+        _logger.LogInformation("TemplateUploadStagingCleanupWorker stopped.");
+    }
+
+    /// <summary>
+    /// Run one sweep. Public for direct invocation from unit tests —
+    /// the timer loop is not the interesting unit; the per-tick
+    /// decision (keep / delete) is. Returns the number of directories
+    /// deleted so tests can assert without re-reading the filesystem.
+    /// </summary>
+    public async Task<int> SweepOnceAsync(CancellationToken ct)
+    {
+        if (!Directory.Exists(_stagingRoot))
+        {
+            // No multipart POSTs have ever landed on this host —
+            // nothing to reclaim. Common in clean dev environments.
+            return 0;
+        }
+
+        // Pull the referenced paths in one query. Comparison happens
+        // in-memory on absolute paths because EF SQLite doesn't
+        // translate Path.GetFullPath; the set size is bounded by
+        // the number of templates that ever used the multipart
+        // register path (typically small).
+        HashSet<string> referenced;
+        using (var scope = _scopeFactory.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ContainersDbContext>();
+            var raw = await db.Templates
+                .AsNoTracking()
+                .Where(t => t.UploadedFilesPath != null)
+                .Select(t => t.UploadedFilesPath!)
+                .ToListAsync(ct);
+            referenced = new HashSet<string>(
+                raw.Select(NormalisePath),
+                StringComparer.Ordinal);
+        }
+
+        var cutoff = _clock.GetUtcNow().UtcDateTime - _options.Retention;
+        var deleted = 0;
+        foreach (var dir in Directory.EnumerateDirectories(_stagingRoot))
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var normalised = NormalisePath(dir);
+            if (referenced.Contains(normalised))
+            {
+                continue;
+            }
+
+            DateTime lastWriteUtc;
+            try
+            {
+                lastWriteUtc = Directory.GetLastWriteTimeUtc(dir);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "TemplateUploadStagingCleanupWorker could not stat {Dir}; skipping.",
+                    dir);
+                continue;
+            }
+
+            if (lastWriteUtc > cutoff)
+            {
+                continue;
+            }
+
+            try
+            {
+                Directory.Delete(dir, recursive: true);
+                deleted++;
+                _logger.LogInformation(
+                    "TemplateUploadStagingCleanupWorker reclaimed orphan staging dir {Dir} (lastWrite={LastWrite}).",
+                    dir, lastWriteUtc);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "TemplateUploadStagingCleanupWorker failed to delete orphan staging dir {Dir}; will retry next tick.",
+                    dir);
+            }
+        }
+
+        if (deleted > 0)
+        {
+            _logger.LogInformation(
+                "TemplateUploadStagingCleanupWorker sweep reclaimed {Count} orphan staging dir(s).",
+                deleted);
+        }
+        return deleted;
+    }
+
+    private static string NormalisePath(string path)
+        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar);
+}

--- a/src/Andy.Containers.Api/Services/TemplateUploadStagingPaths.cs
+++ b/src/Andy.Containers.Api/Services/TemplateUploadStagingPaths.cs
@@ -1,0 +1,26 @@
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// #277. Single source of truth for the on-disk location of
+/// multipart-staged template files. Shared by the multipart register
+/// path (<c>TemplatesController.CreateFromYamlMultipart</c>, which
+/// creates the dirs) and the TTL sweeper
+/// (<see cref="TemplateUploadStagingCleanupWorker"/>, PR C, which
+/// reclaims them).
+/// </summary>
+public static class TemplateUploadStagingPaths
+{
+    /// <summary>
+    /// Absolute path to the staging root —
+    /// <c>&lt;temp&gt;/andy-containers/template-uploads/staging</c>.
+    /// Each multipart register call creates one <c>&lt;stagingId&gt;</c>
+    /// subdirectory underneath; that subdirectory's full path lands in
+    /// <c>ContainerTemplate.UploadedFilesPath</c>.
+    /// </summary>
+    public static string GetStagingRoot()
+        => Path.Combine(
+            Path.GetTempPath(),
+            "andy-containers",
+            "template-uploads",
+            "staging");
+}

--- a/src/Andy.Containers/Models/ContainerTemplate.cs
+++ b/src/Andy.Containers/Models/ContainerTemplate.cs
@@ -115,8 +115,18 @@ public class ContainerTemplate
     /// entry (and the multipart part name on the registration request).
     /// Null for the JSON-only register path and for legacy rows that
     /// pre-date #277. Populated on every multipart register-from-yaml
-    /// call. The directory survives until cleanup runs (#277 PR C).
+    /// call.
     /// </summary>
+    /// <remarks>
+    /// The directory persists as long as this template row exists.
+    /// The PR C TTL sweeper
+    /// (<c>TemplateUploadStagingCleanupWorker</c>) never deletes
+    /// referenced dirs — it only reclaims orphans (paths no longer
+    /// referenced by any template row, older than the configured
+    /// retention). Deleting the template row makes the dir an orphan;
+    /// the sweeper reclaims it on the next tick that crosses the
+    /// retention cutoff.
+    /// </remarks>
     public string? UploadedFilesPath { get; set; }
 }
 

--- a/tests/Andy.Containers.Api.Tests/Services/TemplateUploadStagingCleanupWorkerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/TemplateUploadStagingCleanupWorkerTests.cs
@@ -1,0 +1,166 @@
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+// #277 PR C. The sweeper's interesting unit is the per-tick
+// decision (keep / delete) — the PeriodicTimer loop adds nothing
+// testable. Tests call SweepOnceAsync directly, point the worker at
+// a scratch staging root, and drive time via a fake clock so we
+// don't have to `sleep` for the retention window.
+public sealed class TemplateUploadStagingCleanupWorkerTests : IDisposable
+{
+    private readonly string _stagingRoot;
+    private readonly FakeTime _clock = new(DateTimeOffset.Parse("2026-05-12T00:00:00Z"));
+
+    public TemplateUploadStagingCleanupWorkerTests()
+    {
+        _stagingRoot = Directory.CreateTempSubdirectory("p1f4-partc-staging-").FullName;
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_stagingRoot, recursive: true); } catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task SweepOnceAsync_DeletesUnreferencedDirOlderThanRetention()
+    {
+        var orphan = CreateStagingDir("orphan");
+        AgeTo(orphan, _clock.GetUtcNow().UtcDateTime - TimeSpan.FromDays(8));
+
+        using var db = InMemoryDbHelper.CreateContext();
+        var worker = MakeWorker(db, retention: TimeSpan.FromDays(7));
+
+        var deleted = await worker.SweepOnceAsync(CancellationToken.None);
+
+        deleted.Should().Be(1);
+        Directory.Exists(orphan).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SweepOnceAsync_KeepsDirReferencedByTemplate_EvenWhenOlderThanRetention()
+    {
+        var referenced = CreateStagingDir("referenced");
+        AgeTo(referenced, _clock.GetUtcNow().UtcDateTime - TimeSpan.FromDays(30));
+
+        using var db = InMemoryDbHelper.CreateContext();
+        db.Templates.Add(new ContainerTemplate
+        {
+            Code = "t1",
+            Name = "T1",
+            Version = "1.0.0",
+            BaseImage = "ubuntu:24.04",
+            UploadedFilesPath = referenced,
+        });
+        await db.SaveChangesAsync();
+
+        var worker = MakeWorker(db, retention: TimeSpan.FromDays(7));
+
+        var deleted = await worker.SweepOnceAsync(CancellationToken.None);
+
+        deleted.Should().Be(0);
+        Directory.Exists(referenced).Should().BeTrue(
+            "force-rebuild of a long-lived template needs its uploaded files; referenced dirs are never reclaimed regardless of age.");
+    }
+
+    [Fact]
+    public async Task SweepOnceAsync_KeepsDirYoungerThanRetention_EvenWhenUnreferenced()
+    {
+        var fresh = CreateStagingDir("fresh");
+        AgeTo(fresh, _clock.GetUtcNow().UtcDateTime - TimeSpan.FromDays(1));
+
+        using var db = InMemoryDbHelper.CreateContext();
+        var worker = MakeWorker(db, retention: TimeSpan.FromDays(7));
+
+        var deleted = await worker.SweepOnceAsync(CancellationToken.None);
+
+        deleted.Should().Be(0);
+        Directory.Exists(fresh).Should().BeTrue(
+            "a multipart POST that crashed seconds ago might still be in the controller's `catch` cleanup — don't race it.");
+    }
+
+    [Fact]
+    public async Task SweepOnceAsync_ReturnsZero_WhenStagingRootMissing()
+    {
+        Directory.Delete(_stagingRoot, recursive: true);
+
+        using var db = InMemoryDbHelper.CreateContext();
+        var worker = MakeWorker(db, retention: TimeSpan.FromDays(7));
+
+        var deleted = await worker.SweepOnceAsync(CancellationToken.None);
+
+        deleted.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SweepOnceAsync_DeletesOnlyOrphans_WhenMixed()
+    {
+        var orphan1 = CreateStagingDir("orphan1");
+        var orphan2 = CreateStagingDir("orphan2");
+        var referenced = CreateStagingDir("referenced");
+        var fresh = CreateStagingDir("fresh");
+
+        var old = _clock.GetUtcNow().UtcDateTime - TimeSpan.FromDays(30);
+        AgeTo(orphan1, old);
+        AgeTo(orphan2, old);
+        AgeTo(referenced, old);
+        AgeTo(fresh, _clock.GetUtcNow().UtcDateTime - TimeSpan.FromHours(1));
+
+        using var db = InMemoryDbHelper.CreateContext();
+        db.Templates.Add(new ContainerTemplate
+        {
+            Code = "t1",
+            Name = "T1",
+            Version = "1.0.0",
+            BaseImage = "ubuntu:24.04",
+            UploadedFilesPath = referenced,
+        });
+        await db.SaveChangesAsync();
+
+        var worker = MakeWorker(db, retention: TimeSpan.FromDays(7));
+
+        var deleted = await worker.SweepOnceAsync(CancellationToken.None);
+
+        deleted.Should().Be(2);
+        Directory.Exists(orphan1).Should().BeFalse();
+        Directory.Exists(orphan2).Should().BeFalse();
+        Directory.Exists(referenced).Should().BeTrue();
+        Directory.Exists(fresh).Should().BeTrue();
+    }
+
+    private string CreateStagingDir(string name)
+    {
+        var dir = Path.Combine(_stagingRoot, name);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "marker.txt"), name);
+        return dir;
+    }
+
+    private static void AgeTo(string dir, DateTime utcTimestamp)
+        => Directory.SetLastWriteTimeUtc(dir, utcTimestamp);
+
+    private TemplateUploadStagingCleanupWorker MakeWorker(
+        Andy.Containers.Infrastructure.Data.ContainersDbContext db,
+        TimeSpan retention)
+    {
+        var options = new TemplateUploadStagingCleanupOptions { Retention = retention };
+        return new TemplateUploadStagingCleanupWorker(
+            InMemoryDbHelper.CreateScopeFactory(db),
+            options,
+            NullLogger<TemplateUploadStagingCleanupWorker>.Instance,
+            _stagingRoot,
+            _clock);
+    }
+
+    private sealed class FakeTime : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public FakeTime(DateTimeOffset now) { _now = now; }
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}


### PR DESCRIPTION
## Summary

PR A's controller persists `Template.UploadedFilesPath` and never clears it; PR B's orchestrator reads from it but doesn't clean up either. Without a sweeper, deleted templates leave their staging dirs orphaned under `<temp>/andy-containers/template-uploads/staging` indefinitely — a slow disk leak.

This PR adds `TemplateUploadStagingCleanupWorker`, a hosted `BackgroundService` that periodically reclaims subdirs satisfying **both**:

1. **Not referenced** by any `Template.UploadedFilesPath` row (DB check in a fresh scope per sweep), and
2. **Older than the configured retention** (lastWriteTime).

Referenced dirs are kept regardless of age, so force-rebuilds of long-lived templates always have their source files. Only orphans hit the retention cutoff. When a template is deleted, its dir becomes an orphan and gets reclaimed on the next tick past retention.

### Defaults

- `SweepInterval = 1h`
- `Retention = 7d`

Both bound from `Containers:Image:TemplateUploadStaging` so operators can tune without redeploy. A 30 s startup delay gives the migration worker time to finish before the first sweep.

### Also in this PR

- Extracts the staging-root path into `TemplateUploadStagingPaths.GetStagingRoot()` — single source of truth shared by the controller (which creates dirs) and the worker (which reclaims them).
- Updates `Template.UploadedFilesPath`'s XML doc to spell out the lifecycle now that PR C is real, not aspirational.

## Test plan

- [x] 5 new tests in `TemplateUploadStagingCleanupWorkerTests`:
  - Old + unreferenced → deleted
  - Old + referenced → kept (regardless of age)
  - Fresh + unreferenced → kept (under retention)
  - Staging root missing → no-op, returns 0
  - Mixed bag → only orphans reclaimed
- [x] Full solution test pass: Api.Tests 1079/1080 (1 pre-existing skip), Integration.Tests 46/54 (env-gated skips)

## Notes

Issue #277 already closed via PR B (#296) — it satisfied the issue's acceptance. This PR is the optional cleanup follow-up promised in PR A's description and #277's "constraints" note about disk pressure. After this lands, Epic IM #249 Phase 1 has no loose threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)