### PR TITLE
fix(terminal): stop resize control frames leaking to PTY stdin

### DIFF
--- a/src/Andy.Containers.Api/Controllers/TerminalController.cs
+++ b/src/Andy.Containers.Api/Controllers/TerminalController.cs
@@ -683,7 +683,10 @@ public class TerminalController : ControllerBase
 
                     if (result.Count > 0)
                     {
-                        if (result.Count > 10 && buffer[0] == '{' && IsResizeMessage(buffer, result.Count, out _, out _))
+                        // Swallow resize control frames so they never
+                        // become shell stdin. This path doesn't apply
+                        // the resize (see comment above the task).
+                        if (TryParseResizeFrame(buffer, result.Count, out _, out _))
                         {
                             continue;
                         }
@@ -812,10 +815,11 @@ public class TerminalController : ControllerBase
 
                     // Resize messages route to the daemon's PTY-size
                     // API (provider-specific). The kernel propagates
-                    // SIGWINCH down to the inner shell.
-                    if (result.Count > 10
-                        && buffer[0] == '{'
-                        && IsResizeMessage(buffer, result.Count, out var newCols, out var newRows))
+                    // SIGWINCH down to the inner shell. Frames that
+                    // match the resize shape are always swallowed
+                    // (never written to stdin) even when the values
+                    // are unusable — that's the conductor #836 fix.
+                    if (TryParseResizeFrame(buffer, result.Count, out var newCols, out var newRows))
                     {
                         if (IsValidTerminalSize(newCols, newRows))
                         {
@@ -1135,10 +1139,38 @@ public class TerminalController : ControllerBase
     internal static string BuildTmuxHasSessionArguments(string containerUser, string externalId)
         => $"exec -u {containerUser} {externalId} tmux has-session -t {TmuxSessionName}";
 
-    private static bool IsResizeMessage(byte[] buffer, int count, out int cols, out int rows)
+    /// <summary>
+    /// Returns <c>true</c> iff the buffer holds a well-formed
+    /// <c>{"type":"resize","cols":N,"rows":N}</c> control frame
+    /// emitted by Conductor's Ghostty surface on every grid resize.
+    /// </summary>
+    /// <remarks>
+    /// This recognises the frame by shape only. Whether the parsed
+    /// cols/rows are usable as PTY dimensions is a separate decision
+    /// — call <see cref="IsValidTerminalSize"/> for that. Conflating
+    /// the two caused conductor #836: a 5-row Ghostty surface fired a
+    /// resize frame, the prior implementation rejected it on the
+    /// rows>5 bound, and the JSON fell through to the PTY's stdin
+    /// where the shell printed it as <c>{"type":"resize","cols":88,
+    /// "rows":5}</c> on the user's prompt line.
+    ///
+    /// Any frame matching this shape MUST be swallowed by callers
+    /// (never forwarded to the PTY) even when the values are
+    /// out-of-range — the PTY-exec path can still skip the resize
+    /// itself based on <see cref="IsValidTerminalSize"/>.
+    ///
+    /// Public for unit tests.
+    /// </remarks>
+    internal static bool TryParseResizeFrame(byte[] buffer, int count, out int cols, out int rows)
     {
         cols = 0;
         rows = 0;
+
+        // Fast reject: shortest plausible payload is
+        // `{"type":"resize","cols":1,"rows":1}` (35 bytes). Avoids
+        // UTF-8 + JSON parse cost on every shell keystroke.
+        if (count <= 10 || buffer[0] != (byte)'{') return false;
+
         try
         {
             var text = System.Text.Encoding.UTF8.GetString(buffer, 0, count);
@@ -1149,14 +1181,17 @@ public class TerminalController : ControllerBase
             if (doc.RootElement.TryGetProperty("type", out var typeProp) &&
                 typeProp.GetString() == "resize" &&
                 doc.RootElement.TryGetProperty("cols", out var colsProp) &&
-                doc.RootElement.TryGetProperty("rows", out var rowsProp))
+                doc.RootElement.TryGetProperty("rows", out var rowsProp) &&
+                colsProp.TryGetInt32(out cols) &&
+                rowsProp.TryGetInt32(out rows))
             {
-                cols = colsProp.GetInt32();
-                rows = rowsProp.GetInt32();
-                return cols > 10 && cols < 500 && rows > 5 && rows < 200;
+                return true;
             }
         }
         catch { /* not a resize message */ }
+
+        cols = 0;
+        rows = 0;
         return false;
     }
 }

--- a/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/TerminalControllerTests.cs
@@ -342,6 +342,71 @@ public class TerminalControllerTests : IDisposable
         TerminalController.IsValidTerminalSize(cols, rows).Should().BeFalse(reason);
     }
 
+    // MARK: - TryParseResizeFrame (conductor #836 corrective)
+    //
+    // Regression: prior implementation conflated frame recognition
+    // with value validation. A small Ghostty surface fired
+    // `{"type":"resize","cols":88,"rows":5}`, the old `rows > 5`
+    // bound rejected it as "not a resize message", and the JSON fell
+    // through to the PTY's stdin where the shell printed it on the
+    // user's prompt. The shape-match must succeed independently of
+    // whether the values are usable.
+
+    [Theory]
+    [InlineData(88, 5)]   // the exact case from the conductor #836 report
+    [InlineData(80, 24)]
+    [InlineData(2, 2)]
+    [InlineData(500, 200)]
+    [InlineData(10000, 10000)]  // shape match even when values exceed PTY bounds
+    [InlineData(1, 1)]          // shape match even when values are below tmux floor
+    public void TryParseResizeFrame_RecognisesFrameByShape_RegardlessOfValues(int cols, int rows)
+    {
+        var frame = $"{{\"type\":\"resize\",\"cols\":{cols},\"rows\":{rows}}}";
+        var bytes = System.Text.Encoding.UTF8.GetBytes(frame);
+
+        var result = TerminalController.TryParseResizeFrame(bytes, bytes.Length, out var parsedCols, out var parsedRows);
+
+        result.Should().BeTrue("the frame matches the resize shape");
+        parsedCols.Should().Be(cols);
+        parsedRows.Should().Be(rows);
+    }
+
+    [Theory]
+    [InlineData("ls -la\n", "shell command")]
+    [InlineData("echo hi\n", "shell command")]
+    [InlineData("{\"type\":\"input\",\"data\":\"foo\"}", "different frame type")]
+    [InlineData("{\"cols\":80,\"rows\":24}", "missing type field — old format")]
+    [InlineData("{\"type\":\"resize\"}", "missing cols/rows")]
+    [InlineData("{\"type\":\"resize\",\"cols\":\"eighty\",\"rows\":24}", "non-integer cols")]
+    [InlineData("not json at all", "not JSON")]
+    [InlineData("{ malformed", "malformed JSON")]
+    [InlineData("a", "single byte under length floor")]
+    [InlineData("aaaaaaaaaa", "ten bytes — equals length floor (exclusive)")]
+    public void TryParseResizeFrame_ReturnsFalse_ForNonResizeInput(string text, string reason)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(text);
+
+        var result = TerminalController.TryParseResizeFrame(bytes, bytes.Length, out var cols, out var rows);
+
+        result.Should().BeFalse(reason);
+        cols.Should().Be(0);
+        rows.Should().Be(0);
+    }
+
+    [Fact]
+    public void TryParseResizeFrame_ResetsOutParams_OnMalformedJson()
+    {
+        // Defensive: malformed JSON that partially parses (e.g. type
+        // matches but cols throws on GetInt32) must still leave the
+        // out-params at zero rather than half-populated.
+        var bytes = System.Text.Encoding.UTF8.GetBytes("{\"type\":\"resize\",\"cols\":\"eighty\",\"rows\":24}");
+
+        TerminalController.TryParseResizeFrame(bytes, bytes.Length, out var cols, out var rows);
+
+        cols.Should().Be(0);
+        rows.Should().Be(0);
+    }
+
     // MARK: - BuildWelcomeBannerCommand (conductor #838 corrective)
 
     [Fact]


### PR DESCRIPTION
## Summary
- Resize control frames from Conductor's Ghostty surface (`{"type":"resize","cols":N,"rows":N}`) were being typed into the shell when the values fell outside `IsResizeMessage`'s internal bounds. A 5-row surface fired `rows=5`, the old `rows > 5` check rejected it as "not a resize frame", and the JSON fell through to `stdinStream.WriteAsync` / `session.WriteAsync`.
- Split frame recognition from value validation: `TryParseResizeFrame` matches by JSON shape only; `IsValidTerminalSize` decides whether the PTY-exec path applies the resize. Callers always swallow shape-matching frames.

## Repro
1. Open a Conductor container terminal.
2. Resize the surface so Ghostty computes < 6 rows or ≤ 10 cols (e.g. drag the divider).
3. Prior behavior: `{"type":"resize","cols":88,"rows":5}` appears on the prompt.
4. Fixed behavior: frame is swallowed; resize is silently dropped when below `IsValidTerminalSize` bounds.

## Test plan
- [x] Build passes (`dotnet build src/Andy.Containers.Api`)
- [x] All 89 `TerminalController` tests pass
- [x] New regression test covers the exact `(88, 5)` case from the report
- [x] New tests assert shape-match returns true for out-of-range values (separation of concerns) and false for non-resize input (shell commands, malformed JSON, wrong frame types)
- [ ] Smoke: drag a Conductor container-terminal divider to a tiny size — no JSON appears on the prompt

Related: conductor #836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)