### PR TITLE
fix(idp-3): OBO bearer on proxy-token mint — closes #305

### DIFF
--- a/src/Andy.Containers.Api/Services/AndyModelsProxyTokenService.cs
+++ b/src/Andy.Containers.Api/Services/AndyModelsProxyTokenService.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -21,17 +22,20 @@ public sealed class AndyModelsProxyTokenService : IProxyTokenService
 
     private readonly IHttpClientFactory _httpFactory;
     private readonly IServiceTokenService _serviceTokens;
+    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IOptions<AndyModelsOptions> _options;
     private readonly ILogger<AndyModelsProxyTokenService> _logger;
 
     public AndyModelsProxyTokenService(
         IHttpClientFactory httpFactory,
         IServiceTokenService serviceTokens,
+        IHttpContextAccessor httpContextAccessor,
         IOptions<AndyModelsOptions> options,
         ILogger<AndyModelsProxyTokenService> logger)
     {
         _httpFactory = httpFactory;
         _serviceTokens = serviceTokens;
+        _httpContextAccessor = httpContextAccessor;
         _options = options;
         _logger = logger;
     }
@@ -60,7 +64,7 @@ public sealed class AndyModelsProxyTokenService : IProxyTokenService
                 "AndyModels:BaseUrl is not configured. Cannot mint per-container proxy tokens.");
         }
 
-        var bearer = await GetBearerAsync(ct).ConfigureAwait(false);
+        var bearer = await GetMintBearerAsync(ct).ConfigureAwait(false);
         var http = _httpFactory.CreateClient(HttpClientName);
 
         // Resolve against the configured base. Path matches the
@@ -189,6 +193,57 @@ public sealed class AndyModelsProxyTokenService : IProxyTokenService
         }
     }
 
+    /// <summary>
+    /// Bearer used on the mint path. Prefers an RFC 8693 OBO-exchanged
+    /// token (sub=user, act=andy-containers-api) when the current HTTP
+    /// request carries a user bearer; falls back to the pure-M2M token
+    /// (sub=andy-containers-api) when no inbound user token is
+    /// available (background callers).
+    ///
+    /// This is the consumer-side half of Epic IDP — paired with
+    /// rivoli-ai/andy-models#68's OBO-aware
+    /// <c>ProxyTokensController.CallerHasAsync</c>, it makes andy-rbac
+    /// see the originating user as the subject of the
+    /// <c>proxy:tokens:mint</c> check instead of <c>anonymous</c>.
+    /// Closes rivoli-ai/andy-containers#305.
+    /// </summary>
+    private async Task<string> GetMintBearerAsync(CancellationToken ct)
+    {
+        var userJwt = TryExtractInboundUserJwt();
+        if (!string.IsNullOrWhiteSpace(userJwt))
+        {
+            try
+            {
+                _logger.LogDebug(
+                    "Using OBO bearer (audience={Audience}) for proxy-token mint",
+                    AndyModelsApiAudience);
+                return await _serviceTokens
+                    .GetOnBehalfOfTokenAsync(userJwt, AndyModelsApiAudience, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (ServiceTokenException ex)
+            {
+                throw new ProxyTokenException(
+                    "Could not exchange user token for andy-models OBO bearer. " +
+                    "Check ServiceAuth:* configuration, that the andy-containers-api " +
+                    "OAuth client is on the TokenExchange:Policies allow-list for " +
+                    $"audience '{AndyModelsApiAudience}', and that the inbound user " +
+                    "token is a valid access token issued by andy-auth.", ex);
+            }
+        }
+
+        _logger.LogDebug(
+            "No inbound user token; falling back to M2M bearer (audience={Audience}) for proxy-token mint",
+            AndyModelsApiAudience);
+        return await GetBearerAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Pure M2M bearer (sub=andy-containers-api). Used on the revoke
+    /// path (no user context in destroy hooks) and as fallback on the
+    /// mint path when no inbound user token is available (background
+    /// callers).
+    /// </summary>
     private async Task<string> GetBearerAsync(CancellationToken ct)
     {
         try
@@ -212,6 +267,34 @@ public sealed class AndyModelsProxyTokenService : IProxyTokenService
                 $"OAuth client is permitted to request scope '{AndyModelsApiAudience}' " +
                 "(see andy-containers/config/registration.json apiClient.scopes).", ex);
         }
+    }
+
+    /// <summary>
+    /// Extracts the inbound user's bearer token from the current HTTP
+    /// request, if any. Returns null when called outside an HTTP
+    /// context (background workers, hosted services), or when the
+    /// inbound request didn't carry a bearer header. Strips the
+    /// "Bearer " prefix; returns the raw JWT.
+    /// </summary>
+    private string? TryExtractInboundUserJwt()
+    {
+        var ctx = _httpContextAccessor.HttpContext;
+        if (ctx is null)
+        {
+            return null;
+        }
+        var header = ctx.Request.Headers.Authorization.ToString();
+        if (string.IsNullOrWhiteSpace(header))
+        {
+            return null;
+        }
+        // Tolerate "Bearer xyz" (canonical) and "bearer xyz" (some clients).
+        const string prefix = "Bearer ";
+        if (header.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return header.Substring(prefix.Length).Trim();
+        }
+        return null;
     }
 
     /// <summary>

--- a/src/Andy.Containers.Api/Services/IServiceTokenService.cs
+++ b/src/Andy.Containers.Api/Services/IServiceTokenService.cs
@@ -76,6 +76,57 @@ public interface IServiceTokenService
     /// empty or whitespace.
     /// </exception>
     Task<string> GetAccessTokenAsync(string audience, CancellationToken ct = default);
+
+    /// <summary>
+    /// Exchanges a user access token (<paramref name="subjectToken"/>)
+    /// for an <em>on-behalf-of</em> access token whose <c>sub</c> is
+    /// the original user, whose <c>act</c> records this service as the
+    /// actor, and whose <c>aud</c> is <paramref name="audience"/>.
+    /// Implements the RFC 8693 OAuth 2.0 Token Exchange grant against
+    /// <c>andy-auth</c>'s <c>/connect/token</c> endpoint.
+    ///
+    /// <para>
+    /// Use this on every service-to-service call that originates from a
+    /// user request — without it the downstream RBAC check sees only
+    /// the service principal (or falls back to <c>anonymous</c>) instead
+    /// of the actual user. That failure mode is exactly what
+    /// rivoli-ai/andy-containers#305 exposed.
+    /// </para>
+    ///
+    /// <para>
+    /// Drives the consumer side of Epic IDP (rivoli-ai/conductor#1246).
+    /// This method intentionally mirrors the shape of
+    /// <c>Andy.Auth.M2MClient.IDelegatedTokenProvider.GetTokenOnBehalfOfAsync</c>
+    /// — once the M2M consolidation lands (covered by #990) the local
+    /// implementation here can be swapped for the shared library
+    /// version mechanically.
+    /// </para>
+    ///
+    /// <para>
+    /// Per (<paramref name="subjectToken"/>, <paramref name="audience"/>)
+    /// in-memory cache keyed by the subject token's SHA-256 hash — the
+    /// raw user JWT never lives in a cache key.
+    /// </para>
+    /// </summary>
+    /// <param name="subjectToken">
+    /// The user's bearer access token from the inbound HTTP request.
+    /// Must be a JWT this server's <c>andy-auth</c> validates as one of
+    /// its own issued tokens.
+    /// </param>
+    /// <param name="audience">
+    /// Downstream service the returned token will be presented to
+    /// (e.g. <c>urn:andy-models-api</c>).
+    /// </param>
+    /// <exception cref="ServiceTokenException">
+    /// Thrown on transport failure, when andy-auth rejects the request
+    /// (policy denial → <c>unauthorized_client</c>; invalid subject
+    /// token → <c>invalid_grant</c>), or when the response is empty /
+    /// malformed.
+    /// </exception>
+    Task<string> GetOnBehalfOfTokenAsync(
+        string subjectToken,
+        string audience,
+        CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Andy.Containers.Api/Services/ServiceTokenService.cs
+++ b/src/Andy.Containers.Api/Services/ServiceTokenService.cs
@@ -1,4 +1,6 @@
 using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -37,6 +39,11 @@ public sealed class ServiceTokenService : IServiceTokenService, IDisposable
     // dictionary lookup + an HTTP mint behind the cache miss.
     private readonly SemaphoreSlim _gate = new(initialCount: 1, maxCount: 1);
     private readonly Dictionary<string, CacheEntry> _cache = new(StringComparer.Ordinal);
+
+    // Epic IDP (rivoli-ai/conductor#1246). Separate cache for OBO
+    // tokens, keyed by (SHA-256 of the user's subject token, audience).
+    // Hashing keeps the raw user JWT out of cache keys.
+    private readonly Dictionary<DelegatedCacheKey, CacheEntry> _delegatedCache = new();
 
     /// <summary>HttpClient name registered in DI; tests can override.</summary>
     public const string HttpClientName = "ServiceTokenClient";
@@ -118,6 +125,154 @@ public sealed class ServiceTokenService : IServiceTokenService, IDisposable
         token = string.Empty;
         return false;
     }
+
+    public async Task<string> GetOnBehalfOfTokenAsync(
+        string subjectToken,
+        string audience,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(subjectToken))
+        {
+            throw new ServiceTokenException(
+                "subject_token is required for on-behalf-of token requests.");
+        }
+        if (string.IsNullOrWhiteSpace(audience))
+        {
+            throw new ServiceTokenException(
+                "Audience is required for on-behalf-of token requests.");
+        }
+
+        var key = new DelegatedCacheKey(HashSubject(subjectToken), audience);
+
+        // Fast path: cached and not within refresh skew.
+        if (TryGetFreshCachedDelegated(key, out var fast))
+        {
+            return fast;
+        }
+
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            // Double-check after acquiring the gate.
+            if (TryGetFreshCachedDelegated(key, out var current))
+            {
+                return current;
+            }
+
+            var fresh = await MintOnBehalfOfAsync(subjectToken, audience, ct).ConfigureAwait(false);
+            var expiry = _timeProvider.GetUtcNow() + TimeSpan.FromSeconds(fresh.ExpiresInSeconds);
+            _delegatedCache[key] = new CacheEntry(fresh.AccessToken!, expiry);
+            return fresh.AccessToken!;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private bool TryGetFreshCachedDelegated(DelegatedCacheKey key, out string token)
+    {
+        if (_delegatedCache.TryGetValue(key, out var entry)
+            && _timeProvider.GetUtcNow() + RefreshSkew < entry.Expiry)
+        {
+            token = entry.Token;
+            return true;
+        }
+        token = string.Empty;
+        return false;
+    }
+
+    private async Task<TokenResponse> MintOnBehalfOfAsync(
+        string subjectToken,
+        string audience,
+        CancellationToken ct)
+    {
+        var opts = _options.Value;
+        if (string.IsNullOrWhiteSpace(opts.TokenEndpoint))
+        {
+            throw new ServiceTokenException(
+                "ServiceAuth:TokenEndpoint is not configured. Cannot mint on-behalf-of tokens.");
+        }
+        if (string.IsNullOrWhiteSpace(opts.ClientId))
+        {
+            throw new ServiceTokenException(
+                "ServiceAuth:ClientId is not configured. Cannot mint on-behalf-of tokens.");
+        }
+
+        var http = _httpFactory.CreateClient(HttpClientName);
+
+        // RFC 8693 §2.1 wire shape. The grant URN and token-type URN
+        // are normative; the `resource` parameter names the downstream
+        // audience.
+        var form = new Dictionary<string, string>
+        {
+            ["grant_type"] = "urn:ietf:params:oauth:grant-type:token-exchange",
+            ["client_id"] = opts.ClientId,
+            ["client_secret"] = opts.ClientSecret ?? string.Empty,
+            ["subject_token"] = subjectToken,
+            ["subject_token_type"] = "urn:ietf:params:oauth:token-type:access_token",
+            ["resource"] = audience,
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, opts.TokenEndpoint)
+        {
+            Content = new FormUrlEncodedContent(form),
+        };
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await http.SendAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new ServiceTokenException(
+                $"Token endpoint unreachable for OBO exchange: {opts.TokenEndpoint}", ex);
+        }
+
+        using var _ = response;
+        if (!response.IsSuccessStatusCode)
+        {
+            var bodyPreview = await SafeReadPreviewAsync(response, ct).ConfigureAwait(false);
+            throw new ServiceTokenException(
+                $"Token endpoint returned HTTP {(int)response.StatusCode} for OBO exchange (audience={audience}). " +
+                $"Body preview: {bodyPreview}");
+        }
+
+        TokenResponse? parsed;
+        try
+        {
+            parsed = await response.Content.ReadFromJsonAsync<TokenResponse>(ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new ServiceTokenException(
+                "Token endpoint OBO response was not valid JSON.", ex);
+        }
+        if (parsed is null || string.IsNullOrWhiteSpace(parsed.AccessToken))
+        {
+            throw new ServiceTokenException(
+                "Token endpoint OBO response is missing the `access_token` field.");
+        }
+
+        _logger.LogInformation(
+            "Minted OBO token (clientId={ClientId} audience={Audience} expiresInSeconds={ExpiresInSeconds})",
+            opts.ClientId, audience, parsed.ExpiresInSeconds);
+        return parsed;
+    }
+
+    private static string HashSubject(string subjectToken)
+    {
+        var bytes = Encoding.UTF8.GetBytes(subjectToken);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash);
+    }
+
+    /// <summary>
+    /// Cache key for OBO tokens. Hashing the subject token keeps the
+    /// raw user JWT out of the dictionary key.
+    /// </summary>
+    private readonly record struct DelegatedCacheKey(string SubjectTokenHash, string Audience);
 
     private async Task<TokenResponse> MintAsync(string audience, CancellationToken ct)
     {

--- a/tests/Andy.Containers.Api.Tests/Services/AndyModelsProxyTokenServiceTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/AndyModelsProxyTokenServiceTests.cs
@@ -307,22 +307,102 @@ public class AndyModelsProxyTokenServiceTests
     }
 
     // -----------------------------------------------------------------
+    // Epic IDP (rivoli-ai/conductor#1246) — OBO bearer on mint path
+    // Closes rivoli-ai/andy-containers#305.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task Mint_WithInboundUserBearer_UsesObOBearer()
+    {
+        // When the current HTTP request carries `Authorization: Bearer <user-jwt>`,
+        // the consumer exchanges the user token via OBO instead of using
+        // the pure M2M token. andy-models then sees `sub=<user>` /
+        // `act=<andy-containers-api>` and gates on the user's permission.
+        var bearer = new StubTokenService("obo-exchanged-jwt");
+        var (service, handler, _) = MakeService(
+            opts => opts.BaseUrl = "http://andy-models.test",
+            bearerProvider: bearer,
+            inboundUserJwt: "user.jwt.signature");
+        handler.SetSuccessJsonResponse(
+            "{\"tokenId\":\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\",\"jwt\":\"j.w.t\",\"expiresAt\":\"2026-12-01T00:00:00Z\"}");
+
+        _ = await service.MintForContainerAsync("ctr", "user", new[] { "anthropic/claude-sonnet-4-6" });
+
+        bearer.LastSubjectToken.Should().Be("user.jwt.signature",
+            "the user's inbound token must be presented as subject_token to the OBO exchange.");
+        bearer.LastRequestedAudience.Should().Be("urn:andy-models-api");
+        handler.LastRequest!.Headers.Authorization.Should().Be(
+            new AuthenticationHeaderValue("Bearer", "obo-exchanged-jwt"),
+            "the bearer on the outbound call must be the OBO-exchanged token, not the user's raw JWT.");
+    }
+
+    [Fact]
+    public async Task Mint_WithoutInboundHttpContext_FallsBackToM2M()
+    {
+        // Background callers (workers, hosted services) have no
+        // inbound HTTP context. They keep the existing M2M behaviour.
+        var bearer = new StubTokenService("m2m-bearer");
+        var (service, handler, _) = MakeService(
+            opts => opts.BaseUrl = "http://andy-models.test",
+            bearerProvider: bearer);
+        handler.SetSuccessJsonResponse(
+            "{\"tokenId\":\"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb\",\"jwt\":\"j.w.t\",\"expiresAt\":\"2026-12-01T00:00:00Z\"}");
+
+        _ = await service.MintForContainerAsync("ctr", "user", new[] { "anthropic/claude-sonnet-4-6" });
+
+        bearer.LastSubjectToken.Should().BeNull("no inbound user → no OBO exchange.");
+        bearer.LastRequestedAudience.Should().Be("urn:andy-models-api");
+        handler.LastRequest!.Headers.Authorization.Should().Be(
+            new AuthenticationHeaderValue("Bearer", "m2m-bearer"));
+    }
+
+    [Fact]
+    public async Task Mint_ObOExchangeFailure_WrappedAsProxyTokenException()
+    {
+        // OBO exchange failures should surface with a clear message
+        // pointing at the policy / config — not crash the request with
+        // a raw ServiceTokenException.
+        var bearer = new ThrowingTokenService(new ServiceTokenException("policy denied"));
+        var (service, _, _) = MakeService(
+            opts => opts.BaseUrl = "http://andy-models.test",
+            bearerProvider: bearer,
+            inboundUserJwt: "user.jwt.signature");
+
+        var act = async () => await service.MintForContainerAsync(
+            "ctr", "user", new[] { "anthropic/claude-sonnet-4-6" });
+
+        var ex = await act.Should().ThrowAsync<ProxyTokenException>();
+        ex.Which.Message.Should().Contain("OBO");
+    }
+
+    // -----------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------
 
     private static (AndyModelsProxyTokenService service, StubHttpHandler handler, IServiceTokenService bearer)
         MakeService(
             Action<AndyModelsOptions> configure,
-            IServiceTokenService? bearerProvider = null)
+            IServiceTokenService? bearerProvider = null,
+            string? inboundUserJwt = null)
     {
         var options = new AndyModelsOptions();
         configure(options);
         var handler = new StubHttpHandler();
         var factory = new SingleClientHttpClientFactory(handler);
         var bearer = bearerProvider ?? new StubTokenService("m2m-bearer-stub");
+
+        var httpContextAccessor = new Microsoft.AspNetCore.Http.HttpContextAccessor();
+        if (inboundUserJwt is not null)
+        {
+            var ctx = new Microsoft.AspNetCore.Http.DefaultHttpContext();
+            ctx.Request.Headers.Authorization = $"Bearer {inboundUserJwt}";
+            httpContextAccessor.HttpContext = ctx;
+        }
+
         var service = new AndyModelsProxyTokenService(
             factory,
             bearer,
+            httpContextAccessor,
             Options.Create(options),
             NullLogger<AndyModelsProxyTokenService>.Instance);
         return (service, handler, bearer);
@@ -332,6 +412,7 @@ public class AndyModelsProxyTokenServiceTests
     {
         private readonly string _token;
         public string? LastRequestedAudience { get; private set; }
+        public string? LastSubjectToken { get; private set; }
         public StubTokenService(string token) { _token = token; }
         public Task<string> GetAccessTokenAsync(CancellationToken ct = default)
         {
@@ -343,6 +424,12 @@ public class AndyModelsProxyTokenServiceTests
             LastRequestedAudience = audience;
             return Task.FromResult(_token);
         }
+        public Task<string> GetOnBehalfOfTokenAsync(string subjectToken, string audience, CancellationToken ct = default)
+        {
+            LastRequestedAudience = audience;
+            LastSubjectToken = subjectToken;
+            return Task.FromResult(_token);
+        }
     }
 
     private sealed class ThrowingTokenService : IServiceTokenService
@@ -352,6 +439,8 @@ public class AndyModelsProxyTokenServiceTests
         public Task<string> GetAccessTokenAsync(CancellationToken ct = default)
             => Task.FromException<string>(_ex);
         public Task<string> GetAccessTokenAsync(string audience, CancellationToken ct = default)
+            => Task.FromException<string>(_ex);
+        public Task<string> GetOnBehalfOfTokenAsync(string subjectToken, string audience, CancellationToken ct = default)
             => Task.FromException<string>(_ex);
     }
 

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServicePerToolEnvTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServicePerToolEnvTests.cs
@@ -284,6 +284,7 @@ public class ContainerOrchestrationServicePerToolEnvTests : IDisposable
         public StubServiceTokenService(string token) { _token = token; }
         public Task<string> GetAccessTokenAsync(CancellationToken ct = default) => Task.FromResult(_token);
         public Task<string> GetAccessTokenAsync(string audience, CancellationToken ct = default) => Task.FromResult(_token);
+        public Task<string> GetOnBehalfOfTokenAsync(string subjectToken, string audience, CancellationToken ct = default) => Task.FromResult(_token);
     }
 
     private sealed class StubProxyTokenService : IProxyTokenService

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceProxyTokenTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceProxyTokenTests.cs
@@ -302,6 +302,7 @@ public class ContainerOrchestrationServiceProxyTokenTests : IDisposable
         public StubServiceTokenService(string token) { _token = token; }
         public Task<string> GetAccessTokenAsync(CancellationToken ct = default) => Task.FromResult(_token);
         public Task<string> GetAccessTokenAsync(string audience, CancellationToken ct = default) => Task.FromResult(_token);
+        public Task<string> GetOnBehalfOfTokenAsync(string subjectToken, string audience, CancellationToken ct = default) => Task.FromResult(_token);
     }
 
     /// <summary>

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTokenInjectionTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServiceTokenInjectionTests.cs
@@ -250,5 +250,8 @@ public class ContainerOrchestrationServiceTokenInjectionTests : IDisposable
 
         public Task<string> GetAccessTokenAsync(string audience, CancellationToken ct = default)
             => GetAccessTokenAsync(ct);
+
+        public Task<string> GetOnBehalfOfTokenAsync(string subjectToken, string audience, CancellationToken ct = default)
+            => GetAccessTokenAsync(ct);
     }
 }


### PR DESCRIPTION
## Summary

Closes #305 — container creation with a code assistant (e.g. **.NET 10 Alpine Desktop with Claude Code**) was failing with HTTP 500 because \`AndyModelsProxyTokenService\` called \`andy-models /api/proxy/tokens\` with the service's own M2M bearer (no end-user context). \`andy-models\` then asked andy-rbac \"can this caller mint a proxy token?\" — and rbac saw \`subject = anonymous\`, denied, returned 403, surfaced as \`[SVC-500] Containers: [API-SERVER-500]\`.

This PR migrates the mint path to RFC 8693 OBO (token exchange). When a container is created from an inbound HTTP request, the user's JWT is exchanged for a token whose:

- \`sub\` is the **user**
- \`act\` records \`andy-containers-api\` as the actor
- \`aud\` is \`urn:andy-models-api\`

Paired with rivoli-ai/andy-models#68's OBO-aware \`ProxyTokensController\`, andy-rbac now sees the originating user as the subject of \`proxy:tokens:mint\`, not anonymous.

## Where the change lives

- **\`IServiceTokenService\`** gains \`GetOnBehalfOfTokenAsync(subjectToken, audience, ct)\`. Shape mirrors \`Andy.Auth.M2MClient.IDelegatedTokenProvider\` so the M2M-consolidation pass (rivoli-ai/conductor#990) can swap the local implementation for the shared library mechanically once published.
- **\`ServiceTokenService\`** implements the RFC 8693 wire shape against \`andy-auth /connect/token\`: \`grant_type=urn:ietf:params:oauth:grant-type:token-exchange\`, \`subject_token\`, \`subject_token_type\`, \`resource\`, client_credentials. Per-(SHA-256(subject), audience) in-memory cache reusing the existing semaphore gate.
- **\`AndyModelsProxyTokenService\`** grows \`IHttpContextAccessor\`. New \`GetMintBearerAsync\` prefers OBO when an inbound user JWT is on the request; falls back to the existing M2M \`GetBearerAsync\` when there's no HTTP context (background callers, hosted services).

## Mint path vs revoke path

| Path | Trigger | Bearer | RBAC subject at andy-models |
|---|---|---|---|
| Mint (this PR) | User clicks Create in Conductor | **OBO** (sub=user, act=andy-containers-api) | The **user** |
| Mint fallback | Background worker | M2M (sub=andy-containers-api) | andy-containers-api (allowlist bypass) |
| Revoke | Container destroy (sweepers / lifecycle) | M2M (sub=andy-containers-api) | andy-containers-api (allowlist bypass) |

Revoke stays on M2M because the destroy hook may run without an inbound user request. andy-models's M2M trust allowlist still fires for those paths and is intentionally unchanged.

## Test plan

3 new tests in \`AndyModelsProxyTokenServiceTests\`:

- **\`Mint_WithInboundUserBearer_UsesObOBearer\`** — sets an \`Authorization: Bearer user.jwt.signature\` on the synthetic HTTP context, asserts that the stub token service received the user JWT as \`subject_token\` and the audience as \`urn:andy-models-api\`, and that the outbound POST to andy-models presents the exchanged token (not the user JWT directly).
- **\`Mint_WithoutInboundHttpContext_FallsBackToM2M\`** — no HTTP context → no OBO exchange → M2M bearer presented.
- **\`Mint_ObOExchangeFailure_WrappedAsProxyTokenException\`** — \`ServiceTokenException\` from the exchange is wrapped with a message pointing at policy / config, not raw-exception-propagated.

Test stubs at 5 sites (\`StubTokenService\` / \`StubServiceTokenService\` / \`ThrowingTokenService\`) extended with the new interface member.

**Full \`Andy.Containers.Api.Tests\` suite: 1084 passed, 1 skipped, 0 failed.**

## Scope notes / future work

- The \"persist user \`sub\` on Container row\" piece of IDP.3 (for background-path revoke to assert the stored user) is **deferred**. It needs a new andy-auth grant flavour (\"act-as-stored-user\") that hasn't been designed yet. Background revoke continues on M2M+allowlist — the JWT's \`exp\` is the backstop and revoke is idempotent-on-failure today, so this isn't a user-visible regression.
- The local \`IServiceTokenService\` extension duplicates ~150 lines of \`Andy.Auth.M2MClient.IDelegatedTokenProvider\`. Tagged with a comment in the interface doc; consolidation under rivoli-ai/conductor#990 swaps it mechanically once the M2M shared library publishes the OBO types.

## Related

- Epic IDP: rivoli-ai/conductor#1246
- Auth-server side: rivoli-ai/andy-auth#102 (merged) — the token-exchange endpoint
- Client lib: rivoli-ai/andy-auth#103 (merged) — \`IDelegatedTokenProvider\` (target shape)
- andy-models server side: rivoli-ai/andy-models#68 (merged) — OBO-aware \`ProxyTokensController\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)