### PR TITLE
Inject per-tool proxy base URL + service token env vars (#944)

### DIFF
--- a/src/Andy.Containers.Api/Services/CodeAssistantProxyRouting.cs
+++ b/src/Andy.Containers.Api/Services/CodeAssistantProxyRouting.cs
@@ -1,0 +1,101 @@
+using Andy.Containers.Models;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// rivoli-ai/conductor#944 (M1.5.2). Maps a <see cref="CodeAssistantType"/>
+/// to the env-var trio the assistant inside the container reads:
+/// (1) the API-key env var the tool consults for the bearer to send,
+/// (2) the base-URL env var the tool consults to pick its server, and
+/// (3) the dialect path under the andy-models proxy that handles the
+/// tool's wire format.
+///
+/// The orchestrator combines these with the proxy URL +
+/// per-container service token to produce a concrete env dictionary
+/// the runtime adapter (Docker / Apple Containers) injects at create
+/// time.
+///
+/// Returning <c>null</c> means "the tool is not proxy-routed" —
+/// either because it doesn't speak HTTP to an LLM (GitHub Copilot's
+/// own auth, Continue's IDE-local config) or because the user
+/// explicitly bypassed the proxy via <see cref="CodeAssistantConfig.ApiBaseUrl"/>
+/// (Ollama path, OpenAI-compatible self-hosted backends).
+/// </summary>
+public static class CodeAssistantProxyRouting
+{
+    public sealed record EnvVars(string KeyEnvVar, string BaseUrlEnvVar, string DialectPath);
+
+    /// <summary>
+    /// Returns the proxy routing for the given assistant config, or
+    /// <c>null</c> when the tool either doesn't speak to an LLM HTTP
+    /// surface or the user supplied an explicit
+    /// <see cref="CodeAssistantConfig.ApiBaseUrl"/> (which signals
+    /// "don't proxy — talk directly to this URL").
+    /// </summary>
+    public static EnvVars? For(CodeAssistantConfig config)
+    {
+        // Explicit user-supplied base URL always wins. For OpenCode this
+        // means "user picked OpenAI-compatible (custom URL) or Ollama"
+        // in the launch UI's sub-picker (M1.6.2 / conductor#948). The
+        // orchestrator's existing ApiBaseUrl injection path handles
+        // those cases; the per-tool proxy routing here is the "default
+        // proxy mode" path that fires when the user accepts the
+        // built-in routing.
+        if (!string.IsNullOrWhiteSpace(config.ApiBaseUrl))
+        {
+            return null;
+        }
+
+        return config.Tool switch
+        {
+            // Claude Code reads ANTHROPIC_BASE_URL + ANTHROPIC_API_KEY
+            // out of the box. Route both at the proxy's anthropic
+            // dialect.
+            CodeAssistantType.ClaudeCode
+                => new EnvVars("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "anthropic/v1"),
+
+            // OpenCode + Codex CLI both speak the OpenAI Chat Completions
+            // dialect; the install scripts set OPENAI_BASE_URL +
+            // OPENAI_API_KEY.
+            CodeAssistantType.OpenCode
+                => new EnvVars("OPENAI_API_KEY", "OPENAI_BASE_URL", "openai/v1"),
+            CodeAssistantType.CodexCli
+                => new EnvVars("OPENAI_API_KEY", "OPENAI_BASE_URL", "openai/v1"),
+
+            // Aider historically read OPENAI_API_BASE (not _BASE_URL).
+            // Both have been valid for a while but the older form is
+            // safer for Aider's docs / scripts.
+            CodeAssistantType.Aider
+                => new EnvVars("OPENAI_API_KEY", "OPENAI_API_BASE", "openai/v1"),
+
+            // QwenCoder + GeminiCode + their cousins: routing TBD; the
+            // andy-models proxy needs an alibaba / google dialect mount
+            // before we can flip them on. Returning null keeps the
+            // legacy credential path running for now.
+            CodeAssistantType.QwenCoder => null,
+            CodeAssistantType.GeminiCode => null,
+
+            // IDE-local + provider-bring-your-own-auth tools don't take
+            // an HTTP bearer at all.
+            CodeAssistantType.Continue => null,
+            CodeAssistantType.GitHubCopilot => null,
+            CodeAssistantType.AmazonQ => null,
+            CodeAssistantType.Cline => null,
+
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Build the full container-facing URL for a proxy dialect. Joins
+    /// the container-facing proxy base (e.g.
+    /// <c>http://host.docker.internal:9100</c>) with the
+    /// <c>/models/&lt;dialect&gt;</c> mount that <c>andy-models</c>
+    /// exposes plus the dialect's <c>/v1</c> path.
+    /// </summary>
+    public static string BuildBaseUrl(string proxyBaseUrl, string dialectPath)
+    {
+        var trimmed = proxyBaseUrl.TrimEnd('/');
+        return $"{trimmed}/models/{dialectPath.TrimStart('/')}";
+    }
+}

--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -545,6 +545,38 @@ public class ContainerOrchestrationService : IContainerService
                 _logger.LogInformation(
                     "Injected per-container ANDY_SERVICE_TOKEN (tokenId={TokenId}, slugs={Slugs}, length={Length}) into container env",
                     minted.TokenId, string.Join(",", requiredSlugs), minted.Jwt.Length);
+
+                // rivoli-ai/conductor#944 (M1.5.2). Set the tool-specific
+                // env vars so the code assistant inside the container
+                // routes through the andy-models proxy with the per-
+                // container service token. Without this, Claude Code
+                // would read its real `ANTHROPIC_API_KEY` from the
+                // credentials path (if set) and skip the proxy entirely,
+                // losing the UsageEvent log + the proxy's key resolution.
+                //
+                // We overwrite anything the credentials-based path set
+                // — the proxy mode is the architecture intent, the
+                // direct-credential path is a fallback.
+                var routing = CodeAssistantProxyRouting.For(codeAssistant!);
+                if (routing is not null
+                    && !string.IsNullOrWhiteSpace(containerFacingProxyUrl))
+                {
+                    var dialectURL = CodeAssistantProxyRouting.BuildBaseUrl(
+                        containerFacingProxyUrl,
+                        routing.DialectPath);
+                    envVars[routing.KeyEnvVar] = minted.Jwt;
+                    envVars[routing.BaseUrlEnvVar] = dialectURL;
+                    _logger.LogInformation(
+                        "Routed {Tool} through andy-models proxy: {KeyEnv}=<jwt>, {BaseEnv}={Url}",
+                        codeAssistant!.Tool, routing.KeyEnvVar, routing.BaseUrlEnvVar,
+                        UrlRedactor.Redact(dialectURL));
+                }
+                else if (routing is null && codeAssistant is not null)
+                {
+                    _logger.LogInformation(
+                        "Code assistant {Tool} has no proxy routing entry — leaving credential-path env vars in place",
+                        codeAssistant.Tool);
+                }
             }
         }
 

--- a/src/Andy.Containers.Api/Services/ToolSlugDefaults.cs
+++ b/src/Andy.Containers.Api/Services/ToolSlugDefaults.cs
@@ -33,14 +33,31 @@ public static class ToolSlugDefaults
             CodeAssistantType.ClaudeCode
                 => new[] { "anthropic/claude-sonnet-4-6" },
 
-            // OpenCode is multi-provider. Without an explicit slug
-            // list we can't guess which provider the user actually
-            // wants — return empty (no proxy token) and let the API
-            // key resolution path handle credentials. Users routing
-            // OpenCode through the proxy should set
-            // RequiredModelSlugs (e.g. ["openai/gpt-4o"]).
+            // OpenCode is multi-provider. The Conductor launch UI's
+            // sub-picker (conductor#948 / M1.6.2) signals the user's
+            // backend choice via `ApiBaseUrl`:
+            //   - null/empty → user accepted the proxy default (OpenAI
+            //     via andy-models). Mint a token for the default OpenAI
+            //     slug.
+            //   - non-null → user picked OpenAI-compatible (own URL) or
+            //     Ollama. They're handling auth themselves; no proxy
+            //     token needed.
+            // rivoli-ai/conductor#944 (M1.5.2).
             CodeAssistantType.OpenCode
-                => Array.Empty<string>(),
+                => string.IsNullOrWhiteSpace(config.ApiBaseUrl)
+                    ? new[] { "openai/gpt-5" }
+                    : Array.Empty<string>(),
+
+            // Codex CLI + Aider both speak the OpenAI dialect, default
+            // through the proxy. Same slug as OpenCode-on-default.
+            CodeAssistantType.CodexCli
+                => string.IsNullOrWhiteSpace(config.ApiBaseUrl)
+                    ? new[] { "openai/gpt-5" }
+                    : Array.Empty<string>(),
+            CodeAssistantType.Aider
+                => string.IsNullOrWhiteSpace(config.ApiBaseUrl)
+                    ? new[] { "openai/gpt-5" }
+                    : Array.Empty<string>(),
 
             // Other tools — extend the map as concrete defaults
             // become clear. Returning empty keeps behaviour safe by

--- a/tests/Andy.Containers.Api.Tests/Services/CodeAssistantProxyRoutingTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/CodeAssistantProxyRoutingTests.cs
@@ -1,0 +1,121 @@
+using Andy.Containers.Api.Services;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+/// <summary>
+/// rivoli-ai/conductor#944 (M1.5.2). Pins the per-tool env-var map
+/// that lets the andy-models proxy intercept Claude Code, OpenCode,
+/// Codex CLI, and Aider without those tools knowing they're being
+/// proxied. Drift here is silent: the wrong env var means the tool
+/// reaches upstream directly (bypassing the proxy, the UsageEvent
+/// log, and the key resolver).
+/// </summary>
+public class CodeAssistantProxyRoutingTests
+{
+    [Fact]
+    public void For_ClaudeCode_NoBaseUrl_ReturnsAnthropicEnvVars()
+    {
+        var config = new CodeAssistantConfig { Tool = CodeAssistantType.ClaudeCode };
+
+        var routing = CodeAssistantProxyRouting.For(config);
+
+        routing.Should().NotBeNull();
+        routing!.KeyEnvVar.Should().Be("ANTHROPIC_API_KEY");
+        routing.BaseUrlEnvVar.Should().Be("ANTHROPIC_BASE_URL");
+        routing.DialectPath.Should().Be("anthropic/v1");
+    }
+
+    [Fact]
+    public void For_OpenCode_NoBaseUrl_ReturnsOpenAIEnvVars()
+    {
+        var config = new CodeAssistantConfig { Tool = CodeAssistantType.OpenCode };
+
+        var routing = CodeAssistantProxyRouting.For(config);
+
+        routing.Should().NotBeNull();
+        routing!.KeyEnvVar.Should().Be("OPENAI_API_KEY");
+        routing.BaseUrlEnvVar.Should().Be("OPENAI_BASE_URL");
+        routing.DialectPath.Should().Be("openai/v1");
+    }
+
+    [Theory]
+    [InlineData(CodeAssistantType.CodexCli, "OPENAI_BASE_URL")]
+    [InlineData(CodeAssistantType.Aider, "OPENAI_API_BASE")]
+    public void For_OtherOpenAIDialectTools_PickTheCorrectBaseEnvVar(
+        CodeAssistantType tool, string expectedBaseUrlEnvVar)
+    {
+        // CodexCli reads OPENAI_BASE_URL (newer spelling) while Aider
+        // historically reads OPENAI_API_BASE. Keeping them split here
+        // matches what their install scripts inject.
+        var config = new CodeAssistantConfig { Tool = tool };
+
+        var routing = CodeAssistantProxyRouting.For(config);
+
+        routing.Should().NotBeNull();
+        routing!.KeyEnvVar.Should().Be("OPENAI_API_KEY");
+        routing.BaseUrlEnvVar.Should().Be(expectedBaseUrlEnvVar);
+    }
+
+    [Theory]
+    [InlineData("http://host.docker.internal:11434")]
+    [InlineData("https://llm.internal.example.com/v1")]
+    [InlineData("  https://leading-trim.example.com  ")]
+    public void For_AnyTool_WithExplicitBaseUrl_ReturnsNull(string apiBaseUrl)
+    {
+        // An explicit ApiBaseUrl means the user (or the launch UI's
+        // sub-picker) opted out of proxy routing — Ollama, OpenAI-
+        // compatible self-hosted, or any one-off override. The
+        // orchestrator's existing direct-credential + ApiBaseUrl path
+        // handles those.
+        var config = new CodeAssistantConfig
+        {
+            Tool = CodeAssistantType.OpenCode,
+            ApiBaseUrl = apiBaseUrl,
+        };
+
+        var routing = CodeAssistantProxyRouting.For(config);
+
+        routing.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(CodeAssistantType.Continue)]
+    [InlineData(CodeAssistantType.GitHubCopilot)]
+    [InlineData(CodeAssistantType.AmazonQ)]
+    [InlineData(CodeAssistantType.Cline)]
+    [InlineData(CodeAssistantType.QwenCoder)]
+    [InlineData(CodeAssistantType.GeminiCode)]
+    public void For_UnsupportedTools_ReturnNull(CodeAssistantType tool)
+    {
+        var config = new CodeAssistantConfig { Tool = tool };
+
+        var routing = CodeAssistantProxyRouting.For(config);
+
+        routing.Should().BeNull(
+            "$\"{tool}\" doesn't read OpenAI/Anthropic env vars — it has its own auth flow, so we must NOT pretend to proxy it");
+    }
+
+    [Theory]
+    [InlineData("http://host.docker.internal:9100", "anthropic/v1",
+        "http://host.docker.internal:9100/models/anthropic/v1")]
+    [InlineData("http://host.docker.internal:9100/", "anthropic/v1",
+        "http://host.docker.internal:9100/models/anthropic/v1")]
+    [InlineData("http://host.docker.internal:9100", "openai/v1",
+        "http://host.docker.internal:9100/models/openai/v1")]
+    [InlineData("https://proxy.internal.example.com", "/anthropic/v1",
+        "https://proxy.internal.example.com/models/anthropic/v1")]
+    public void BuildBaseUrl_JoinsProxyBaseWithDialectPath(
+        string proxyBase, string dialectPath, string expected)
+    {
+        // The proxy URL coming from config sometimes has a trailing
+        // slash, the dialect path sometimes has a leading slash — the
+        // helper normalises both so the result is always exactly one
+        // slash between segments. Drift here means a 404 from the proxy.
+        var url = CodeAssistantProxyRouting.BuildBaseUrl(proxyBase, dialectPath);
+
+        url.Should().Be(expected);
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServicePerToolEnvTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServicePerToolEnvTests.cs
@@ -1,0 +1,313 @@
+using Andy.Containers.Abstractions;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+/// <summary>
+/// rivoli-ai/conductor#944 (M1.5.2). Integration coverage for the
+/// per-tool proxy env-var injection done by
+/// <see cref="ContainerOrchestrationService.CreateContainerAsync"/>:
+///
+/// - Claude Code: ANTHROPIC_API_KEY (= service token) + ANTHROPIC_BASE_URL
+///   (= proxy /anthropic/v1)
+/// - OpenCode (default backend): OPENAI_API_KEY + OPENAI_BASE_URL
+///   pointing at the proxy
+/// - OpenCode + user base URL: NO proxy env vars, user URL forwarded
+///   instead (Ollama / OpenAI-compatible)
+/// - Tools without a proxy routing entry (Continue, GitHub Copilot)
+///   leave the credential-path env vars alone
+///
+/// Drift in any of these silently re-routes traffic around the proxy
+/// — the user loses the UsageEvent log and andy-models' key resolver
+/// stops being load-bearing.
+/// </summary>
+public class ContainerOrchestrationServicePerToolEnvTests : IDisposable
+{
+    private const string ProxyBase = "http://host.docker.internal:9100";
+
+    private readonly ContainersDbContext _db;
+    private readonly Mock<IInfrastructureRoutingService> _mockRouting = new();
+    private readonly Mock<IInfrastructureProviderFactory> _mockFactory = new();
+    private readonly Mock<IInfrastructureProvider> _mockInfra = new();
+    private readonly ContainerProvisioningQueue _queue = new();
+    private readonly Mock<IGitRepositoryProbeService> _mockProbe = new();
+    private readonly EphemeralDataProtectionProvider _dataProtection = new();
+
+    public ContainerOrchestrationServicePerToolEnvTests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+        _mockFactory.Setup(f => f.GetProvider(It.IsAny<InfrastructureProvider>()))
+            .Returns(_mockInfra.Object);
+        _mockProbe.Setup(p => p.ProbeRepositoriesAsync(
+                It.IsAny<IReadOnlyList<GitRepositoryConfig>>(),
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<string>());
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task CreateContainer_ClaudeCode_SetsAnthropicEnvVarsToProxy()
+    {
+        var (template, provider) = await SeedAsync();
+        var proxy = StubMintingToken("anthropic.jwt");
+        var service = MakeService(proxy);
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "claude-proxy",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            OwnerId = "user-1",
+            CodeAssistant = new CodeAssistantConfig { Tool = CodeAssistantType.ClaudeCode },
+        }, CancellationToken.None);
+
+        var env = (await ReadEnqueuedJobAsync()).EnvironmentVariables;
+        env.Should().NotBeNull();
+        env!["ANTHROPIC_API_KEY"].Should().Be("anthropic.jwt",
+            "Claude Code reads ANTHROPIC_API_KEY for its bearer — the per-container service token must replace the user's real Anthropic key.");
+        env["ANTHROPIC_BASE_URL"].Should().Be(
+            "http://host.docker.internal:9100/models/anthropic/v1",
+            "Claude Code reads ANTHROPIC_BASE_URL to pick its server — must route through the andy-models proxy.");
+        env["ANDY_SERVICE_TOKEN"].Should().Be("anthropic.jwt",
+            "the generic ANDY_SERVICE_TOKEN must still land for non-Claude callers (CodeAssistantInstallService scripts).");
+    }
+
+    [Fact]
+    public async Task CreateContainer_OpenCodeWithoutBaseUrl_SetsOpenAIEnvVarsToProxy()
+    {
+        var (template, provider) = await SeedAsync();
+        var proxy = StubMintingToken("opencode.jwt");
+        var service = MakeService(proxy);
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "opencode-default",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            OwnerId = "user-1",
+            CodeAssistant = new CodeAssistantConfig { Tool = CodeAssistantType.OpenCode },
+        }, CancellationToken.None);
+
+        var env = (await ReadEnqueuedJobAsync()).EnvironmentVariables;
+        env.Should().NotBeNull();
+        env!["OPENAI_API_KEY"].Should().Be("opencode.jwt");
+        env["OPENAI_BASE_URL"].Should().Be(
+            "http://host.docker.internal:9100/models/openai/v1");
+    }
+
+    [Fact]
+    public async Task CreateContainer_OpenCodeWithCustomBaseUrl_KeepsUserUrlAndSkipsProxyOverride()
+    {
+        var (template, provider) = await SeedAsync();
+        // ToolSlugDefaults returns empty for OpenCode + ApiBaseUrl set,
+        // so the proxy token never gets minted. The orchestrator falls
+        // through to the credential / direct path, which keeps the
+        // user-supplied URL.
+        var proxy = StubMintingToken("must.not.be.minted");
+        var service = MakeService(proxy);
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "opencode-ollama",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            OwnerId = "user-1",
+            CodeAssistant = new CodeAssistantConfig
+            {
+                Tool = CodeAssistantType.OpenCode,
+                ApiBaseUrl = "http://host.docker.internal:11434",
+            },
+        }, CancellationToken.None);
+
+        var env = (await ReadEnqueuedJobAsync()).EnvironmentVariables;
+        env.Should().NotBeNull();
+        env!["OPENAI_API_BASE"].Should().Be("http://host.docker.internal:11434",
+            "Ollama path: the user-supplied URL must reach OPENAI_API_BASE (the credential-path env var), not be replaced by the proxy URL.");
+        env.Should().NotContainKey("OPENAI_BASE_URL",
+            "no proxy routing — must not synthesise the proxy-flavoured env var.");
+        proxy.MintCallCount.Should().Be(0,
+            "an explicit ApiBaseUrl signals 'bypass the proxy' — no token mint should happen.");
+    }
+
+    [Fact]
+    public async Task CreateContainer_CodexCli_SetsOpenAIEnvVarsToProxy()
+    {
+        var (template, provider) = await SeedAsync();
+        var proxy = StubMintingToken("codex.jwt");
+        var service = MakeService(proxy);
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "codex",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            OwnerId = "user-1",
+            CodeAssistant = new CodeAssistantConfig { Tool = CodeAssistantType.CodexCli },
+        }, CancellationToken.None);
+
+        var env = (await ReadEnqueuedJobAsync()).EnvironmentVariables;
+        env!["OPENAI_API_KEY"].Should().Be("codex.jwt");
+        env["OPENAI_BASE_URL"].Should().Be(
+            "http://host.docker.internal:9100/models/openai/v1");
+    }
+
+    [Fact]
+    public async Task CreateContainer_Aider_SetsApiBaseAtAiderSpelling()
+    {
+        var (template, provider) = await SeedAsync();
+        var proxy = StubMintingToken("aider.jwt");
+        var service = MakeService(proxy);
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "aider",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            OwnerId = "user-1",
+            CodeAssistant = new CodeAssistantConfig { Tool = CodeAssistantType.Aider },
+        }, CancellationToken.None);
+
+        var env = (await ReadEnqueuedJobAsync()).EnvironmentVariables;
+        env!["OPENAI_API_BASE"].Should().Be(
+            "http://host.docker.internal:9100/models/openai/v1",
+            "Aider reads OPENAI_API_BASE (not _BASE_URL) — the wrong spelling silently means Aider hits api.openai.com directly.");
+    }
+
+    [Fact]
+    public async Task CreateContainer_WithProxyButNoConfiguredUrl_LeavesProxyEnvVarsUnset()
+    {
+        var (template, provider) = await SeedAsync();
+        var proxy = StubMintingToken("claude.jwt");
+        // No Proxy:ContainerFacingBaseUrl → routing helper has no URL
+        // to build with → tool-specific env vars stay nil. The
+        // ANDY_SERVICE_TOKEN still lands (existing path); the
+        // tool-specific override needs both inputs.
+        var service = MakeService(proxy, configureProxyUrl: false);
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "claude-no-proxy-url",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            OwnerId = "user-1",
+            CodeAssistant = new CodeAssistantConfig { Tool = CodeAssistantType.ClaudeCode },
+        }, CancellationToken.None);
+
+        var env = (await ReadEnqueuedJobAsync()).EnvironmentVariables ?? new Dictionary<string, string>();
+        env.Should().NotContainKey("ANTHROPIC_BASE_URL",
+            "without a configured proxy URL, the tool-specific override must not fire — a half-applied override would point the tool at the empty string and break it.");
+        env["ANDY_SERVICE_TOKEN"].Should().Be("claude.jwt",
+            "the per-container token still lands — it's useful for scripts that read it directly.");
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers (mirror the proxy-token test file's setup)
+    // -----------------------------------------------------------------
+
+    private async Task<(ContainerTemplate template, InfrastructureProvider provider)> SeedAsync()
+    {
+        var template = new ContainerTemplate
+        {
+            Code = "per-tool-env-test",
+            Name = "Per-tool env test",
+            Version = "1.0.0",
+            BaseImage = "ubuntu:24.04",
+        };
+        var provider = new InfrastructureProvider
+        {
+            Code = "env-provider",
+            Name = "Provider",
+            Type = ProviderType.Docker,
+            IsEnabled = true,
+        };
+        _db.Templates.Add(template);
+        _db.Providers.Add(provider);
+        await _db.SaveChangesAsync();
+        return (template, provider);
+    }
+
+    private StubProxyTokenService StubMintingToken(string jwt)
+    {
+        return new StubProxyTokenService(new MintedProxyToken(
+            Guid.NewGuid(),
+            jwt,
+            DateTimeOffset.UtcNow.AddHours(1)));
+    }
+
+    private ContainerOrchestrationService MakeService(
+        IProxyTokenService proxyTokens,
+        bool configureProxyUrl = true)
+    {
+        var configValues = new Dictionary<string, string?>();
+        if (configureProxyUrl)
+        {
+            configValues["Proxy:ContainerFacingBaseUrl"] = ProxyBase;
+        }
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(configValues)
+            .Build();
+        return new ContainerOrchestrationService(
+            _db,
+            _mockRouting.Object,
+            _mockFactory.Object,
+            _queue,
+            _mockProbe.Object,
+            new Mock<IApiKeyService>().Object,
+            config,
+            NullLogger<ContainerOrchestrationService>.Instance,
+            serviceTokenService: new StubServiceTokenService("shared-m2m"),
+            proxyTokenService: proxyTokens,
+            dataProtection: _dataProtection);
+    }
+
+    private async Task<ContainerProvisionJob> ReadEnqueuedJobAsync()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        return await _queue.Reader.ReadAsync(cts.Token);
+    }
+
+    private sealed class StubServiceTokenService : IServiceTokenService
+    {
+        private readonly string _token;
+        public StubServiceTokenService(string token) { _token = token; }
+        public Task<string> GetAccessTokenAsync(CancellationToken ct = default) => Task.FromResult(_token);
+        public Task<string> GetAccessTokenAsync(string audience, CancellationToken ct = default) => Task.FromResult(_token);
+    }
+
+    private sealed class StubProxyTokenService : IProxyTokenService
+    {
+        private readonly MintedProxyToken? _mintResult;
+        public int MintCallCount { get; private set; }
+
+        public StubProxyTokenService(MintedProxyToken? mintResult)
+        {
+            _mintResult = mintResult;
+        }
+
+        public Task<MintedProxyToken?> MintForContainerAsync(
+            string containerId,
+            string subjectId,
+            IReadOnlyList<string> allowedSlugs,
+            CancellationToken ct = default)
+        {
+            MintCallCount++;
+            return Task.FromResult(_mintResult);
+        }
+
+        public Task RevokeAsync(Guid tokenId, CancellationToken ct = default)
+            => Task.CompletedTask;
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Services/ToolSlugDefaultsTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ToolSlugDefaultsTests.cs
@@ -57,23 +57,64 @@ public class ToolSlugDefaultsTests
     }
 
     [Fact]
-    public void Resolve_WhenRequiredModelSlugsIsNull_OpenCode_FallsBackToEmpty()
+    public void Resolve_WhenRequiredModelSlugsIsNull_OpenCode_WithoutBaseUrl_DefaultsToOpenAI()
     {
+        // rivoli-ai/conductor#944 (M1.5.2). The launch UI signals
+        // "user accepted the proxy default backend" by leaving
+        // ApiBaseUrl null. We mint a token scoped to the OpenAI default
+        // so the container's OpenCode install can hit the proxy out
+        // of the box.
         var config = new CodeAssistantConfig
         {
             Tool = CodeAssistantType.OpenCode,
             RequiredModelSlugs = null,
+            ApiBaseUrl = null,
+        };
+
+        var slugs = ToolSlugDefaults.Resolve(config);
+
+        slugs.Should().Equal("openai/gpt-5");
+    }
+
+    [Fact]
+    public void Resolve_WhenRequiredModelSlugsIsNull_OpenCode_WithBaseUrl_ReturnsEmpty()
+    {
+        // User picked OpenAI-compatible (own URL) or Ollama in the
+        // sub-picker — ApiBaseUrl carries their URL, and they're
+        // handling auth themselves. Don't mint a proxy token.
+        var config = new CodeAssistantConfig
+        {
+            Tool = CodeAssistantType.OpenCode,
+            RequiredModelSlugs = null,
+            ApiBaseUrl = "http://host.docker.internal:11434",
         };
 
         var slugs = ToolSlugDefaults.Resolve(config);
 
         slugs.Should().BeEmpty(
-            "OpenCode is multi-provider; without an explicit slug list we don't guess.");
+            "an explicit ApiBaseUrl signals 'bypass the proxy' — no proxy token should be minted.");
     }
 
     [Theory]
-    [InlineData(CodeAssistantType.Aider)]
     [InlineData(CodeAssistantType.CodexCli)]
+    [InlineData(CodeAssistantType.Aider)]
+    public void Resolve_OpenAIDialectTools_WithoutBaseUrl_DefaultToOpenAI(CodeAssistantType tool)
+    {
+        // Codex CLI + Aider both speak OpenAI Chat Completions. When
+        // the user accepts the default routing, they get the same
+        // proxy-scoped token as OpenCode.
+        var config = new CodeAssistantConfig
+        {
+            Tool = tool,
+            RequiredModelSlugs = null,
+        };
+
+        var slugs = ToolSlugDefaults.Resolve(config);
+
+        slugs.Should().Equal("openai/gpt-5");
+    }
+
+    [Theory]
     [InlineData(CodeAssistantType.Continue)]
     [InlineData(CodeAssistantType.QwenCoder)]
     [InlineData(CodeAssistantType.GeminiCode)]


### PR DESCRIPTION
Tracks rivoli-ai/conductor#944 (M1.5.2).

## Summary

When a container's code assistant supports proxy mode and a per-container service token was minted, overwrite the tool-specific env vars (\`ANTHROPIC_*\`, \`OPENAI_*\`) so the assistant inside the container reaches the andy-models proxy with the JWT — never the user's raw provider key.

## Background

Conductor already injects \`ANDY_PROXY_BASE_URL\` and \`ANDY_SERVICE_TOKEN\` into every container, but Claude Code + OpenCode don't read those — they read tool-specific env vars (\`ANTHROPIC_BASE_URL\`, \`OPENAI_BASE_URL\`, etc.). Without per-tool wiring, the in-container assistant either talks directly to upstream (bypassing the proxy + UsageEvent log) or fails to find a working credential. This PR fills that gap.

## What changes

- **New \`CodeAssistantProxyRouting\` static helper** — maps each supported tool to its \`(KeyEnvVar, BaseUrlEnvVar, DialectPath)\` trio:
  | Tool | Key env | Base URL env | Dialect |
  | --- | --- | --- | --- |
  | Claude Code | \`ANTHROPIC_API_KEY\` | \`ANTHROPIC_BASE_URL\` | \`anthropic/v1\` |
  | OpenCode | \`OPENAI_API_KEY\` | \`OPENAI_BASE_URL\` | \`openai/v1\` |
  | Codex CLI | \`OPENAI_API_KEY\` | \`OPENAI_BASE_URL\` | \`openai/v1\` |
  | Aider | \`OPENAI_API_KEY\` | \`OPENAI_API_BASE\` | \`openai/v1\` (Aider's older spelling) |

  Returns \`null\` for tools that don't read HTTP env vars (Continue, GitHub Copilot, Amazon Q, Cline, Qwen, Gemini) **and** when the caller set an explicit \`ApiBaseUrl\` (signal: "user picked OpenAI-compatible or Ollama in the launch UI sub-picker — bypass the proxy").

- **\`BuildBaseUrl(proxyBase, dialect)\`** — joins the container-facing proxy URL (from \`Proxy:ContainerFacingBaseUrl\`) with the \`/models/<dialect>\` mount, normalising slashes so a trailing \`/\` on the base or a leading \`/\` on the path produces the same result.

- **\`ContainerOrchestrationService.CreateContainerAsync\`** — calls the routing helper after a successful token mint. When found and the proxy URL is configured, the env dictionary's \`KeyEnvVar\` and \`BaseUrlEnvVar\` are set/overwritten so the proxy mode wins over the credential-based path.

- **\`ToolSlugDefaults.Resolve\`** — now grants OpenCode, Codex CLI, and Aider a default \`openai/gpt-5\` slug when \`ApiBaseUrl\` is null. With an explicit \`ApiBaseUrl\` they return empty → no token mint, no proxy routing, user-supplied URL stays.

## Test plan

- [x] \`CodeAssistantProxyRoutingTests\` (14 cases) pin every entry of the per-tool map + the BuildBaseUrl slash-normalisation matrix + the explicit-ApiBaseUrl bypass.
- [x] \`ToolSlugDefaultsTests\` updated for the new OpenCode / Codex / Aider default behaviour.
- [x] \`ContainerOrchestrationServicePerToolEnvTests\` (6 cases) integration-style: launches the orchestrator with a stubbed proxy-token service + a configured proxy URL, reads the env dict off the enqueued provisioning job, asserts the per-tool keys/URLs land correctly. Covers Claude Code, OpenCode (default + custom URL), Codex CLI, Aider, and a guard case where the proxy URL is missing so the tool-specific override is suppressed.
- [x] \`dotnet test Andy.Containers.Api.Tests\` — 1103/1104 pass (1 skipped is the unrelated Postgres migration test).

## Acceptance criteria

- [x] Each assistant + provider combination produces the right env-var set on container creation
- [x] Env vars are injected via the container runtime API (Docker / Apple Containers) — flows through the existing \`EnvironmentVariables\` on the provisioning job
- [x] \`andy-models-proxy\` resolves correctly — uses the existing \`Proxy:ContainerFacingBaseUrl\` config (\`host.docker.internal\` for Docker)
- [x] Ollama path uses the user-configured local base URL — no token, no proxy override
- [ ] Existing containers (pre-this-story) get the env vars on next start — separate path through start API; covered in a follow-up if not already in scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)