### PR TITLE
feat: honor ASPNETCORE_ENVIRONMENT=Embedded alongside Development

### DIFF
--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Andy.Containers.Abstractions;
 using Andy.Containers.Api.Data;
 using Andy.Containers.Api.Services;
+// HostEnvironmentExtensions.IsEmbedded / IsLocalOrEmbedded live here
 using Andy.Containers.Configurator;
 using Andy.Containers.DependencyInjection;
 using Andy.Containers.Infrastructure.Build.Local;
@@ -249,7 +250,12 @@ try
             {
                 options.Authority = authority;
                 options.Audience = builder.Configuration["AndyAuth:Audience"];
-                options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
+                // HTTPS metadata off in every non-production mode.
+                // Conductor's embedded mode talks to andy-auth over HTTP
+                // via the unified proxy on port 9100 — without
+                // IsLocalOrEmbedded() the JWT bearer middleware would
+                // refuse the discovery document.
+                options.RequireHttpsMetadata = !builder.Environment.IsLocalOrEmbedded();
                 if (builder.Environment.IsDevelopment())
                 {
                     options.BackchannelHttpHandler = new HttpClientHandler
@@ -430,7 +436,13 @@ try
         await ThemeSeeder.SeedAsync(db, app.Environment, themeSeederLogger);
     }
 
-    app.UseHttpsRedirection();
+    // Conductor's embedded mode terminates HTTPS at the unified proxy
+    // on port 9100; the in-process Kestrel only ever binds to HTTP.
+    // Forcing a redirect would trap every request in a redirect loop.
+    if (!app.Environment.IsEmbedded())
+    {
+        app.UseHttpsRedirection();
+    }
 
     if (app.Environment.IsDevelopment())
     {


### PR DESCRIPTION
## Summary

Two `IsDevelopment()` branches broke under Conductor's embedded mode. Migrated:

| Branch | Old | New |
|---|---|---|
| `options.RequireHttpsMetadata` | `!IsDevelopment()` | `!IsLocalOrEmbedded()` |
| `app.UseHttpsRedirection()` | unconditional | wrapped in `!IsEmbedded()` |

Audited but kept on `IsDevelopment()`:
- JWT bearer / RBAC-client SSL bypass — Embedded uses HTTP
- `app.UseSwagger()` / `UseSwaggerUI()` — dev-iteration cosmetics
- `AllowAllPolicyProvider` RBAC bypass — Embedded uses real RBAC
- Dev default-identity middleware — Embedded must use real JWT
- Authority-missing throw — Embedded ships Authority configured; strict throw still appropriate

DB migration already unconditional (Conductor #883) — no change needed.

Part of [conductor#1163](https://github.com/rivoli-ai/conductor/issues/1163).

## Test plan

- [x] `dotnet build` → 0 errors
- [x] **1632/1632 tests pass** (29 client + 467 unit + 1082 API + 54 integration, 9 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)