### PR TITLE
docs: refresh stale markdown content

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,15 @@ This starts all services:
 
 | Service | URL | Description |
 |---------|-----|-------------|
-| Frontend | http://localhost:4200 | Angular 18 web UI |
-| API (HTTPS) | https://localhost:5200 | REST / MCP API |
-| API (HTTP) | http://localhost:5201 | HTTP access |
-| PostgreSQL | localhost:5434 | Database (postgres:16-alpine) |
+| Frontend | http://localhost:6200 | Angular 18 web UI (Docker) |
+| API (HTTPS) | https://localhost:7200 | REST / MCP API (Docker) |
+| API (HTTP) | http://localhost:7201 | HTTP access (Docker) |
+| PostgreSQL | localhost:7434 | Database (postgres:16-alpine, Docker) |
 | Andy Auth | https://localhost:5001 | OAuth 2.0 / OIDC server |
 | Andy RBAC API | https://localhost:7003 | RBAC permission server |
 | Andy RBAC Web | https://localhost:5180 | RBAC admin UI |
+
+Local (non-Docker) development uses ports `5200/5201` (API) and `4200` (Angular) — see [`docs/getting-started.md`](docs/getting-started.md) and [`config/registration.json`](config/registration.json).
 
 The database schema is auto-created on first startup and seed data (providers, templates) is inserted automatically.
 
@@ -105,9 +107,10 @@ src/
 └── andy-containers-web/          # Web UI (Angular 18 SPA)
 
 tests/
-├── Andy.Containers.Tests/        # Core library tests
-├── Andy.Containers.Api.Tests/    # API integration tests
-└── Andy.Containers.Client.Tests/ # Client library tests
+├── Andy.Containers.Tests/             # Core library tests
+├── Andy.Containers.Api.Tests/         # API controller tests
+├── Andy.Containers.Client.Tests/      # Client library tests
+└── Andy.Containers.Integration.Tests/ # End-to-end provisioning tests
 
 config/
 ├── templates/                    # YAML template definitions

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -796,9 +796,9 @@ Five `BackgroundService` workers run concurrently:
 ### 13.1 Docker Compose (Local Development)
 
 ```
-PostgreSQL ← andy-containers-db (port 5434)
-API Server ← andy-containers-api (port 5200)
-Web UI     ← andy-containers-web (port 5280)
+PostgreSQL ← andy-containers-db (port 7434 docker / 5434 local)
+API Server ← andy-containers-api (port 7200 docker / 5200 local)
+Web UI     ← andy-containers-web (port 6200 docker / 4200 local)
 ```
 
 ### 13.2 Production

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -5,16 +5,18 @@
 All services run in Docker via `docker compose up`:
 
 ```yaml
-# Andy Containers services
-postgres          -> localhost:5434   # PostgreSQL 16-alpine (maps to internal 5432)
-api               -> localhost:5200   # API (HTTPS), localhost:5201 (HTTP)
-web               -> localhost:4200   # Angular frontend (nginx)
+# Andy Containers services (Docker port mappings — see docker-compose.yml)
+postgres          -> localhost:7434   # PostgreSQL 16-alpine (maps to internal 5432)
+api               -> localhost:7200   # API (HTTPS), localhost:7201 (HTTP)
+web               -> localhost:6200   # Angular frontend (nginx)
 
 # Dependent Andy services
 andy-auth         -> localhost:5001   # Andy Auth (HTTPS), localhost:5002 (HTTP)
 andy-rbac-api     -> localhost:7003   # Andy RBAC API (HTTPS), localhost:7004 (HTTP)
 andy-rbac-web     -> localhost:5180   # Andy RBAC Web (HTTPS), localhost:5181 (HTTP)
 ```
+
+For local (non-Docker) `dotnet run` the API and Angular dev server use the canonical local ports `5200/5201/4200` per [`config/registration.json`](../config/registration.json).
 
 ## Volumes and Mounts
 
@@ -64,13 +66,15 @@ docker compose build api
 
 ## Port Reference
 
-### Andy Containers
+### Andy Containers (Docker)
 
 | Service | HTTPS | HTTP | Internal |
 |---------|-------|------|----------|
-| API | 5200 | 5201 | 8443/8080 |
-| Frontend | -- | 4200 | 80 |
-| PostgreSQL | -- | 5434 | 5432 |
+| API | 7200 | 7201 | 8443/8080 |
+| Frontend | -- | 6200 | 80 |
+| PostgreSQL | -- | 7434 | 5432 |
+
+Local (non-Docker) `dotnet run`: API `5200/5201`, Angular `4200`, Postgres `5434` — see `config/registration.json` for the canonical port map.
 
 ### Related Andy Services
 
@@ -83,7 +87,7 @@ docker compose build api
 ## Database
 
 - **Engine**: PostgreSQL 16-alpine
-- **External port**: 5434 (maps to internal 5432)
+- **External port (Docker)**: 7434 (maps to internal 5432). Local `dotnet run` connects on 5434.
 - **Schema**: Auto-created on first startup via `EnsureCreatedAsync()`
 - **Seed data**: Providers and templates seeded automatically by `DataSeeder`
 - **Persistence**: Data persists across restarts via Docker volume

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,10 +20,10 @@ This starts:
 
 | Service | URL | Description |
 |---------|-----|-------------|
-| **Frontend** | http://localhost:4200 | Angular 18 web UI |
-| **API (HTTPS)** | https://localhost:5200 | REST / MCP API |
-| **API (HTTP)** | http://localhost:5201 | HTTP access |
-| **PostgreSQL** | localhost:5434 | Database (maps to internal 5432) |
+| **Frontend** | http://localhost:6200 | Angular 18 web UI (Docker) |
+| **API (HTTPS)** | https://localhost:7200 | REST / MCP API (Docker) |
+| **API (HTTP)** | http://localhost:7201 | HTTP access (Docker) |
+| **PostgreSQL** | localhost:7434 | Database (maps to internal 5432, Docker) |
 | **Andy Auth** | https://localhost:5001 | OAuth 2.0 / OIDC server |
 | **Andy RBAC API** | https://localhost:7003 | RBAC permission server |
 | **Andy RBAC Web** | https://localhost:5180 | RBAC admin UI |

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -943,9 +943,9 @@ The Dockerfile (`src/Andy.Containers.Api/Dockerfile`) uses a two-stage build:
 
 ```yaml
 services:
-  postgres:          # PostgreSQL 16 Alpine, port 5434:5432
-  api:               # Andy Containers API, ports 5200:8443 (HTTPS), 5201:8080 (HTTP)
-  web:               # Angular SPA (nginx), port 4200:80
+  postgres:          # PostgreSQL 16 Alpine, port 7434:5432
+  api:               # Andy Containers API, ports 7200:8443 (HTTPS), 7201:8080 (HTTP)
+  web:               # Angular SPA (nginx), port 6200:8443
 ```
 
 Key docker-compose features:

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,13 +41,15 @@ Andy Containers provisions, manages, and orchestrates isolated development envir
 
 | Service | URL | Description |
 |---------|-----|-------------|
-| Frontend | http://localhost:4200 | Angular 18 web UI |
-| API (HTTPS) | https://localhost:5200 | REST / MCP API |
-| API (HTTP) | http://localhost:5201 | HTTP access |
-| PostgreSQL | localhost:5434 | Database (postgres:16-alpine) |
+| Frontend | http://localhost:6200 | Angular 18 web UI (Docker) |
+| API (HTTPS) | https://localhost:7200 | REST / MCP API (Docker) |
+| API (HTTP) | http://localhost:7201 | HTTP access (Docker) |
+| PostgreSQL | localhost:7434 | Database (postgres:16-alpine, Docker) |
 | Andy Auth | https://localhost:5001 | OAuth 2.0 / OIDC server |
 | Andy RBAC API | https://localhost:7003 | RBAC permission server |
 | Andy RBAC Web | https://localhost:5180 | RBAC admin UI |
+
+For local (non-Docker) development the API uses `5200/5201` and the Angular dev server uses `4200` — see [`config/registration.json`](https://github.com/rivoli-ai/andy-containers/blob/main/config/registration.json).
 
 ## Background Workers
 

--- a/docs/presentation.md
+++ b/docs/presentation.md
@@ -303,7 +303,7 @@ The hard work runs asynchronously in the background worker.
 - **Andy RBAC** `[RequirePermission]` on every controller
 - **Resource types**: container, template, provider, workspace, credential, api-key, image
 - **Audit**: `ContainerEvent` rows capture every state transition
-- Service-to-service calls propagate the caller's JWT (`BearerForwardingHandler` pattern)
+- Service-to-service calls propagate the caller's JWT via the `DelegatedBearerHandler` (OBO) pattern
 - Secrets (`ConnectionConfig`, env vars, API keys) encrypted with ASP.NET Core Data Protection
 
 ---
@@ -327,6 +327,8 @@ Mount: `/var/run/docker.sock` for the Docker provider.
 
 ## Ports & Docker
 
+Local `dotnet run` (canonical, from `config/registration.json`):
+
 | Port | Service |
 |------|---------|
 | 5200 | API HTTPS |
@@ -335,7 +337,7 @@ Mount: `/var/run/docker.sock` for the Docker provider.
 | 5434 | PostgreSQL |
 | 4222 | NATS |
 
-`docker-compose.yml` runs Postgres 16, NATS 2, API, Web. Dockerfile is multi-stage with custom CA injection and non-root runtime.
+`docker compose up` shifts to the docker-port set (`7200/7201/6200/7434/7422`) — see `docker-compose.yml` and `docs/docker-setup.md`. Dockerfile is multi-stage with custom CA injection and non-root runtime.
 
 Volumes: `postgres_data`, `nats_data`, `dataprotection_keys`.
 


### PR DESCRIPTION
## Summary

Markdown sweep targeting fact-level staleness (paths, ports, version numbers, removed-feature references). Out of scope: license headers, prose/style, section reorganization, generated docs.

- Docker-compose port tables in `README.md`, `docs/index.md`, `docs/getting-started.md`, `docs/docker-setup.md` claimed `5200/5201/4200/5434` for the `docker compose up` set — actual `docker-compose.yml` mappings are `7200/7201/6200/7434` (and `7422` for NATS). Local `dotnet run` keeps the canonical `5200/5201/4200/5434` from `config/registration.json`; the tables now distinguish the two modes.
- `docs/ARCHITECTURE.md` deployment block and `docs/implementation.md` docker-compose snippet had the same mismatch (the web port was even listed as `5280`).
- `docs/presentation.md`: replaced the `BearerForwardingHandler` reference with `DelegatedBearerHandler` (OBO) — IDP-5 has landed across the org. Fixed the ports cheat-sheet to clarify local vs docker.
- `README.md` project tree: added the missing `Andy.Containers.Integration.Tests` project.

## Test plan

- [ ] CI passes
- [ ] Spot-check that the new port tables match `docker-compose.yml` and `config/registration.json`