### PR TITLE
feat(#316): capture + publish OutputArtifacts on run-terminal events

### DIFF
--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -403,6 +403,14 @@ try
     // the terminal run.* event to the outbox.
     builder.Services.AddScoped<IHeadlessRunner, HeadlessRunner>();
 
+    // rivoli-ai/andy-containers#316. Output-artifact collector:
+    // probes /workspace/.andy/outputs/ via IContainerService.ExecAsync
+    // at terminal-event time and emits the manifest on the run.* event
+    // payload (and persists onto Run.OutputArtifacts for the agent-run
+    // path). Scoped because the default impl pulls in the request-scoped
+    // IContainerService and a request-scoped logger.
+    builder.Services.AddScoped<IOutputArtifactCollector, FilesystemOutputArtifactCollector>();
+
     // AP5 (rivoli-ai/andy-containers#107). Mode dispatcher: selects the
     // run's container, transitions Pending → Provisioning, and routes
     // headless runs to the runner above (terminal/desktop modes branch

--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -30,6 +30,12 @@ public class ContainerOrchestrationService : IContainerService
     private readonly IDataProtector? _proxyTokenProtector;
     private readonly IBuildArtifactStore? _buildArtifactStore;
     private readonly IRegistryConfiguration? _registryConfiguration;
+    // rivoli-ai/andy-containers#316. Optional so the existing test
+    // surface (which doesn't construct one) keeps working; live DI
+    // always supplies FilesystemOutputArtifactCollector. When null,
+    // terminal events publish without an OutputArtifacts manifest —
+    // matches the v1 schema-version-1 wire shape exactly.
+    private readonly IOutputArtifactCollector? _artifactCollector;
 
     /// <summary>
     /// rivoli-ai/conductor#943. Data-protection purpose for encrypting
@@ -60,7 +66,8 @@ public class ContainerOrchestrationService : IContainerService
         IProxyTokenService? proxyTokenService = null,
         IDataProtectionProvider? dataProtection = null,
         IBuildArtifactStore? buildArtifactStore = null,
-        IRegistryConfiguration? registryConfiguration = null)
+        IRegistryConfiguration? registryConfiguration = null,
+        IOutputArtifactCollector? artifactCollector = null)
     {
         _db = db;
         _routing = routing;
@@ -84,6 +91,35 @@ public class ContainerOrchestrationService : IContainerService
         // pre-IM behaviour. Live DI always supplies both.
         _buildArtifactStore = buildArtifactStore;
         _registryConfiguration = registryConfiguration;
+        // #316. Optional; null = pre-#316 wire shape, no artifact
+        // manifest on the terminal event.
+        _artifactCollector = artifactCollector;
+    }
+
+    // rivoli-ai/andy-containers#316. Wraps the collector call so a
+    // misbehaving probe (exec failure, hash crash, timeout) can never
+    // block the terminal-event write. Returns null on any failure —
+    // the outbox helper omits the OutputArtifacts field when null,
+    // preserving the v1-compatible wire shape.
+    private async Task<IReadOnlyList<RunOutputArtifact>?> TryCollectArtifactsAsync(
+        Container container, CancellationToken ct)
+    {
+        if (_artifactCollector is null) return null;
+        try
+        {
+            return await _artifactCollector.CollectAsync(container, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Artifact collection failed for container {ContainerId}; emitting terminal event without manifest. {Message}",
+                container.Id, ex.Message);
+            return null;
+        }
     }
 
     /// <summary>
@@ -784,6 +820,13 @@ public class ContainerOrchestrationService : IContainerService
             throw new InvalidOperationException($"Container is {container.Status}, cannot stop");
 
         var infra = _providerFactory.GetProvider(container.Provider!);
+
+        // #316. Collect artifacts BEFORE stopping the container — the
+        // probe runs in-band via ExecAsync so the container must still
+        // be Running when we ask. A Stopped container would just yield
+        // an exec-failed warning and an empty manifest.
+        var artifacts = await TryCollectArtifactsAsync(container, ct);
+
         await infra.StopContainerAsync(container.ExternalId!, ct);
 
         container.Status = ContainerStatus.Stopped;
@@ -793,7 +836,8 @@ public class ContainerOrchestrationService : IContainerService
         var durationSeconds = (container.StartedAt.HasValue && container.StoppedAt.HasValue)
             ? (container.StoppedAt.Value - container.StartedAt.Value).TotalSeconds
             : (double?)null;
-        _db.AppendRunEvent(container, RunEventKind.Finished, exitCode: null, durationSeconds: durationSeconds);
+        _db.AppendRunEvent(container, RunEventKind.Finished,
+            exitCode: null, durationSeconds: durationSeconds, outputArtifacts: artifacts);
         await _db.SaveChangesAsync(ct);
     }
 
@@ -804,6 +848,16 @@ public class ContainerOrchestrationService : IContainerService
         activity?.SetTag("containerId", containerId.ToString()); // deprecated; removed in Andy.Telemetry 0.3.0 (OT7 / #1265)
 
         var container = await GetContainerAsync(containerId, ct);
+
+        // #316. Collect artifacts BEFORE the destroy call wipes the
+        // filesystem. Only meaningful while the container is still
+        // running; for already-stopped rows (e.g. a destroy after a
+        // prior stop) the probe will exec-fail and the helper returns
+        // null — terminal event still publishes, just without a manifest.
+        var artifacts = container.Status == ContainerStatus.Running
+            ? await TryCollectArtifactsAsync(container, ct)
+            : null;
+
         if (container.ExternalId is not null)
         {
             var infra = _providerFactory.GetProvider(container.Provider!);
@@ -829,7 +883,8 @@ public class ContainerOrchestrationService : IContainerService
         var destroyedDuration = (container.StartedAt.HasValue)
             ? (DateTime.UtcNow - container.StartedAt.Value).TotalSeconds
             : (double?)null;
-        _db.AppendRunEvent(container, RunEventKind.Cancelled, exitCode: null, durationSeconds: destroyedDuration);
+        _db.AppendRunEvent(container, RunEventKind.Cancelled,
+            exitCode: null, durationSeconds: destroyedDuration, outputArtifacts: artifacts);
         await _db.SaveChangesAsync(ct);
 
         Meters.ContainersDeleted.Add(1);

--- a/src/Andy.Containers.Api/Services/FilesystemOutputArtifactCollector.cs
+++ b/src/Andy.Containers.Api/Services/FilesystemOutputArtifactCollector.cs
@@ -1,0 +1,241 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Globalization;
+using Andy.Containers.Abstractions;
+using Andy.Containers.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// Default <see cref="IOutputArtifactCollector"/> for rivoli-ai/andy-containers#316.
+///
+/// Walks the agent's well-known outputs root inside the container by
+/// shelling out via <see cref="IContainerService.ExecAsync(Guid, string, TimeSpan, CancellationToken)"/>.
+/// Using the exec path (rather than a host bind-mount probe) makes the
+/// collector provider-agnostic — every provider that supports run
+/// execution can also support artifact collection without per-runtime
+/// workspace-path resolution.
+///
+/// The probe shell pipeline is one command:
+///
+/// <code>
+/// test -d /workspace/.andy/outputs &amp;&amp; \
+///   find /workspace/.andy/outputs -type f -print0 | \
+///   xargs -0 -I{} sh -c 'sz=$(stat -c %s "{}"); h=$(sha256sum "{}" | awk "{print \$1}"); echo "$sz\t$h\t{}"'
+/// </code>
+///
+/// Output is one record per line, TAB-separated:
+/// <c>size_bytes \t sha256 \t absolute_path</c>. We re-base
+/// <c>absolute_path</c> onto the outputs root to get the relative path.
+///
+/// All failures (exec error, non-zero exit, parse trouble, hashing
+/// trouble) collapse to "empty list + logged warning" — by contract,
+/// artifact collection must never block the terminal event. See
+/// <see cref="IOutputArtifactCollector"/>.
+///
+/// TODO #316.B: when a future Container.WorkspaceHostPath column lands
+/// (bind-mount-aware providers), short-circuit the exec round-trip and
+/// walk the host filesystem directly for those providers. The
+/// interface contract is the same either way; only the implementation
+/// differs.
+/// </summary>
+public sealed class FilesystemOutputArtifactCollector : IOutputArtifactCollector
+{
+    // Pinned by design in the issue (#316). The agent SDK plants files
+    // here; consumers know to look here. Changing it requires a
+    // coordinated bump on the agent side.
+    public const string OutputsRoot = "/workspace/.andy/outputs";
+
+    // Cap collection wall-clock so a misbehaving container can't wedge
+    // the terminal-event write. 30s is generous — sha256sum at ~500MB/s
+    // covers ~15GB of artifacts before we trip, which is well above any
+    // realistic agent output budget.
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly IContainerService _containers;
+    private readonly ILogger<FilesystemOutputArtifactCollector> _logger;
+
+    public FilesystemOutputArtifactCollector(
+        IContainerService containers,
+        ILogger<FilesystemOutputArtifactCollector> logger)
+    {
+        _containers = containers;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<RunOutputArtifact>> CollectAsync(
+        Container container,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(container);
+
+        // No external id → container never reached a runnable state.
+        // Nothing to scan; skip silently rather than fabricating an
+        // exec failure.
+        if (string.IsNullOrEmpty(container.ExternalId))
+        {
+            return Array.Empty<RunOutputArtifact>();
+        }
+
+        try
+        {
+            // -print0 / xargs -0 keeps spaces and quotes in filenames
+            // intact. The inner shell prints size, sha256, and the
+            // file path, tab-separated. `2>/dev/null` swallows
+            // permission-denied / vanished-file noise that would
+            // otherwise show up on stderr without changing the
+            // semantically-empty success case.
+            var script = $"if [ -d {OutputsRoot} ]; then " +
+                "find " + OutputsRoot + " -type f -print0 2>/dev/null | " +
+                "xargs -0 -I{} sh -c 'sz=$(stat -c %s \"{}\" 2>/dev/null); " +
+                "h=$(sha256sum \"{}\" 2>/dev/null | awk \"{print \\$1}\"); " +
+                "[ -n \"$sz\" ] && [ -n \"$h\" ] && printf \"%s\\t%s\\t%s\\n\" \"$sz\" \"$h\" \"{}\"'; " +
+                "fi";
+
+            var result = await _containers.ExecAsync(
+                container.Id, $"sh -c '{script.Replace("'", "'\\''")}'", ProbeTimeout, ct);
+
+            if (result.ExitCode != 0)
+            {
+                _logger.LogWarning(
+                    "Artifact probe in container {ContainerId} exited with code {ExitCode}; treating as empty manifest. StdErr: {StdErr}",
+                    container.Id, result.ExitCode, Truncate(result.StdErr, 500));
+                return Array.Empty<RunOutputArtifact>();
+            }
+
+            return ParseProbeOutput(result.StdOut);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Caller cancelled — propagate the cancel so the terminal
+            // path can decide whether to skip the event entirely.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to collect output artifacts from container {ContainerId}: {Message}",
+                container.Id, ex.Message);
+            return Array.Empty<RunOutputArtifact>();
+        }
+    }
+
+    // Parser is internal-visible-for-tests. Each line is
+    // `size_bytes \t sha256 \t absolute_path`. Lines that don't match
+    // the shape are skipped (defensive — a noisy shell could emit a
+    // banner line we don't want to corrupt the manifest with).
+    internal static IReadOnlyList<RunOutputArtifact> ParseProbeOutput(string? stdout)
+    {
+        if (string.IsNullOrWhiteSpace(stdout))
+        {
+            return Array.Empty<RunOutputArtifact>();
+        }
+
+        var results = new List<RunOutputArtifact>();
+        var rootWithSlash = OutputsRoot.EndsWith('/') ? OutputsRoot : OutputsRoot + "/";
+
+        foreach (var rawLine in stdout.Split('\n'))
+        {
+            var line = rawLine.TrimEnd('\r');
+            if (line.Length == 0) continue;
+
+            var parts = line.Split('\t');
+            if (parts.Length < 3) continue;
+
+            if (!long.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var size))
+            {
+                continue;
+            }
+
+            var sha = parts[1].Trim().ToLowerInvariant();
+            if (sha.Length != 64) continue;
+
+            // The path is parts[2..] re-joined (in case the file path
+            // itself contained a tab — unusual but POSIX-legal).
+            var absolutePath = string.Join('\t', parts.Skip(2));
+            string relativePath;
+            if (absolutePath.StartsWith(rootWithSlash, StringComparison.Ordinal))
+            {
+                relativePath = absolutePath[rootWithSlash.Length..];
+            }
+            else if (absolutePath == OutputsRoot)
+            {
+                // File is the root itself — shouldn't happen for -type f
+                // but tolerate it without crashing.
+                continue;
+            }
+            else
+            {
+                // Path outside our expected root: skip rather than
+                // mis-attribute. Could happen if `find` followed a
+                // symlink out of the tree — the artifact contract
+                // pins paths relative to the outputs root.
+                continue;
+            }
+
+            if (relativePath.Length == 0) continue;
+
+            var name = Path.GetFileName(relativePath);
+            var contentType = GuessContentType(name);
+
+            results.Add(new RunOutputArtifact(
+                Name: name,
+                RelativePath: relativePath,
+                SizeBytes: size,
+                Sha256: sha,
+                ContentType: contentType));
+        }
+
+        return results;
+    }
+
+    // Tiny static MIME map covering the extensions an agent run is
+    // most likely to produce. We deliberately don't pull in
+    // System.Web.MimeMapping — it brings the full ASP.NET hosting
+    // surface as a transitive dep, which is overkill for a 30-entry
+    // lookup. Unknown extensions return null and downstream consumers
+    // can fall back to application/octet-stream.
+    internal static string? GuessContentType(string fileName)
+    {
+        var ext = Path.GetExtension(fileName).ToLowerInvariant();
+        return ext switch
+        {
+            ".txt" or ".log" => "text/plain",
+            ".md" => "text/markdown",
+            ".json" => "application/json",
+            ".yaml" or ".yml" => "application/yaml",
+            ".xml" => "application/xml",
+            ".csv" => "text/csv",
+            ".tsv" => "text/tab-separated-values",
+            ".html" or ".htm" => "text/html",
+            ".pdf" => "application/pdf",
+            ".png" => "image/png",
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".gif" => "image/gif",
+            ".svg" => "image/svg+xml",
+            ".webp" => "image/webp",
+            ".zip" => "application/zip",
+            ".tar" => "application/x-tar",
+            ".gz" => "application/gzip",
+            ".tgz" => "application/gzip",
+            ".bz2" => "application/x-bzip2",
+            ".sh" => "application/x-sh",
+            ".py" => "text/x-python",
+            ".js" => "application/javascript",
+            ".ts" => "application/typescript",
+            ".cs" => "text/x-csharp",
+            ".go" => "text/x-go",
+            ".rs" => "text/x-rust",
+            ".sql" => "application/sql",
+            _ => null,
+        };
+    }
+
+    private static string? Truncate(string? value, int max)
+    {
+        if (string.IsNullOrEmpty(value)) return null;
+        return value.Length <= max ? value : value[..max] + "...";
+    }
+}

--- a/src/Andy.Containers.Api/Services/HeadlessRunner.cs
+++ b/src/Andy.Containers.Api/Services/HeadlessRunner.cs
@@ -17,6 +17,10 @@ public sealed class HeadlessRunner : IHeadlessRunner
     private readonly IRunCancellationRegistry _cancellation;
     private readonly ITokenIssuer _tokens;
     private readonly ILogger<HeadlessRunner> _logger;
+    // #316. Optional so the existing test surface keeps working.
+    // When null, terminal events publish without an OutputArtifacts
+    // manifest — pre-#316 wire shape exactly.
+    private readonly IOutputArtifactCollector? _artifactCollector;
 
     // Outer-watchdog grace: AQ3 honours limits.timeout_seconds internally
     // and exits with code 4 (→ RunEventKind.Timeout) when its CTS fires.
@@ -36,13 +40,15 @@ public sealed class HeadlessRunner : IHeadlessRunner
         ContainersDbContext db,
         IRunCancellationRegistry cancellation,
         ITokenIssuer tokens,
-        ILogger<HeadlessRunner> logger)
+        ILogger<HeadlessRunner> logger,
+        IOutputArtifactCollector? artifactCollector = null)
     {
         _containers = containers;
         _db = db;
         _cancellation = cancellation;
         _tokens = tokens;
         _logger = logger;
+        _artifactCollector = artifactCollector;
     }
 
     public async Task<HeadlessRunOutcome> StartAsync(Run run, string configPath, CancellationToken ct = default)
@@ -169,6 +175,37 @@ public sealed class HeadlessRunner : IHeadlessRunner
         int? exitCode, double? durationSeconds, string? error,
         CancellationToken ct)
     {
+        // #316. Collect artifacts BEFORE the persistence try/catch so a
+        // probe-time exec failure (logged inside the collector) can't
+        // accidentally short-circuit the terminal-event write. The
+        // collector runs only when AP5 assigned a container (no
+        // container → nothing inside which to scan).
+        IReadOnlyList<RunOutputArtifact>? artifacts = null;
+        if (_artifactCollector is not null && run.ContainerId is { } containerId)
+        {
+            try
+            {
+                var container = await _db.Containers.FindAsync(new object[] { containerId }, ct);
+                if (container is not null)
+                {
+                    artifacts = await _artifactCollector.CollectAsync(container, ct);
+                }
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // Caller cancelled the terminal write — let the parent
+                // catch handle it; don't mask with an artifact-collection
+                // log line.
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Artifact collection failed for Run {RunId}; emitting terminal event without manifest.",
+                    run.Id);
+            }
+        }
+
         try
         {
             // Best-effort transition. If the run is already terminal (e.g.
@@ -184,7 +221,7 @@ public sealed class HeadlessRunner : IHeadlessRunner
                 run.Error ??= error;
             }
 
-            _db.AppendAgentRunEvent(run, kind, exitCode, durationSeconds);
+            _db.AppendAgentRunEvent(run, kind, exitCode, durationSeconds, artifacts);
             await _db.SaveChangesAsync(ct);
         }
         catch (Exception ex)

--- a/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
+++ b/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
@@ -1,8 +1,10 @@
+using System.Text.Json;
 using Andy.Containers.Messaging;
 using Andy.Containers.Models;
 using Andy.Containers.Models.ImageManagement;
 using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Andy.Containers.Infrastructure.Data;
 
@@ -352,6 +354,38 @@ public class ContainersDbContext : DbContext, IDataProtectionKeyContext
                 wr.Property(w => w.WorkspaceId).HasColumnName("WorkspaceRef_WorkspaceId");
                 wr.Property(w => w.Branch).HasColumnName("WorkspaceRef_Branch").HasMaxLength(200);
             });
+
+            // OutputArtifacts (rivoli-ai/andy-containers#316). Persisted as
+            // JSON so the schema can absorb shape changes (new fields on
+            // RunOutputArtifact) without a per-field migration. We
+            // round-trip the IReadOnlyList<RunOutputArtifact> through a
+            // value converter rather than EF's OwnsMany(...).ToJson()
+            // because the latter requires a parent navigation reference
+            // and would force us to either model RunOutputArtifact as a
+            // mutable entity or rebuild the collection on every read —
+            // both worse than a single JSON column for an essentially
+            // append-only list. Comparer uses sequence equality so EF
+            // change-tracking notices replacements (entire-list swaps,
+            // which is the only mutation pattern callers use today).
+            var jsonOpts = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+            var outputArtifactsConverter = new Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter<
+                IReadOnlyList<RunOutputArtifact>?, string?>(
+                v => v == null ? null : JsonSerializer.Serialize(v, jsonOpts),
+                v => string.IsNullOrEmpty(v)
+                    ? null
+                    : JsonSerializer.Deserialize<List<RunOutputArtifact>>(v, jsonOpts));
+            var outputArtifactsComparer = new ValueComparer<IReadOnlyList<RunOutputArtifact>?>(
+                (a, b) => ReferenceEquals(a, b) || (a != null && b != null && a.SequenceEqual(b)),
+                v => v == null ? 0 : v.Aggregate(0, (h, x) => HashCode.Combine(h, x.GetHashCode())),
+                v => v == null ? null : v.ToList());
+            var outputArtifactsProp = e.Property(r => r.OutputArtifacts)
+                .HasConversion(outputArtifactsConverter)
+                .Metadata;
+            outputArtifactsProp.SetValueComparer(outputArtifactsComparer);
+            if (jsonColumnType != null)
+            {
+                e.Property(r => r.OutputArtifacts).HasColumnType(jsonColumnType);
+            }
         });
 
         // EnvironmentProfile — catalog of runtime shapes (X1, rivoli-ai/andy-containers#90).

--- a/src/Andy.Containers.Infrastructure/Messaging/RunEventOutbox.cs
+++ b/src/Andy.Containers.Infrastructure/Messaging/RunEventOutbox.cs
@@ -18,19 +18,27 @@ public static class RunEventOutbox
     // Container-lifecycle variant. Subject is keyed on Container.Id —
     // this is the legacy run.* path used by the provisioning worker /
     // orchestration service for create/stop/destroy transitions.
+    //
+    // outputArtifacts (rivoli-ai/andy-containers#316) is optional and
+    // flows straight into the payload. The container path does not
+    // persist artifacts onto the Container entity (no column) — the
+    // agent-run path is where replay matters; here we publish in-memory
+    // and let consumers store them downstream.
     public static void AppendRunEvent(
         this ContainersDbContext db,
         Container container,
         RunEventKind kind,
         int? exitCode = null,
-        double? durationSeconds = null)
+        double? durationSeconds = null,
+        IReadOnlyList<RunOutputArtifact>? outputArtifacts = null)
     {
         var payload = new RunEventPayload(
             RunId: container.Id,
             StoryId: container.StoryId,
             Status: container.Status.ToString(),
             ExitCode: exitCode,
-            DurationSeconds: durationSeconds);
+            DurationSeconds: durationSeconds,
+            OutputArtifacts: outputArtifacts);
 
         var subject = $"andy.containers.events.run.{container.Id}.{kind.ToSubjectKind()}";
 
@@ -54,19 +62,35 @@ public static class RunEventOutbox
     // back to the run row directly. Status mirrors Run.Status; the
     // CorrelationId chain prefers Run.CorrelationId over a fresh id so
     // ADR-0001 header semantics are preserved end-to-end.
+    //
+    // outputArtifacts (rivoli-ai/andy-containers#316) is additionally
+    // persisted on Run.OutputArtifacts so a late subscriber can replay
+    // the manifest off the entity even after the outbox row has been
+    // dispatched + reaped.
     public static void AppendAgentRunEvent(
         this ContainersDbContext db,
         Run run,
         RunEventKind kind,
         int? exitCode = null,
-        double? durationSeconds = null)
+        double? durationSeconds = null,
+        IReadOnlyList<RunOutputArtifact>? outputArtifacts = null)
     {
+        // Persist onto the Run row first so the payload and the entity
+        // agree byte-for-byte (the payload reads `run.OutputArtifacts`
+        // back via the local variable — assigning before serialise keeps
+        // the in-memory and on-the-wire copies identical).
+        if (outputArtifacts is not null)
+        {
+            run.OutputArtifacts = outputArtifacts;
+        }
+
         var payload = new RunEventPayload(
             RunId: run.Id,
             StoryId: null,
             Status: run.Status.ToString(),
             ExitCode: exitCode,
-            DurationSeconds: durationSeconds);
+            DurationSeconds: durationSeconds,
+            OutputArtifacts: outputArtifacts);
 
         var subject = $"andy.containers.events.run.{run.Id}.{kind.ToSubjectKind()}";
 

--- a/src/Andy.Containers.Infrastructure/Migrations/20260518201313_AddRunOutputArtifacts.Designer.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260518201313_AddRunOutputArtifacts.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Andy.Containers.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Containers.Infrastructure.Migrations
 {
     [DbContext(typeof(ContainersDbContext))]
-    partial class ContainersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260518201313_AddRunOutputArtifacts")]
+    partial class AddRunOutputArtifacts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Containers.Infrastructure/Migrations/20260518201313_AddRunOutputArtifacts.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260518201313_AddRunOutputArtifacts.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Containers.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRunOutputArtifacts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OutputArtifacts",
+                table: "Runs",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OutputArtifacts",
+                table: "Runs");
+        }
+    }
+}

--- a/src/Andy.Containers/Abstractions/IOutputArtifactCollector.cs
+++ b/src/Andy.Containers/Abstractions/IOutputArtifactCollector.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Models;
+
+namespace Andy.Containers.Abstractions;
+
+/// <summary>
+/// Walks the well-known outputs directory inside a container and
+/// produces a structured manifest of artifacts to publish on the
+/// terminal run event.
+///
+/// Issue rivoli-ai/andy-containers#316. The default contract:
+///
+/// <list type="bullet">
+///   <item>Scan path is <c>/workspace/.andy/outputs/</c> inside the
+///   container.</item>
+///   <item>Walk is recursive. <see cref="RunOutputArtifact.RelativePath"/>
+///   is the file's path relative to that root, forward-slash
+///   separated.</item>
+///   <item>Missing directory → empty list (no error).</item>
+///   <item>Any internal failure must surface as an empty list and a
+///   logged warning — artifact collection is best-effort and must
+///   never block the terminal event from being written.</item>
+/// </list>
+///
+/// Implementations are free to read the filesystem directly (when the
+/// workspace is bind-mounted host-side) or shell out via
+/// <see cref="IInfrastructureProvider.ExecAsync(string, string, CancellationToken)"/>
+/// to inspect the container in-band. The default implementation uses
+/// the exec path so it works for every provider that supports
+/// <see cref="ProviderCapabilities.SupportsExec"/>.
+/// </summary>
+public interface IOutputArtifactCollector
+{
+    Task<IReadOnlyList<RunOutputArtifact>> CollectAsync(
+        Container container,
+        CancellationToken ct = default);
+}

--- a/src/Andy.Containers/Messaging/Events/RunEvents.cs
+++ b/src/Andy.Containers/Messaging/Events/RunEvents.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using Andy.Containers.Models;
+
 namespace Andy.Containers.Messaging.Events;
 
 // Payload for andy.containers.events.run.{runId}.{kind} events, per
@@ -11,14 +13,26 @@ namespace Andy.Containers.Messaging.Events;
 // stamped by the caller (andy-issues' SandboxService) at create time.
 // Status mirrors the Container's terminal state so consumers don't
 // need to parse the subject's trailing kind token.
+//
+// OutputArtifacts (rivoli-ai/andy-containers#316) is the v2 addition.
+// Producers populate it at terminal-event time by walking the agent's
+// well-known outputs root. Nullable on the wire (and omitted by the
+// EventJson WhenWritingNull policy) so legacy v1 consumers continue to
+// deserialise without schema friction; consumers that opt in
+// (andy-tasks#275) project it onto TaskNode.OutputDocRefs.
 public sealed record RunEventPayload(
     Guid RunId,
     Guid? StoryId,
     string Status,
     int? ExitCode,
-    double? DurationSeconds)
+    double? DurationSeconds,
+    IReadOnlyList<RunOutputArtifact>? OutputArtifacts = null)
 {
-    public const int SchemaVersion = 1;
+    // Bumped to 2 when OutputArtifacts landed. New consumers can
+    // gate behaviour on schema_version >= 2; v1 consumers ignore
+    // the new field (the property is omitted when null and EventJson
+    // tolerates unknown properties on read).
+    public const int SchemaVersion = 2;
 
     public int Schema_Version => SchemaVersion;
 }

--- a/src/Andy.Containers/Models/Run.cs
+++ b/src/Andy.Containers/Models/Run.cs
@@ -54,6 +54,19 @@ public class Run
     public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
 
     /// <summary>
+    /// Manifest of files produced by the agent in the well-known outputs
+    /// directory (<c>/workspace/.andy/outputs/</c>), collected at
+    /// terminal-event time. Persisted as JSON (jsonb on Postgres, TEXT on
+    /// SQLite) so late subscribers can replay the artifact list without
+    /// rescanning the (potentially torn-down) container.
+    ///
+    /// Issue rivoli-ai/andy-containers#316. Companion field on the wire
+    /// event lives at <c>RunEventPayload.OutputArtifacts</c>; the two are
+    /// always written together by <c>RunEventOutbox.AppendAgentRunEvent</c>.
+    /// </summary>
+    public IReadOnlyList<RunOutputArtifact>? OutputArtifacts { get; set; }
+
+    /// <summary>
     /// Transition the run to <paramref name="next"/> according to AP1's state-machine
     /// invariants. Throws <see cref="InvalidOperationException"/> for illegal
     /// transitions so callers cannot silently corrupt history.

--- a/src/Andy.Containers/Models/RunOutputArtifact.cs
+++ b/src/Andy.Containers/Models/RunOutputArtifact.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Containers.Models;
+
+/// <summary>
+/// One file produced by an agent run, surfaced on the terminal
+/// <c>andy.containers.events.run.{id}.*</c> event payload and on the
+/// persisted <see cref="Run.OutputArtifacts"/> column.
+///
+/// Issue rivoli-ai/andy-containers#316. Consumed by andy-tasks#275
+/// (upload to andy-docs + persist as <c>TaskNode.OutputDocRefs</c>) and
+/// by Conductor's <c>TaskArtifactsCardView</c> via that consumer.
+/// </summary>
+/// <param name="Name">
+/// Basename of the produced file (e.g. <c>report.pdf</c>). Useful for
+/// display when the relative path is uninformative.
+/// </param>
+/// <param name="RelativePath">
+/// Path of the file relative to the agent's well-known outputs root
+/// (<c>/workspace/.andy/outputs/</c>). Forward-slash separated.
+/// </param>
+/// <param name="SizeBytes">
+/// File size in bytes at collection time. Captured at terminal so a
+/// late mutation by the agent post-exit is observed.
+/// </param>
+/// <param name="Sha256">
+/// Hex-encoded SHA-256 of the file contents. Lower-case, no leading
+/// "sha256:" prefix — consumers add their own scheme tag if needed.
+/// </param>
+/// <param name="ContentType">
+/// MIME type guessed from the filename extension. Null when the
+/// extension is unknown or the file has none.
+/// </param>
+public sealed record RunOutputArtifact(
+    string Name,
+    string RelativePath,
+    long SizeBytes,
+    string Sha256,
+    string? ContentType);

--- a/tests/Andy.Containers.Api.Tests/Messaging/RunEventOutboxTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Messaging/RunEventOutboxTests.cs
@@ -154,4 +154,182 @@ public class RunEventOutboxTests
         var entry = await db.OutboxEntries.SingleAsync();
         entry.CorrelationId.Should().Be(run.Id);
     }
+
+    // ----- rivoli-ai/andy-containers#316 OutputArtifacts coverage -----
+
+    [Fact]
+    public async Task AppendAgentRunEvent_WithOutputArtifacts_PersistsOnRunAndSerialisesToPayload()
+    {
+        using var db = InMemoryDbHelper.CreateContext();
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "triage-agent",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            ContainerId = Guid.NewGuid(),
+            Status = RunStatus.Succeeded,
+        };
+        db.Runs.Add(run);
+        await db.SaveChangesAsync();
+
+        var artifacts = new List<RunOutputArtifact>
+        {
+            new("report.pdf", "report.pdf", 12345, new string('a', 64), "application/pdf"),
+            new("data.json", "sub/data.json", 678, new string('b', 64), "application/json"),
+        };
+
+        db.AppendAgentRunEvent(run, RunEventKind.Finished,
+            exitCode: 0, durationSeconds: 4.2, outputArtifacts: artifacts);
+        await db.SaveChangesAsync();
+
+        // Persisted on the Run row.
+        var persisted = await db.Runs.FindAsync(run.Id);
+        persisted!.OutputArtifacts.Should().NotBeNull();
+        persisted.OutputArtifacts!.Should().HaveCount(2);
+        persisted.OutputArtifacts.Should().Contain(a =>
+            a.RelativePath == "report.pdf" && a.SizeBytes == 12345);
+
+        // Round-trips through the outbox payload as a snake_case array.
+        var entry = await db.OutboxEntries.SingleAsync();
+        using var doc = JsonDocument.Parse(entry.PayloadJson);
+        var root = doc.RootElement;
+        root.GetProperty("schema_version").GetInt32().Should().Be(RunEventPayload.SchemaVersion);
+        root.GetProperty("schema_version").GetInt32().Should().Be(2,
+            "OutputArtifacts shipped in the v2 wire shape");
+
+        var arr = root.GetProperty("output_artifacts");
+        arr.GetArrayLength().Should().Be(2);
+        arr[0].GetProperty("name").GetString().Should().Be("report.pdf");
+        arr[0].GetProperty("relative_path").GetString().Should().Be("report.pdf");
+        arr[0].GetProperty("size_bytes").GetInt64().Should().Be(12345);
+        arr[0].GetProperty("sha256").GetString().Should().Be(new string('a', 64));
+        arr[0].GetProperty("content_type").GetString().Should().Be("application/pdf");
+    }
+
+    [Fact]
+    public async Task AppendAgentRunEvent_WithoutOutputArtifacts_OmitsFieldFromPayload()
+    {
+        // Legacy callers (and the headless runner pre-#316 surface)
+        // pass no artifacts. The wire payload must omit the field so
+        // existing v1 consumers continue to decode without seeing a
+        // null where they expect "no field".
+        using var db = InMemoryDbHelper.CreateContext();
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "x",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            Status = RunStatus.Succeeded,
+        };
+        db.Runs.Add(run);
+        await db.SaveChangesAsync();
+
+        db.AppendAgentRunEvent(run, RunEventKind.Finished, exitCode: 0);
+        await db.SaveChangesAsync();
+
+        var entry = await db.OutboxEntries.SingleAsync();
+        using var doc = JsonDocument.Parse(entry.PayloadJson);
+        doc.RootElement.TryGetProperty("output_artifacts", out _).Should().BeFalse(
+            "EventJson omits null properties on write");
+
+        var persisted = await db.Runs.FindAsync(run.Id);
+        persisted!.OutputArtifacts.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AppendAgentRunEvent_EmptyArtifactList_StillSerialisedAsEmptyArray()
+    {
+        // The collector returns an empty list (not null) when the
+        // outputs directory exists but is empty. The payload should
+        // carry the empty array — that's semantically different from
+        // "no artifact collection ran".
+        using var db = InMemoryDbHelper.CreateContext();
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "x",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            Status = RunStatus.Succeeded,
+        };
+        db.Runs.Add(run);
+        await db.SaveChangesAsync();
+
+        db.AppendAgentRunEvent(run, RunEventKind.Finished,
+            exitCode: 0, outputArtifacts: Array.Empty<RunOutputArtifact>());
+        await db.SaveChangesAsync();
+
+        var entry = await db.OutboxEntries.SingleAsync();
+        using var doc = JsonDocument.Parse(entry.PayloadJson);
+        doc.RootElement.GetProperty("output_artifacts").GetArrayLength().Should().Be(0);
+
+        var persisted = await db.Runs.FindAsync(run.Id);
+        persisted!.OutputArtifacts.Should().NotBeNull();
+        persisted.OutputArtifacts!.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AppendRunEvent_WithOutputArtifacts_SurfacesOnContainerPayload()
+    {
+        // The container-lifecycle path also accepts the manifest.
+        // Container has no persisted column for it (decided in #316);
+        // we only verify the payload carries the array.
+        using var db = InMemoryDbHelper.CreateContext();
+        var container = new Container
+        {
+            Id = Guid.NewGuid(),
+            Name = "c",
+            OwnerId = "u",
+            Status = ContainerStatus.Stopped
+        };
+        var artifacts = new List<RunOutputArtifact>
+        {
+            new("out.txt", "out.txt", 11, new string('c', 64), "text/plain"),
+        };
+
+        db.AppendRunEvent(container, RunEventKind.Finished,
+            exitCode: 0, durationSeconds: 1.0, outputArtifacts: artifacts);
+        await db.SaveChangesAsync();
+
+        var entry = await db.OutboxEntries.SingleAsync();
+        using var doc = JsonDocument.Parse(entry.PayloadJson);
+        var arr = doc.RootElement.GetProperty("output_artifacts");
+        arr.GetArrayLength().Should().Be(1);
+        arr[0].GetProperty("name").GetString().Should().Be("out.txt");
+    }
+
+    [Fact]
+    public void RunEventPayload_RoundTripsThroughEventJson()
+    {
+        // Sanity: serialize then deserialize a populated payload with
+        // EventJson.Options. Snake-case property names must reach the
+        // consumer side cleanly.
+        var payload = new RunEventPayload(
+            RunId: Guid.NewGuid(),
+            StoryId: Guid.NewGuid(),
+            Status: "Succeeded",
+            ExitCode: 0,
+            DurationSeconds: 1.5,
+            OutputArtifacts: new[]
+            {
+                new RunOutputArtifact("r.pdf", "r.pdf", 99, new string('d', 64), "application/pdf"),
+            });
+
+        var json = JsonSerializer.Serialize(payload,
+            Andy.Containers.Messaging.EventJson.Options);
+        var back = JsonSerializer.Deserialize<RunEventPayload>(json,
+            Andy.Containers.Messaging.EventJson.Options);
+
+        back.Should().NotBeNull();
+        back!.RunId.Should().Be(payload.RunId);
+        back.OutputArtifacts.Should().NotBeNull();
+        back.OutputArtifacts!.Should().HaveCount(1);
+        back.OutputArtifacts![0].Name.Should().Be("r.pdf");
+        back.OutputArtifacts![0].Sha256.Should().Be(new string('d', 64));
+    }
 }

--- a/tests/Andy.Containers.Api.Tests/Services/FilesystemOutputArtifactCollectorTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/FilesystemOutputArtifactCollectorTests.cs
@@ -1,0 +1,315 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Abstractions;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+// rivoli-ai/andy-containers#316. Two test surfaces here:
+//   * ParseProbeOutput — pure parser, exhaustively covered (empty,
+//     single, nested, hidden, malformed lines, paths-with-tabs,
+//     paths-outside-root). No I/O.
+//   * CollectAsync — orchestration over IContainerService.ExecAsync.
+//     Mock the exec, assert the right command flows in and the
+//     output flows out. Failure paths collapse to empty list per the
+//     IOutputArtifactCollector contract.
+public class FilesystemOutputArtifactCollectorTests
+{
+    private const string Root = FilesystemOutputArtifactCollector.OutputsRoot;
+
+    // ----- ParseProbeOutput -----
+
+    [Fact]
+    public void Parse_EmptyOutput_ReturnsEmpty()
+    {
+        FilesystemOutputArtifactCollector.ParseProbeOutput("")
+            .Should().BeEmpty();
+        FilesystemOutputArtifactCollector.ParseProbeOutput(null)
+            .Should().BeEmpty();
+        FilesystemOutputArtifactCollector.ParseProbeOutput("   \n  \n")
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_SingleFile_ReturnsOneArtifactWithRelativePath()
+    {
+        // size=42, sha=64 hex chars, absolute path under root.
+        var sha = new string('a', 64);
+        var line = $"42\t{sha}\t{Root}/report.pdf";
+
+        var artifacts = FilesystemOutputArtifactCollector.ParseProbeOutput(line);
+
+        artifacts.Should().HaveCount(1);
+        artifacts[0].Name.Should().Be("report.pdf");
+        artifacts[0].RelativePath.Should().Be("report.pdf");
+        artifacts[0].SizeBytes.Should().Be(42);
+        artifacts[0].Sha256.Should().Be(sha);
+        artifacts[0].ContentType.Should().Be("application/pdf");
+    }
+
+    [Fact]
+    public void Parse_NestedFile_ReturnsRelativePathWithSubdir()
+    {
+        var sha = new string('b', 64);
+        var line = $"100\t{sha}\t{Root}/sub/dir/data.json";
+
+        var artifacts = FilesystemOutputArtifactCollector.ParseProbeOutput(line);
+
+        artifacts.Should().HaveCount(1);
+        artifacts[0].RelativePath.Should().Be("sub/dir/data.json");
+        artifacts[0].Name.Should().Be("data.json");
+        artifacts[0].ContentType.Should().Be("application/json");
+    }
+
+    [Fact]
+    public void Parse_MultipleLines_ReturnsAllArtifacts()
+    {
+        var sha1 = new string('1', 64);
+        var sha2 = new string('2', 64);
+        var sha3 = new string('3', 64);
+        var stdout = string.Join('\n', new[]
+        {
+            $"10\t{sha1}\t{Root}/a.txt",
+            $"20\t{sha2}\t{Root}/sub/b.log",
+            $"30\t{sha3}\t{Root}/c.zip",
+        });
+
+        var artifacts = FilesystemOutputArtifactCollector.ParseProbeOutput(stdout);
+
+        artifacts.Should().HaveCount(3);
+        artifacts.Select(a => a.RelativePath).Should().BeEquivalentTo(
+            new[] { "a.txt", "sub/b.log", "c.zip" });
+    }
+
+    [Fact]
+    public void Parse_HiddenFile_IsIncluded()
+    {
+        // Hidden files (leading dot) under the outputs root ARE
+        // included — the agent might legitimately want to publish a
+        // `.metadata` file alongside outputs. The `.andy` parent dir
+        // is just the chosen prefix; nothing magical about the dot
+        // inside the user's tree. Documented: included.
+        var sha = new string('c', 64);
+        var line = $"5\t{sha}\t{Root}/.metadata";
+
+        var artifacts = FilesystemOutputArtifactCollector.ParseProbeOutput(line);
+
+        artifacts.Should().HaveCount(1);
+        artifacts[0].Name.Should().Be(".metadata");
+        artifacts[0].RelativePath.Should().Be(".metadata");
+    }
+
+    [Fact]
+    public void Parse_MalformedLines_AreSkipped()
+    {
+        var sha = new string('d', 64);
+        var stdout = string.Join('\n', new[]
+        {
+            "notanumber\tdeadbeef\t/x",                          // bad size
+            $"42\tshort-sha\t{Root}/x.txt",                       // sha not 64 chars
+            $"42\t{sha}",                                          // missing path field
+            $"42\t{sha}\t{Root}/legit.txt",                       // good line
+            "",                                                    // empty
+            "garbage line with no tabs",                           // no tabs
+        });
+
+        var artifacts = FilesystemOutputArtifactCollector.ParseProbeOutput(stdout);
+
+        artifacts.Should().HaveCount(1);
+        artifacts[0].RelativePath.Should().Be("legit.txt");
+    }
+
+    [Fact]
+    public void Parse_PathOutsideRoot_IsSkipped()
+    {
+        // Symlink-followed paths that escape the outputs root must
+        // not be mis-attributed as artifacts. The contract pins paths
+        // relative to OutputsRoot; an absolute path elsewhere is
+        // skipped silently.
+        var sha = new string('e', 64);
+        var line = $"42\t{sha}\t/etc/passwd";
+
+        var artifacts = FilesystemOutputArtifactCollector.ParseProbeOutput(line);
+
+        artifacts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_PathWithEmbeddedTab_IsRecovered()
+    {
+        // POSIX filenames may contain tabs — the parser re-joins
+        // trailing tab-separated fields back into the path so a
+        // `weird\tname.txt` survives the round-trip.
+        var sha = new string('f', 64);
+        var line = $"7\t{sha}\t{Root}/weird\tname.txt";
+
+        var artifacts = FilesystemOutputArtifactCollector.ParseProbeOutput(line);
+
+        artifacts.Should().HaveCount(1);
+        artifacts[0].RelativePath.Should().Be("weird\tname.txt");
+        artifacts[0].Name.Should().Be("weird\tname.txt");
+    }
+
+    [Fact]
+    public void Parse_TrailingCarriageReturns_AreTolerated()
+    {
+        // sh/awk on Windows-mounted volumes can emit CRLF. The parser
+        // trims trailing \r so a cross-platform pipeline still produces
+        // a clean manifest.
+        var sha = new string('a', 64);
+        var line = $"42\t{sha}\t{Root}/x.txt\r";
+
+        var artifacts = FilesystemOutputArtifactCollector.ParseProbeOutput(line);
+
+        artifacts.Should().HaveCount(1);
+        artifacts[0].RelativePath.Should().Be("x.txt");
+    }
+
+    // ----- ContentType guessing -----
+
+    [Theory]
+    [InlineData("foo.txt", "text/plain")]
+    [InlineData("foo.json", "application/json")]
+    [InlineData("foo.pdf", "application/pdf")]
+    [InlineData("foo.png", "image/png")]
+    [InlineData("foo.tar.gz", "application/gzip")]  // by .gz extension
+    [InlineData("foo", null)]                        // no extension
+    [InlineData("foo.unknownext", null)]
+    public void GuessContentType_HandlesCommonExtensions(string name, string? expected)
+    {
+        FilesystemOutputArtifactCollector.GuessContentType(name).Should().Be(expected);
+    }
+
+    // ----- CollectAsync orchestration -----
+
+    [Fact]
+    public async Task Collect_NoExternalId_ReturnsEmpty_WithoutExec()
+    {
+        var containers = new Mock<IContainerService>();
+        var collector = new FilesystemOutputArtifactCollector(
+            containers.Object, NullLogger<FilesystemOutputArtifactCollector>.Instance);
+
+        var container = new Container
+        {
+            Id = Guid.NewGuid(),
+            Name = "no-external",
+            OwnerId = "u",
+            ExternalId = null,
+        };
+
+        var artifacts = await collector.CollectAsync(container);
+
+        artifacts.Should().BeEmpty();
+        containers.Verify(
+            c => c.ExecAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Collect_ExecExitsNonZero_ReturnsEmpty()
+    {
+        var containers = new Mock<IContainerService>();
+        containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExecResult { ExitCode = 1, StdErr = "find: permission denied" });
+
+        var collector = new FilesystemOutputArtifactCollector(
+            containers.Object, NullLogger<FilesystemOutputArtifactCollector>.Instance);
+
+        var container = new Container
+        {
+            Id = Guid.NewGuid(), Name = "c", OwnerId = "u", ExternalId = "ext-1",
+        };
+
+        var artifacts = await collector.CollectAsync(container);
+
+        artifacts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Collect_ExecThrows_ReturnsEmpty()
+    {
+        var containers = new Mock<IContainerService>();
+        containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("docker daemon unreachable"));
+
+        var collector = new FilesystemOutputArtifactCollector(
+            containers.Object, NullLogger<FilesystemOutputArtifactCollector>.Instance);
+
+        var container = new Container
+        {
+            Id = Guid.NewGuid(), Name = "c", OwnerId = "u", ExternalId = "ext-1",
+        };
+
+        var artifacts = await collector.CollectAsync(container);
+
+        artifacts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Collect_HappyPath_ReturnsParsedArtifacts()
+    {
+        var sha1 = new string('1', 64);
+        var sha2 = new string('2', 64);
+        var stdout = string.Join('\n', new[]
+        {
+            $"100\t{sha1}\t{Root}/report.pdf",
+            $"50\t{sha2}\t{Root}/logs/run.log",
+        });
+
+        var containers = new Mock<IContainerService>();
+        containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExecResult { ExitCode = 0, StdOut = stdout });
+
+        var collector = new FilesystemOutputArtifactCollector(
+            containers.Object, NullLogger<FilesystemOutputArtifactCollector>.Instance);
+
+        var container = new Container
+        {
+            Id = Guid.NewGuid(), Name = "c", OwnerId = "u", ExternalId = "ext-1",
+        };
+
+        var artifacts = await collector.CollectAsync(container);
+
+        artifacts.Should().HaveCount(2);
+        artifacts.Should().Contain(a =>
+            a.RelativePath == "report.pdf" && a.Sha256 == sha1 && a.SizeBytes == 100);
+        artifacts.Should().Contain(a =>
+            a.RelativePath == "logs/run.log" && a.Sha256 == sha2 && a.SizeBytes == 50);
+    }
+
+    [Fact]
+    public async Task Collect_PropagatesCallerCancellation()
+    {
+        var containers = new Mock<IContainerService>();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var collector = new FilesystemOutputArtifactCollector(
+            containers.Object, NullLogger<FilesystemOutputArtifactCollector>.Instance);
+
+        var container = new Container
+        {
+            Id = Guid.NewGuid(), Name = "c", OwnerId = "u", ExternalId = "ext-1",
+        };
+
+        var act = () => collector.CollectAsync(container, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
@@ -390,6 +390,142 @@ public class HeadlessRunnerTests : IDisposable
             "ADR-0001 root-causation chain must propagate from the Run");
     }
 
+    // ----- rivoli-ai/andy-containers#316 OutputArtifacts wiring -----
+
+    [Fact]
+    public async Task StartAsync_WithArtifactCollector_PersistsAndPublishesArtifacts()
+    {
+        // End-to-end through the runner's terminal path: collector is
+        // invoked, results land on Run.OutputArtifacts AND on the
+        // outbox payload's output_artifacts array.
+        var artifacts = new List<RunOutputArtifact>
+        {
+            new("report.pdf", "report.pdf", 100, new string('a', 64), "application/pdf"),
+            new("data.json", "sub/data.json", 50, new string('b', 64), "application/json"),
+        };
+        var collector = new Mock<IOutputArtifactCollector>();
+        collector
+            .Setup(c => c.CollectAsync(It.IsAny<Container>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(artifacts);
+
+        // Seed a real container row so the runner can FindAsync it.
+        var run = SeedRun();
+        SeedContainer(run.ContainerId!.Value);
+
+        var runner = new HeadlessRunner(
+            _containers.Object, _db, _cancellation, _tokens.Object,
+            NullLogger<HeadlessRunner>.Instance, collector.Object);
+        SetupExec(run.ContainerId.Value, exitCode: 0);
+
+        await runner.StartAsync(run, "/tmp/x/config.json");
+
+        var persisted = await _db.Runs.FindAsync(run.Id);
+        persisted!.OutputArtifacts.Should().HaveCount(2);
+        persisted.OutputArtifacts!.Should().Contain(a => a.RelativePath == "report.pdf");
+
+        var entry = await _db.OutboxEntries.SingleAsync();
+        using var doc = JsonDocument.Parse(entry.PayloadJson);
+        var arr = doc.RootElement.GetProperty("output_artifacts");
+        arr.GetArrayLength().Should().Be(2);
+        arr[0].GetProperty("relative_path").GetString().Should().Be("report.pdf");
+
+        collector.Verify(
+            c => c.CollectAsync(It.Is<Container>(ct => ct.Id == run.ContainerId.Value),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task StartAsync_CollectorThrows_TerminalEventStillWritten()
+    {
+        // Collector failures must NEVER block the terminal-event write.
+        // The runner logs and proceeds with a null manifest (no
+        // output_artifacts field on the payload).
+        var collector = new Mock<IOutputArtifactCollector>();
+        collector
+            .Setup(c => c.CollectAsync(It.IsAny<Container>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("probe exec died"));
+
+        var run = SeedRun();
+        SeedContainer(run.ContainerId!.Value);
+
+        var runner = new HeadlessRunner(
+            _containers.Object, _db, _cancellation, _tokens.Object,
+            NullLogger<HeadlessRunner>.Instance, collector.Object);
+        SetupExec(run.ContainerId.Value, exitCode: 0);
+
+        var outcome = await runner.StartAsync(run, "/tmp/x/config.json");
+
+        outcome.Status.Should().Be(RunStatus.Succeeded,
+            "collector failures must not corrupt the run outcome");
+
+        var entry = await _db.OutboxEntries.SingleAsync();
+        entry.Subject.Should().EndWith(".finished");
+
+        using var doc = JsonDocument.Parse(entry.PayloadJson);
+        doc.RootElement.TryGetProperty("output_artifacts", out _).Should().BeFalse(
+            "a failed probe omits the field so v1 consumers stay happy");
+
+        var persisted = await _db.Runs.FindAsync(run.Id);
+        persisted!.OutputArtifacts.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task StartAsync_NoCollector_BehavesLikePreFix()
+    {
+        // Pre-#316 wire shape: no collector configured → payload
+        // omits output_artifacts entirely, Run.OutputArtifacts stays null.
+        var run = SeedRun();
+        SetupExec(run.ContainerId!.Value, exitCode: 0);
+
+        // Default _runner (constructed in the class ctor) has no
+        // collector. Exercise it directly.
+        await _runner.StartAsync(run, "/tmp/x/config.json");
+
+        var entry = await _db.OutboxEntries.SingleAsync();
+        using var doc = JsonDocument.Parse(entry.PayloadJson);
+        doc.RootElement.TryGetProperty("output_artifacts", out _).Should().BeFalse();
+
+        var persisted = await _db.Runs.FindAsync(run.Id);
+        persisted!.OutputArtifacts.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task StartAsync_NoContainerId_DoesNotInvokeCollector()
+    {
+        // AP5 never assigned a container → nothing to scan, no exec
+        // round-trip to spend.
+        var collector = new Mock<IOutputArtifactCollector>();
+        var run = SeedRunWithoutContainer();
+
+        var runner = new HeadlessRunner(
+            _containers.Object, _db, _cancellation, _tokens.Object,
+            NullLogger<HeadlessRunner>.Instance, collector.Object);
+
+        await runner.StartAsync(run, "/tmp/x/config.json");
+
+        collector.Verify(
+            c => c.CollectAsync(It.IsAny<Container>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private void SeedContainer(Guid containerId)
+    {
+        // Minimal Container row for the runner's collector-path FindAsync.
+        // The Container Status doesn't matter for these tests since the
+        // mocked collector ignores it; we still seed it as Running for
+        // realism.
+        _db.Containers.Add(new Container
+        {
+            Id = containerId,
+            Name = $"c-{containerId:N}",
+            OwnerId = "u",
+            ExternalId = "ext-" + containerId.ToString("N")[..8],
+            Status = ContainerStatus.Running,
+        });
+        _db.SaveChanges();
+    }
+
     // Writes a real headless config to a temp file so the runner can
     // parse limits.timeout_seconds. Other fields are placeholders — only
     // the limits block is exercised by these tests, but a complete object

--- a/tests/Andy.Containers.Integration.Tests/Data/RunRepositoryTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/Data/RunRepositoryTests.cs
@@ -197,6 +197,107 @@ public class RunRepositoryTests : IAsyncLifetime
         reloaded.EndedAt.Should().BeNull();
     }
 
+    // ----- rivoli-ai/andy-containers#316 OutputArtifacts column -----
+
+    [Fact]
+    public async Task Run_OutputArtifactsColumn_RoundTripsAsJson()
+    {
+        // Verifies the new column added in AddRunOutputArtifacts:
+        // a List<RunOutputArtifact> persists, reloads byte-for-byte
+        // through EF's value converter, and survives a fresh DbContext
+        // (i.e. not memoised on the change-tracker).
+        var artifacts = new List<RunOutputArtifact>
+        {
+            new("report.pdf", "report.pdf", 12345, new string('a', 64), "application/pdf"),
+            new("data.json", "sub/data.json", 67, new string('b', 64), "application/json"),
+        };
+        var run = new Run
+        {
+            AgentId = "artifact-agent",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            OutputArtifacts = artifacts,
+        };
+        _db.Runs.Add(run);
+        await _db.SaveChangesAsync();
+
+        using var otherDb = new ContainersDbContext(
+            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).Options);
+        var reloaded = await otherDb.Runs.SingleAsync(r => r.Id == run.Id);
+
+        reloaded.OutputArtifacts.Should().NotBeNull();
+        reloaded.OutputArtifacts!.Should().HaveCount(2);
+        reloaded.OutputArtifacts.Should().BeEquivalentTo(artifacts);
+    }
+
+    [Fact]
+    public async Task Run_OutputArtifactsColumn_DefaultsToNull()
+    {
+        // Existing rows (pre-#316) must continue to deserialise with
+        // OutputArtifacts == null, not as an empty list — empty-list
+        // means "we ran a probe and it found nothing", null means
+        // "we never collected".
+        var run = new Run
+        {
+            AgentId = "no-artifacts",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+        };
+        _db.Runs.Add(run);
+        await _db.SaveChangesAsync();
+
+        using var otherDb = new ContainersDbContext(
+            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).Options);
+        var reloaded = await otherDb.Runs.SingleAsync(r => r.Id == run.Id);
+
+        reloaded.OutputArtifacts.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Run_OutputArtifactsColumn_PersistsAsTextOnSqlite()
+    {
+        // The schema-level invariant: a JSON-converted column lands as
+        // a TEXT cell on SQLite (and jsonb on Postgres — covered by the
+        // migration file). Probing the raw cell guards against EF
+        // silently picking a different storage shape across upgrades.
+        var run = new Run
+        {
+            AgentId = "x",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            OutputArtifacts = new[]
+            {
+                new RunOutputArtifact("a.txt", "a.txt", 1, new string('a', 64), "text/plain")
+            },
+        };
+        _db.Runs.Add(run);
+        await _db.SaveChangesAsync();
+
+        var cmd = _conn.CreateCommand();
+        cmd.CommandText = "SELECT OutputArtifacts FROM Runs LIMIT 1";
+        var raw = await cmd.ExecuteScalarAsync() as string;
+        raw.Should().NotBeNull();
+        raw.Should().Contain("a.txt").And.Contain("text/plain");
+    }
+
+    [Fact]
+    public async Task Run_OutputArtifactsColumn_ListedInTableInfo()
+    {
+        var cmd = _conn.CreateCommand();
+        cmd.CommandText = "SELECT name FROM pragma_table_info('Runs') ORDER BY cid";
+        using var reader = await cmd.ExecuteReaderAsync();
+        var columns = new List<string>();
+        while (await reader.ReadAsync())
+        {
+            columns.Add(reader.GetString(0));
+        }
+        columns.Should().Contain("OutputArtifacts",
+            "the AddRunOutputArtifacts migration / model config must have created this column");
+    }
+
     [Fact]
     public async Task Run_QueryByStatus_UsesIndexedColumn()
     {


### PR DESCRIPTION
## Summary

Producer-side of rivoli-ai/andy-containers#316: terminal `andy.containers.events.run.{id}.*` events now carry an optional `output_artifacts` manifest, and the agent-run path persists it onto a new `Run.OutputArtifacts` JSON column for replay. Unblocks rivoli-ai/andy-tasks#275 (consumer-side upload to andy-docs) and rivoli-ai/conductor#1223 (`TaskArtifactsCardView` empty-state).

## What landed

**Wire shape (RunEventPayload bumped to schema_version 2):**
- New `output_artifacts: [{ name, relative_path, size_bytes, sha256, content_type }]` field
- Nullable / omitted by default — pre-#316 v1 consumers continue to decode unchanged
- Snake-case round-trips through `EventJson.Options`

**Collection (`FilesystemOutputArtifactCollector`):**
- Probes `/workspace/.andy/outputs/` inside the container via `IContainerService.ExecAsync`
- Portable across every provider that supports exec — no per-runtime workspace-path resolution required
- One shell pipeline emits `size \t sha256 \t absolute_path` per file; parser re-bases onto the outputs root
- Wall-clock capped at 30s; any exec / parse / hash failure collapses to an empty list + logged warning
- MIME guess via a tiny static extension map (avoids pulling `System.Web.MimeMapping`)

**Producer wiring:**
- `ContainerOrchestrationService.StopContainerAsync` / `DestroyContainerAsync` collect BEFORE stopping/destroying so the filesystem is still reachable
- `HeadlessRunner.TerminateAsync` collects before persisting the terminal event
- Collector failures caught + logged; terminal event always lands (artifact collection must never block the terminal write)

**Persistence:**
- `Run.OutputArtifacts` nullable JSON column (`jsonb` on Postgres, TEXT on SQLite) via EF value converter
- Migration: `AddRunOutputArtifacts` (`20260518201313`)
- `Container.OutputArtifacts` deliberately skipped — the agent-run path is where replay matters

## Tests

- `tests/Andy.Containers.Api.Tests/Services/FilesystemOutputArtifactCollectorTests.cs` (17 new) — parser (empty/single/nested/hidden/malformed/path-outside-root/embedded-tab/CRLF), MIME guess, orchestration over mocked `IContainerService` (no-external-id / non-zero exit / throw / happy path / cancellation propagation)
- `tests/Andy.Containers.Api.Tests/Messaging/RunEventOutboxTests.cs` (+5) — `AppendAgentRunEvent` persists onto Run + serialises to payload; without-artifacts omits the field; empty list serialises as empty array; container-path variant; `RunEventPayload` round-trips through `EventJson`
- `tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs` (+4) — collector wired through full terminal path; collector-throws keeps the event; no-collector behaves like pre-#316; no-container-id skips collector
- `tests/Andy.Containers.Integration.Tests/Data/RunRepositoryTests.cs` (+4) — column round-trip via real EF + SQLite; null default; raw TEXT shape; `pragma_table_info` presence

`PendingMigrationGuardTests` is green — model snapshot matches the new migration.

## Follow-ups

- **TODO #316.B** (commented in `FilesystemOutputArtifactCollector`): a future `Container.WorkspaceHostPath` column would let bind-mount-aware providers (local Docker, Apple Containers) short-circuit the exec round-trip and walk the host filesystem directly. Same `IOutputArtifactCollector` contract; cheaper implementation. Out of scope for this PR.

## Test plan

- [x] `dotnet build` (clean, 0 warnings)
- [x] `dotnet ef migrations add AddRunOutputArtifacts` — generated cleanly
- [x] `dotnet test` — 1689 passed / 0 failed / 9 skipped (the 1 skip in API + 8 environment-gated skips in Integration are pre-existing; nothing flipped state)
- [ ] Once andy-tasks#275 lands, end-to-end verify a run with files under `/workspace/.andy/outputs/` surfaces on the Conductor task card

## Notes for review

- The collector lives in `Andy.Containers.Api` because it depends on `IContainerService` (which lives in `Andy.Containers.Abstractions` but is only implemented in the API project). The interface itself is in `Andy.Containers/Abstractions` per the prescription.
- `RunEventPayload.OutputArtifacts` is a positional-record parameter with a default of `null` — keeps the existing 5-positional-arg call sites compiling without a churn pass.
- DI registration in `Program.cs` is `AddScoped` because the default impl depends on the request-scoped `IContainerService` and logger.