### PR TITLE
feat(#320): upload OutputArtifact bytes to andy-docs during collection

### DIFF
--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -4,6 +4,7 @@ using Andy.Containers.Api.Data;
 using Andy.Containers.Api.Services;
 using Andy.Containers.Configurator;
 using Andy.Containers.DependencyInjection;
+using Andy.Containers.Infrastructure.Audit;
 using Andy.Containers.Infrastructure.Build.Local;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Infrastructure.Messaging;
@@ -403,12 +404,72 @@ try
     // the terminal run.* event to the outbox.
     builder.Services.AddScoped<IHeadlessRunner, HeadlessRunner>();
 
+    // rivoli-ai/andy-containers#320. andy-docs HTTP client for the
+    // output-artifact collector. Registered only when AndyDocs:ApiBaseUrl
+    // is set so dev / embedded mode (no andy-docs instance) does NOT
+    // fail at startup; in that mode the collector falls back to
+    // metadata-only artifacts (DocsRef stays null on every emitted
+    // RunOutputArtifact, matching the pre-#320 wire shape exactly).
+    builder.Services.Configure<AndyDocsOptions>(
+        builder.Configuration.GetSection(AndyDocsOptions.SectionName));
+    var docsBaseUrl = builder.Configuration[$"{AndyDocsOptions.SectionName}:ApiBaseUrl"];
+    if (!string.IsNullOrWhiteSpace(docsBaseUrl))
+    {
+        var docsOptions = builder.Configuration
+            .GetSection(AndyDocsOptions.SectionName)
+            .Get<AndyDocsOptions>() ?? new AndyDocsOptions();
+        var docsBuilder = builder.Services.AddHttpClient(AndyDocsHttpClient.HttpClientName, client =>
+        {
+            // Trailing slash so URI resolution preserves any path
+            // prefix (e.g. embedded mode where the base might be
+            // http://localhost:9100/docs).
+            client.BaseAddress = new Uri(docsBaseUrl.TrimEnd('/') + "/");
+            client.Timeout = docsOptions.Timeout;
+        });
+        // Attach the M2M bearer when AndyAuth is configured. In bypass
+        // mode (Authority empty) we leave the client anonymous, mirroring
+        // the existing AndyModels / inbound JWT-bearer postures.
+        var docsAuthority = builder.Configuration["AndyAuth:Authority"];
+        if (!string.IsNullOrWhiteSpace(docsAuthority))
+        {
+            var audience = docsOptions.Audience;
+            docsBuilder.AddHttpMessageHandler(sp =>
+            {
+                var tokens = sp.GetRequiredService<IServiceTokenService>();
+                var logger = sp.GetService<ILogger<ServiceBearerHandler>>();
+                return new ServiceBearerHandler(
+                    async ct =>
+                    {
+                        try
+                        {
+                            return await tokens.GetAccessTokenAsync(audience, ct);
+                        }
+                        catch (ServiceTokenException)
+                        {
+                            // Surface as "no token" — the handler then
+                            // sends anonymously and andy-docs replies
+                            // 401, which the client treats as a normal
+                            // upload failure (best-effort fallback).
+                            return null;
+                        }
+                    },
+                    logger);
+            });
+        }
+        builder.Services.AddSingleton<IAndyDocsClient, AndyDocsHttpClient>();
+    }
+
     // rivoli-ai/andy-containers#316. Output-artifact collector:
     // probes /workspace/.andy/outputs/ via IContainerService.ExecAsync
     // at terminal-event time and emits the manifest on the run.* event
     // payload (and persists onto Run.OutputArtifacts for the agent-run
     // path). Scoped because the default impl pulls in the request-scoped
     // IContainerService and a request-scoped logger.
+    //
+    // #320: the collector now also pushes each artifact's bytes to
+    // andy-docs via the optionally-registered IAndyDocsClient above.
+    // The dependency is optional — when the client isn't registered
+    // (no AndyDocs:ApiBaseUrl) the collector emits metadata-only.
     builder.Services.AddScoped<IOutputArtifactCollector, FilesystemOutputArtifactCollector>();
 
     // AP5 (rivoli-ai/andy-containers#107). Mode dispatcher: selects the

--- a/src/Andy.Containers.Api/Services/FilesystemOutputArtifactCollector.cs
+++ b/src/Andy.Containers.Api/Services/FilesystemOutputArtifactCollector.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Andy.Containers.Abstractions;
+using Andy.Containers.Infrastructure.Audit;
 using Andy.Containers.Models;
 using Microsoft.Extensions.Logging;
 
@@ -54,15 +55,38 @@ public sealed class FilesystemOutputArtifactCollector : IOutputArtifactCollector
     // realistic agent output budget.
     private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(30);
 
+    // rivoli-ai/andy-containers#320. Wall-clock cap on the per-file
+    // base64 read. Keep distinct from ProbeTimeout so a large artifact
+    // can't burn the whole probe budget on its first file. 60s
+    // accommodates a multi-hundred-MB artifact streamed through the
+    // exec channel; smaller files are the common case.
+    private static readonly TimeSpan ReadTimeout = TimeSpan.FromSeconds(60);
+
+    // rivoli-ai/andy-containers#320. Hard upload cap per artifact. The
+    // exec-channel base64 round-trip materialises the full payload in
+    // memory twice (once as base64 stdout, once as the decoded byte[]),
+    // so we cap at 64MiB to keep peak RSS bounded even when an agent
+    // produces a pathologically large file. Larger artifacts log a
+    // warning and are emitted metadata-only (no DocsRef).
+    private const long MaxUploadSizeBytes = 64L * 1024 * 1024;
+
     private readonly IContainerService _containers;
+    private readonly IAndyDocsClient? _andyDocs;
     private readonly ILogger<FilesystemOutputArtifactCollector> _logger;
 
     public FilesystemOutputArtifactCollector(
         IContainerService containers,
-        ILogger<FilesystemOutputArtifactCollector> logger)
+        ILogger<FilesystemOutputArtifactCollector> logger,
+        IAndyDocsClient? andyDocs = null)
     {
         _containers = containers;
         _logger = logger;
+        // rivoli-ai/andy-containers#320. Optional. When null, the
+        // collector operates in pre-#320 metadata-only mode — every
+        // emitted artifact has DocsRef=null. Live DI registers the
+        // client iff AndyDocs:ApiBaseUrl is set, so dev / embedded
+        // setups without andy-docs degrade cleanly.
+        _andyDocs = andyDocs;
     }
 
     public async Task<IReadOnlyList<RunOutputArtifact>> CollectAsync(
@@ -105,7 +129,22 @@ public sealed class FilesystemOutputArtifactCollector : IOutputArtifactCollector
                 return Array.Empty<RunOutputArtifact>();
             }
 
-            return ParseProbeOutput(result.StdOut);
+            var parsed = ParseProbeOutput(result.StdOut);
+
+            // rivoli-ai/andy-containers#320. After enumeration, push
+            // each artifact's bytes to andy-docs. The client is
+            // best-effort: failures collapse to a metadata-only entry
+            // (DocsRef stays null) so a transient andy-docs outage
+            // never blocks container stop. When the client isn't wired
+            // (DI didn't register one — typical in dev / embedded
+            // mode without an andy-docs instance), we short-circuit
+            // and return the parsed manifest unchanged.
+            if (_andyDocs is null || parsed.Count == 0)
+            {
+                return parsed;
+            }
+
+            return await UploadAndAttachDocsRefsAsync(container, parsed, ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -119,6 +158,149 @@ public sealed class FilesystemOutputArtifactCollector : IOutputArtifactCollector
                 "Failed to collect output artifacts from container {ContainerId}: {Message}",
                 container.Id, ex.Message);
             return Array.Empty<RunOutputArtifact>();
+        }
+    }
+
+    // rivoli-ai/andy-containers#320. Per-artifact byte read + andy-docs
+    // upload. One bad file MUST NOT kill the whole collection — each
+    // file is wrapped in its own try/catch so a single read failure
+    // or upload error just leaves that one artifact metadata-only.
+    private async Task<IReadOnlyList<RunOutputArtifact>> UploadAndAttachDocsRefsAsync(
+        Container container,
+        IReadOnlyList<RunOutputArtifact> parsed,
+        CancellationToken ct)
+    {
+        var enriched = new List<RunOutputArtifact>(parsed.Count);
+        foreach (var artifact in parsed)
+        {
+            DocsRef? docsRef = null;
+            try
+            {
+                if (artifact.SizeBytes > MaxUploadSizeBytes)
+                {
+                    _logger.LogWarning(
+                        "Artifact {RelativePath} in container {ContainerId} is {SizeBytes} bytes — exceeds upload cap ({MaxBytes}); emitting metadata-only.",
+                        artifact.RelativePath, container.Id, artifact.SizeBytes, MaxUploadSizeBytes);
+                }
+                else
+                {
+                    var bytes = await ReadArtifactBytesAsync(container, artifact, ct);
+                    if (bytes is not null)
+                    {
+                        var request = new UploadRequest(
+                            Content: bytes.Value,
+                            MimeType: artifact.ContentType ?? "application/octet-stream",
+                            Name: artifact.Name,
+                            Digest: artifact.Sha256,
+                            Links: new[]
+                            {
+                                new DocumentLinkDescriptor(
+                                    TargetType: "Run",
+                                    TargetId: container.Id.ToString(),
+                                    Role: "Output"),
+                            });
+                        docsRef = await _andyDocs!.UploadAsync(request, ct);
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // Caller cancelled — propagate so the terminal-event
+                // path can decide. Don't mask with a log line.
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to upload artifact {RelativePath} from container {ContainerId} to andy-docs; emitting metadata-only.",
+                    artifact.RelativePath, container.Id);
+                docsRef = null;
+            }
+
+            // Even if docsRef is null we still surface the artifact —
+            // metadata + sha is useful to downstream consumers (#316
+            // contract). #320 just adds the optional DocsRef pointer.
+            enriched.Add(artifact with { DocsRef = docsRef });
+        }
+        return enriched;
+    }
+
+    // rivoli-ai/andy-containers#320. Read a single artifact's bytes out
+    // of the container via the exec channel. We `base64`-encode in the
+    // container and decode here — `cat` over an exec channel mangles
+    // binary content on every provider that line-buffers stdout (LF/CR
+    // translation, EOF detection). base64 is portable across the BSD
+    // and GNU coreutils variants we ship in our base images.
+    //
+    // Returns null on any non-cancellation failure (exec error, decode
+    // error, size mismatch). The caller treats null as "no bytes →
+    // metadata-only entry, no DocsRef".
+    private async Task<ReadOnlyMemory<byte>?> ReadArtifactBytesAsync(
+        Container container,
+        RunOutputArtifact artifact,
+        CancellationToken ct)
+    {
+        // Re-anchor the relative path against the outputs root. Path
+        // separators are normalised to forward slashes by the collector
+        // contract, so a naive concat works.
+        var absolutePath = OutputsRoot + "/" + artifact.RelativePath;
+        // Single-quote the path inside a sh -c invocation, doubling
+        // any embedded single quotes via the POSIX `'\''` escape.
+        var quoted = "'" + absolutePath.Replace("'", "'\\''") + "'";
+        // `-w 0` suppresses line wrapping (BusyBox + GNU coreutils);
+        // BSD `base64` ignores `-w` but we tolerate the difference by
+        // stripping all whitespace from stdout below before decoding.
+        var script = $"base64 -w 0 {quoted} 2>/dev/null || base64 {quoted} 2>/dev/null";
+
+        ExecResult exec;
+        try
+        {
+            exec = await _containers.ExecAsync(
+                container.Id, $"sh -c '{script.Replace("'", "'\\''")}'", ReadTimeout, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to read bytes for artifact {RelativePath} from container {ContainerId}: {Message}",
+                artifact.RelativePath, container.Id, ex.Message);
+            return null;
+        }
+
+        if (exec.ExitCode != 0 || string.IsNullOrWhiteSpace(exec.StdOut))
+        {
+            _logger.LogWarning(
+                "base64 read for artifact {RelativePath} in container {ContainerId} exited {ExitCode}; StdErr: {StdErr}",
+                artifact.RelativePath, container.Id, exec.ExitCode, Truncate(exec.StdErr, 200));
+            return null;
+        }
+
+        try
+        {
+            // Strip all whitespace (BSD `base64` always wraps at 76;
+            // some shells re-emit with \r\n). Pre-strip rather than
+            // rely on Convert.FromBase64String's narrow whitespace
+            // tolerance.
+            var raw = exec.StdOut;
+            var buf = new char[raw.Length];
+            var n = 0;
+            for (var i = 0; i < raw.Length; i++)
+            {
+                var c = raw[i];
+                if (!char.IsWhiteSpace(c)) buf[n++] = c;
+            }
+            var bytes = Convert.FromBase64CharArray(buf, 0, n);
+            return bytes;
+        }
+        catch (FormatException ex)
+        {
+            _logger.LogWarning(ex,
+                "base64 output for artifact {RelativePath} in container {ContainerId} failed to decode.",
+                artifact.RelativePath, container.Id);
+            return null;
         }
     }
 

--- a/src/Andy.Containers.Infrastructure/Audit/AndyDocsHttpClient.cs
+++ b/src/Andy.Containers.Infrastructure/Audit/AndyDocsHttpClient.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Andy.Containers.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Containers.Infrastructure.Audit;
+
+/// <summary>
+/// rivoli-ai/andy-containers#320. HTTP client for andy-docs's
+/// <c>POST /api/documents:put</c> multipart endpoint (AJ5). Used by
+/// <see cref="Andy.Containers.Api.Services.FilesystemOutputArtifactCollector"/>
+/// to push the bytes of each <c>RunOutputArtifact</c> into the andy-docs
+/// content-addressed store at terminal-event time.
+///
+/// <para>
+/// <strong>Best-effort contract:</strong> every failure mode
+/// (network error, 4xx/5xx, timeout, mis-shaped body) surfaces as
+/// <c>null</c> with a logged warning — container stop is never blocked
+/// on andy-docs availability. Callers that need to distinguish
+/// "metadata-only" from "fully uploaded" do so by checking
+/// <c>RunOutputArtifact.DocsRef</c> for null.
+/// </para>
+///
+/// <para>
+/// Wire contract is identical to andy-tasks's <c>AndyDocsHttpUploader</c>
+/// (multipart body with <c>file</c> + <c>meta</c> parts; <c>meta</c> is a
+/// JSON document carrying <c>name</c> and <c>links</c>). We deliberately
+/// do NOT take a code dependency on andy-tasks — the contract is
+/// duplicated here so the two services stay decoupled at the build
+/// graph.
+/// </para>
+///
+/// <para>
+/// The auth header (when configured) is attached by the named
+/// <see cref="HttpClient"/>'s bearer handler — registered in
+/// <c>Program.cs</c> via <c>AddBearerFromService</c>. In bypass mode
+/// (no <c>AndyAuth:Authority</c>) the client is anonymous; this mirrors
+/// the rest of the inbound JWT-bearer / outbound M2M wiring elsewhere
+/// in the service.
+/// </para>
+/// </summary>
+public sealed class AndyDocsHttpClient : IAndyDocsClient
+{
+    /// <summary>Named HttpClient registered in DI; tests can override.</summary>
+    public const string HttpClientName = "andy-docs-artifacts";
+
+    // andy-docs uses ASP.NET's default camelCase web JSON options for
+    // its response bodies. We pin a dedicated options object so the
+    // deserialiser doesn't get cross-contaminated by any process-wide
+    // snake-case defaults.
+    private static readonly JsonSerializerOptions DocsResponseJson =
+        new(JsonSerializerDefaults.Web);
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<AndyDocsHttpClient> _logger;
+
+    public AndyDocsHttpClient(
+        IHttpClientFactory httpClientFactory,
+        ILogger<AndyDocsHttpClient> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<DocsRef?> UploadAsync(UploadRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var http = _httpClientFactory.CreateClient(HttpClientName);
+
+        using var content = new MultipartFormDataContent();
+
+        // Materialise the ReadOnlyMemory<byte> into a ByteArrayContent.
+        // andy-docs streams the request to disk; the in-memory copy is
+        // OK at our artifact size cap.
+        var fileContent = new ByteArrayContent(request.Content.ToArray());
+        if (!string.IsNullOrWhiteSpace(request.MimeType))
+        {
+            try
+            {
+                fileContent.Headers.ContentType = new MediaTypeHeaderValue(request.MimeType);
+            }
+            catch (FormatException)
+            {
+                // Defensive: ContentGuessing in the collector should
+                // always produce a valid MIME shape, but if a caller
+                // hand-rolls a request with a junk value we just drop
+                // the header rather than throw — andy-docs falls back
+                // to application/octet-stream when missing.
+            }
+        }
+        content.Add(fileContent, name: "file", fileName: SafeFileName(request.Name));
+
+        var meta = BuildMeta(request);
+        var metaContent = new StringContent(meta, Encoding.UTF8, "application/json");
+        content.Add(metaContent, "meta");
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, "api/documents:put")
+        {
+            Content = content,
+        };
+
+        HttpResponseMessage? response = null;
+        try
+        {
+            response = await http.SendAsync(httpRequest, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Caller cancelled — propagate so the surrounding terminal
+            // path can decide what to do (typically skip the event).
+            throw;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex,
+                "andy-docs upload failed: network error for digest {Digest} ({Name}).",
+                request.Digest, request.Name);
+            return null;
+        }
+        catch (TaskCanceledException ex)
+        {
+            // Per-attempt HttpClient timeout fired (caller token is NOT
+            // cancelled — that path is handled above). Best-effort:
+            // metadata-only fallback.
+            _logger.LogWarning(ex,
+                "andy-docs upload timed out for digest {Digest} ({Name}).",
+                request.Digest, request.Name);
+            return null;
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var body = await SafeReadAsync(response.Content, ct).ConfigureAwait(false);
+                _logger.LogWarning(
+                    "andy-docs upload returned HTTP {Status} ({StatusName}) for digest {Digest} ({Name}). Body preview: {Body}",
+                    (int)response.StatusCode, response.StatusCode, request.Digest, request.Name,
+                    Truncate(body, 200));
+                return null;
+            }
+
+            DocsRefWireDto? dto;
+            try
+            {
+                dto = await response.Content
+                    .ReadFromJsonAsync<DocsRefWireDto>(DocsResponseJson, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "andy-docs upload succeeded with HTTP {Status} but the response body was unparseable for digest {Digest} ({Name}).",
+                    (int)response.StatusCode, request.Digest, request.Name);
+                return null;
+            }
+
+            if (dto is null || dto.DocumentId == Guid.Empty || dto.LinkId == Guid.Empty)
+            {
+                _logger.LogWarning(
+                    "andy-docs upload returned an incomplete DocsRef for digest {Digest} ({Name}) — documentId or linkId missing.",
+                    request.Digest, request.Name);
+                return null;
+            }
+
+            return new DocsRef(dto.DocumentId, dto.LinkId);
+        }
+    }
+
+    // The `meta` part is a JSON document carrying the upload's name and
+    // links. Schema mirrors andy-tasks's BuildMeta — keep these in sync
+    // by hand; both target the same andy-docs endpoint.
+    private static string BuildMeta(UploadRequest request)
+    {
+        var meta = new
+        {
+            name = request.Name,
+            links = request.Links.Select(l => new
+            {
+                targetType = l.TargetType,
+                targetId = l.TargetId,
+                role = l.Role,
+            }).ToArray(),
+        };
+        return JsonSerializer.Serialize(meta);
+    }
+
+    // Strip control chars from the filename used in the multipart
+    // Content-Disposition. RFC 7578 lets the server reject filenames
+    // containing CR/LF; we sanitise defensively so the response is
+    // not lost to a 400.
+    private static string SafeFileName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return "artifact";
+        Span<char> buf = stackalloc char[Math.Min(name.Length, 256)];
+        var n = 0;
+        foreach (var c in name)
+        {
+            if (n >= buf.Length) break;
+            if (c == '\r' || c == '\n' || c == '"') continue;
+            buf[n++] = c;
+        }
+        return n == 0 ? "artifact" : new string(buf[..n]);
+    }
+
+    private static async Task<string> SafeReadAsync(HttpContent content, CancellationToken ct)
+    {
+        try
+        {
+            return await content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    private static string? Truncate(string? value, int max)
+    {
+        if (string.IsNullOrEmpty(value)) return value;
+        return value.Length <= max ? value : value[..max] + "...";
+    }
+
+    /// <summary>
+    /// Wire shape returned by andy-docs's <c>POST /api/documents:put</c>.
+    /// Mirrors the relevant fields on <c>DocsRefDto</c> — additional
+    /// fields (versionHash, sizeBytes, additionalLinkIds) are present on
+    /// the wire but unused here so the local record stays minimal.
+    /// </summary>
+    private sealed record DocsRefWireDto(
+        Guid DocumentId,
+        Guid LinkId);
+}

--- a/src/Andy.Containers.Infrastructure/Audit/AndyDocsOptions.cs
+++ b/src/Andy.Containers.Infrastructure/Audit/AndyDocsOptions.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Containers.Infrastructure.Audit;
+
+/// <summary>
+/// rivoli-ai/andy-containers#320. Configuration for the andy-docs
+/// HTTP client used by the output-artifact collector. Bound from
+/// <c>AndyDocs:</c> in <c>appsettings.json</c> / environment
+/// overrides.
+///
+/// <para>
+/// When <see cref="ApiBaseUrl"/> is empty the client is NOT registered
+/// — the collector operates in metadata-only mode, matching the
+/// pre-#320 wire shape. This mirrors the andy-tasks AndyDocs wiring
+/// posture so dev / embedded mode without an andy-docs instance does
+/// not fail at startup.
+/// </para>
+/// </summary>
+public sealed class AndyDocsOptions
+{
+    public const string SectionName = "AndyDocs";
+
+    /// <summary>
+    /// Base URL of the andy-docs API — e.g.
+    /// <c>http://localhost:5450/</c> in dev or
+    /// <c>https://andy-docs.example.com/</c> in production. Empty / null
+    /// disables the client entirely (collector falls back to metadata-
+    /// only mode).
+    /// </summary>
+    public string? ApiBaseUrl { get; set; }
+
+    /// <summary>
+    /// Per-request HttpClient timeout. Caps the slowest single upload
+    /// before the bearer-handler timeout / caller cancel fires.
+    /// Defaults to 30s — generous for a single artifact (the per-file
+    /// upload cap is 64 MiB) without holding the terminal-event path
+    /// open indefinitely.
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Audience the M2M bearer should be minted with. Defaults to the
+    /// andy-docs API audience as registered in andy-auth's seed.
+    /// </summary>
+    public string Audience { get; set; } = "urn:andy-docs-api";
+}

--- a/src/Andy.Containers.Infrastructure/Audit/IAndyDocsClient.cs
+++ b/src/Andy.Containers.Infrastructure/Audit/IAndyDocsClient.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Models;
+
+namespace Andy.Containers.Infrastructure.Audit;
+
+/// <summary>
+/// rivoli-ai/andy-containers#320. Andy-docs upload surface used by
+/// the artifact collector to push OutputArtifact bytes to the
+/// content-addressed document store at terminal-event time.
+///
+/// <para>
+/// <strong>Failure semantics:</strong> <see cref="UploadAsync"/> returns
+/// <c>null</c> on any transient or recoverable failure (network error,
+/// 5xx, timeout, mis-shaped response) rather than throwing. This is the
+/// "best-effort" contract — container stop must NOT block on andy-docs
+/// availability. A null return signals the caller to fall back to a
+/// metadata-only artifact entry (no <c>DocsRef</c> populated). Throws
+/// only on caller-initiated cancellation or programmer error (null
+/// arguments).
+/// </para>
+///
+/// <para>
+/// Mirrors the wire contract used by andy-tasks's
+/// <c>AndyDocsHttpUploader</c> (AD3) — both target the same
+/// <c>POST /api/documents:put</c> multipart endpoint. We deliberately do
+/// NOT take a code dependency on andy-tasks; the contract is duplicated
+/// locally so the two services stay decoupled at the build-graph level.
+/// </para>
+/// </summary>
+public interface IAndyDocsClient
+{
+    Task<DocsRef?> UploadAsync(UploadRequest request, CancellationToken ct = default);
+}
+
+/// <summary>
+/// One upload payload bound for <c>POST /api/documents:put</c>. Content
+/// is held in memory rather than streamed because the artifact size cap
+/// (see <c>FilesystemOutputArtifactCollector</c>) is well within the
+/// per-request budget; switching to streaming requires a sidecar
+/// stream-based exec channel that the current
+/// <see cref="Andy.Containers.Abstractions.IContainerService"/> surface
+/// does not expose.
+/// </summary>
+public sealed record UploadRequest(
+    ReadOnlyMemory<byte> Content,
+    string MimeType,
+    string Name,
+    string Digest,
+    IReadOnlyList<DocumentLinkDescriptor> Links);
+
+/// <summary>
+/// Single <c>(targetType, targetId, role)</c> link tuple that andy-docs
+/// records on the uploaded document. The first link becomes the
+/// primary <c>LinkId</c> returned in <see cref="DocsRef"/>; additional
+/// links are recorded but not surfaced individually in the return type
+/// (andy-docs's wire response also surfaces them under a separate
+/// <c>additionalLinkIds</c> field which we intentionally do not project).
+/// </summary>
+public sealed record DocumentLinkDescriptor(
+    string TargetType,
+    string TargetId,
+    string Role);

--- a/src/Andy.Containers.Infrastructure/Audit/ServiceBearerHandler.cs
+++ b/src/Andy.Containers.Infrastructure/Audit/ServiceBearerHandler.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Containers.Infrastructure.Audit;
+
+/// <summary>
+/// rivoli-ai/andy-containers#320. Tiny DelegatingHandler that resolves a
+/// bearer token (typically from an M2M client-credentials cache) and
+/// attaches it to every outbound request as
+/// <c>Authorization: Bearer &lt;token&gt;</c>. Registered as the message
+/// handler on the named <c>andy-docs-artifacts</c> HttpClient when
+/// AndyAuth is wired; in bypass mode the handler is omitted entirely
+/// and the client goes anonymous.
+///
+/// <para>
+/// Failures from the token provider degrade to "send without
+/// Authorization" — the andy-docs server will then reject with 401,
+/// which the client treats as a normal upload failure (returns null →
+/// metadata-only artifact). We deliberately do not block the request
+/// on token-mint failures; the upstream best-effort contract still
+/// applies.
+/// </para>
+/// </summary>
+public sealed class ServiceBearerHandler : DelegatingHandler
+{
+    private readonly Func<CancellationToken, Task<string?>> _tokenProvider;
+    private readonly ILogger<ServiceBearerHandler>? _logger;
+
+    public ServiceBearerHandler(
+        Func<CancellationToken, Task<string?>> tokenProvider,
+        ILogger<ServiceBearerHandler>? logger = null)
+    {
+        _tokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
+        _logger = logger;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        string? token = null;
+        try
+        {
+            token = await _tokenProvider(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex,
+                "Failed to obtain service bearer for outbound request to {Url}; sending anonymously.",
+                request.RequestUri);
+        }
+
+        if (!string.IsNullOrWhiteSpace(token))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Andy.Containers/Messaging/Events/RunEvents.cs
+++ b/src/Andy.Containers/Messaging/Events/RunEvents.cs
@@ -20,6 +20,14 @@ namespace Andy.Containers.Messaging.Events;
 // EventJson WhenWritingNull policy) so legacy v1 consumers continue to
 // deserialise without schema friction; consumers that opt in
 // (andy-tasks#275) project it onto TaskNode.OutputDocRefs.
+//
+// v3 (rivoli-ai/andy-containers#320) extends each RunOutputArtifact with
+// an optional DocsRef (DocumentId + LinkId) populated when the bytes
+// were successfully uploaded to andy-docs during collection. The
+// payload shape itself is unchanged — only the per-artifact record
+// grew a new nullable field. v2 consumers continue to deserialise
+// successfully (DocsRef is ignored as an unknown property under the
+// EventJson tolerant-read policy).
 public sealed record RunEventPayload(
     Guid RunId,
     Guid? StoryId,
@@ -28,11 +36,10 @@ public sealed record RunEventPayload(
     double? DurationSeconds,
     IReadOnlyList<RunOutputArtifact>? OutputArtifacts = null)
 {
-    // Bumped to 2 when OutputArtifacts landed. New consumers can
-    // gate behaviour on schema_version >= 2; v1 consumers ignore
-    // the new field (the property is omitted when null and EventJson
-    // tolerates unknown properties on read).
-    public const int SchemaVersion = 2;
+    // Bumped to 3 when DocsRef landed on RunOutputArtifact (#320).
+    // Consumers that need the bytes-uploaded guarantee can gate on
+    // schema_version >= 3; pre-v3 consumers ignore DocsRef cleanly.
+    public const int SchemaVersion = 3;
 
     public int Schema_Version => SchemaVersion;
 }

--- a/src/Andy.Containers/Models/DocsRef.cs
+++ b/src/Andy.Containers/Models/DocsRef.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Containers.Models;
+
+/// <summary>
+/// rivoli-ai/andy-containers#320. Canonical pointer into andy-docs for a
+/// piece of uploaded content. Stamped onto
+/// <see cref="RunOutputArtifact.DocsRef"/> after a successful
+/// <c>POST /api/documents:put</c>; <c>null</c> when the andy-docs upload
+/// was skipped or failed (best-effort / metadata-only fallback).
+///
+/// <para>
+/// Lives in <c>Andy.Containers.Models</c> rather than the infrastructure
+/// layer so it can ride on the wire payload (<c>RunEventPayload</c>) and
+/// the persisted entity (<c>Run.OutputArtifacts</c>) without forcing
+/// either to depend on infrastructure. The HTTP-client surface in
+/// <c>Andy.Containers.Infrastructure.Audit</c> projects onto this type
+/// after parsing andy-docs's response DTO.
+/// </para>
+///
+/// <para>
+/// Mirrors andy-docs's domain <c>DocsRef</c> value object on the wire:
+/// <c>DocumentId</c> is the content-addressed document id (stable across
+/// re-uploads of identical bytes), <c>LinkId</c> is the per-target link
+/// id (one per <c>(documentId, target, role)</c> tuple).
+/// </para>
+/// </summary>
+public sealed record DocsRef(Guid DocumentId, Guid LinkId);

--- a/src/Andy.Containers/Models/RunOutputArtifact.cs
+++ b/src/Andy.Containers/Models/RunOutputArtifact.cs
@@ -32,9 +32,29 @@ namespace Andy.Containers.Models;
 /// MIME type guessed from the filename extension. Null when the
 /// extension is unknown or the file has none.
 /// </param>
+/// <param name="DocsRef">
+/// rivoli-ai/andy-containers#320. Pointer into andy-docs for the
+/// uploaded bytes, populated by the collector during terminal-event
+/// processing. <c>null</c> when:
+/// <list type="bullet">
+///   <item>The collector ran with no <c>IAndyDocsClient</c> registered
+///   (metadata-only mode — the pre-#320 wire shape).</item>
+///   <item>The andy-docs upload failed (transient network error,
+///   5xx response, timeout). The artifact is still emitted with
+///   metadata; downstream consumers (andy-tasks#275 Phase 2) treat
+///   a null <c>DocsRef</c> as "bytes unavailable" and surface a
+///   degraded UX rather than dropping the artifact entirely.</item>
+///   <item>The file was read but unreadable (empty / vanished /
+///   permission-denied at upload time).</item>
+/// </list>
+/// Nullable keeps the JSON wire shape backwards-compatible —
+/// <c>EventJson.Options</c> omits null fields, so v2 consumers see
+/// exactly the v2 payload they expect.
+/// </param>
 public sealed record RunOutputArtifact(
     string Name,
     string RelativePath,
     long SizeBytes,
     string Sha256,
-    string? ContentType);
+    string? ContentType,
+    DocsRef? DocsRef = null);

--- a/tests/Andy.Containers.Api.Tests/Messaging/RunEventOutboxTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Messaging/RunEventOutboxTests.cs
@@ -196,8 +196,8 @@ public class RunEventOutboxTests
         using var doc = JsonDocument.Parse(entry.PayloadJson);
         var root = doc.RootElement;
         root.GetProperty("schema_version").GetInt32().Should().Be(RunEventPayload.SchemaVersion);
-        root.GetProperty("schema_version").GetInt32().Should().Be(2,
-            "OutputArtifacts shipped in the v2 wire shape");
+        root.GetProperty("schema_version").GetInt32().Should().Be(3,
+            "DocsRef on RunOutputArtifact bumped the wire shape to v3 (#320)");
 
         var arr = root.GetProperty("output_artifacts");
         arr.GetArrayLength().Should().Be(2);
@@ -331,5 +331,137 @@ public class RunEventOutboxTests
         back.OutputArtifacts!.Should().HaveCount(1);
         back.OutputArtifacts![0].Name.Should().Be("r.pdf");
         back.OutputArtifacts![0].Sha256.Should().Be(new string('d', 64));
+    }
+
+    // ----- rivoli-ai/andy-containers#320 DocsRef coverage -----
+
+    [Fact]
+    public void RunEventPayload_WithDocsRef_RoundTripsThroughEventJson()
+    {
+        // After #320 each RunOutputArtifact carries an optional DocsRef.
+        // Serialise + deserialise asserts both that the payload reaches
+        // consumers with DocsRef intact AND that the JSON property name
+        // is snake_cased to `docs_ref` per EventJson's policy.
+        var docDocId = Guid.NewGuid();
+        var docLinkId = Guid.NewGuid();
+        var payload = new RunEventPayload(
+            RunId: Guid.NewGuid(),
+            StoryId: null,
+            Status: "Succeeded",
+            ExitCode: 0,
+            DurationSeconds: 2.0,
+            OutputArtifacts: new[]
+            {
+                new RunOutputArtifact(
+                    Name: "report.pdf",
+                    RelativePath: "report.pdf",
+                    SizeBytes: 12345,
+                    Sha256: new string('a', 64),
+                    ContentType: "application/pdf",
+                    DocsRef: new DocsRef(docDocId, docLinkId)),
+            });
+
+        var json = JsonSerializer.Serialize(payload,
+            Andy.Containers.Messaging.EventJson.Options);
+
+        // Wire-form: snake_case property, nested object with snake_case keys.
+        using var doc = JsonDocument.Parse(json);
+        var arr = doc.RootElement.GetProperty("output_artifacts");
+        arr.GetArrayLength().Should().Be(1);
+        var artifact = arr[0];
+        artifact.TryGetProperty("docs_ref", out var docsRefEl).Should().BeTrue(
+            "DocsRef must serialise as snake_case `docs_ref` for consumer compat");
+        docsRefEl.GetProperty("document_id").GetString().Should().Be(docDocId.ToString());
+        docsRefEl.GetProperty("link_id").GetString().Should().Be(docLinkId.ToString());
+
+        // Round-trip parses back into the typed record.
+        var back = JsonSerializer.Deserialize<RunEventPayload>(json,
+            Andy.Containers.Messaging.EventJson.Options);
+        back.Should().NotBeNull();
+        back!.OutputArtifacts!.Single().DocsRef.Should().NotBeNull();
+        back.OutputArtifacts!.Single().DocsRef!.DocumentId.Should().Be(docDocId);
+        back.OutputArtifacts!.Single().DocsRef!.LinkId.Should().Be(docLinkId);
+    }
+
+    [Fact]
+    public void RunEventPayload_WithNullDocsRef_OmitsFieldFromWire()
+    {
+        // Metadata-only fallback (andy-docs down / not configured) leaves
+        // DocsRef null. The JSON wire shape must OMIT the property so v2
+        // consumers see exactly the v2 payload they expect — no surprise
+        // null on a field they don't know about.
+        var payload = new RunEventPayload(
+            RunId: Guid.NewGuid(),
+            StoryId: null,
+            Status: "Succeeded",
+            ExitCode: 0,
+            DurationSeconds: 1.0,
+            OutputArtifacts: new[]
+            {
+                new RunOutputArtifact("a.txt", "a.txt", 3, new string('a', 64), "text/plain"),
+            });
+
+        var json = JsonSerializer.Serialize(payload,
+            Andy.Containers.Messaging.EventJson.Options);
+
+        using var doc = JsonDocument.Parse(json);
+        var artifact = doc.RootElement.GetProperty("output_artifacts")[0];
+        artifact.TryGetProperty("docs_ref", out _).Should().BeFalse(
+            "EventJson omits null properties on write — pre-v3 consumers see no docs_ref key");
+    }
+
+    [Fact]
+    public async Task AppendAgentRunEvent_WithDocsRefPopulated_RoundTripsThroughOutboxAndPersists()
+    {
+        // Integration: write through AppendAgentRunEvent + the EF
+        // JSON-column converter on Run.OutputArtifacts, then read back
+        // and verify DocsRef survives both the outbox payload AND the
+        // database row. Together these prove the v3 wire shape is
+        // wired end-to-end (collector → outbox → entity → consumer).
+        using var db = InMemoryDbHelper.CreateContext();
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "triage-agent",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            ContainerId = Guid.NewGuid(),
+            Status = RunStatus.Succeeded,
+        };
+        db.Runs.Add(run);
+        await db.SaveChangesAsync();
+
+        var docDocId = Guid.NewGuid();
+        var docLinkId = Guid.NewGuid();
+        var artifacts = new List<RunOutputArtifact>
+        {
+            new("report.pdf", "report.pdf", 12345, new string('a', 64), "application/pdf",
+                DocsRef: new DocsRef(docDocId, docLinkId)),
+        };
+
+        db.AppendAgentRunEvent(run, RunEventKind.Finished,
+            exitCode: 0, durationSeconds: 4.2, outputArtifacts: artifacts);
+        await db.SaveChangesAsync();
+
+        // Outbox payload carries the DocsRef.
+        var entry = await db.OutboxEntries.SingleAsync();
+        using var doc = JsonDocument.Parse(entry.PayloadJson);
+        var arr = doc.RootElement.GetProperty("output_artifacts");
+        arr[0].GetProperty("docs_ref").GetProperty("document_id").GetString()
+            .Should().Be(docDocId.ToString());
+        arr[0].GetProperty("docs_ref").GetProperty("link_id").GetString()
+            .Should().Be(docLinkId.ToString());
+
+        // Schema version reflects the v3 bump.
+        doc.RootElement.GetProperty("schema_version").GetInt32().Should().Be(3);
+
+        // Persisted Run row also carries the DocsRef (through the
+        // EF JSON converter on Run.OutputArtifacts).
+        var persisted = await db.Runs.FindAsync(run.Id);
+        persisted!.OutputArtifacts.Should().NotBeNull();
+        persisted.OutputArtifacts!.Single().DocsRef.Should().NotBeNull();
+        persisted.OutputArtifacts!.Single().DocsRef!.DocumentId.Should().Be(docDocId);
+        persisted.OutputArtifacts!.Single().DocsRef!.LinkId.Should().Be(docLinkId);
     }
 }

--- a/tests/Andy.Containers.Api.Tests/Services/FilesystemOutputArtifactCollectorTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/FilesystemOutputArtifactCollectorTests.cs
@@ -3,6 +3,7 @@
 
 using Andy.Containers.Abstractions;
 using Andy.Containers.Api.Services;
+using Andy.Containers.Infrastructure.Audit;
 using Andy.Containers.Models;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -311,5 +312,275 @@ public class FilesystemOutputArtifactCollectorTests
         var act = () => collector.CollectAsync(container, cts.Token);
 
         await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    // ----- rivoli-ai/andy-containers#320 byte-upload behaviour -----
+    //
+    // The probe pipeline (find | xargs sha256sum) is the FIRST exec; the
+    // per-file base64 read is the SECOND-and-onward exec. We model both
+    // by setup-ordering: ReturnsAsync chains responses, so the first
+    // ExecAsync call lands on the probe response and subsequent calls
+    // (one per artifact) land on the base64 response.
+
+    private static Mock<IContainerService> MockExecPipeline(
+        string probeStdOut, params string[] base64StdOuts)
+    {
+        var containers = new Mock<IContainerService>();
+        var queue = new Queue<string>();
+        queue.Enqueue(probeStdOut);
+        foreach (var b in base64StdOuts) queue.Enqueue(b);
+
+        containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new ExecResult { ExitCode = 0, StdOut = queue.Dequeue() });
+        return containers;
+    }
+
+    [Fact]
+    public async Task Collect_WithAndyDocsClient_PopulatesDocsRefOnEachArtifact()
+    {
+        // Two probe hits → two base64 reads → two andy-docs uploads;
+        // every emitted artifact has its DocsRef stamped from the
+        // client's response.
+        var sha1 = new string('1', 64);
+        var sha2 = new string('2', 64);
+        var probe = string.Join('\n', new[]
+        {
+            $"3\t{sha1}\t{Root}/a.txt",
+            $"3\t{sha2}\t{Root}/b.txt",
+        });
+        var b64 = Convert.ToBase64String(new byte[] { 0x61, 0x62, 0x63 }); // "abc"
+
+        var containers = MockExecPipeline(probe, b64, b64);
+
+        var fixedDocId = Guid.NewGuid();
+        var fixedLinkId = Guid.NewGuid();
+        var docs = new Mock<IAndyDocsClient>();
+        docs.Setup(d => d.UploadAsync(It.IsAny<UploadRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DocsRef(fixedDocId, fixedLinkId));
+
+        var collector = new FilesystemOutputArtifactCollector(
+            containers.Object,
+            NullLogger<FilesystemOutputArtifactCollector>.Instance,
+            docs.Object);
+        var container = new Container
+        {
+            Id = Guid.NewGuid(), Name = "c", OwnerId = "u", ExternalId = "ext-1",
+        };
+
+        var artifacts = await collector.CollectAsync(container);
+
+        artifacts.Should().HaveCount(2);
+        artifacts.Should().OnlyContain(a =>
+            a.DocsRef != null
+            && a.DocsRef.DocumentId == fixedDocId
+            && a.DocsRef.LinkId == fixedLinkId);
+        docs.Verify(d => d.UploadAsync(It.IsAny<UploadRequest>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Collect_WithAndyDocsClient_PassesCorrectUploadRequestFields()
+    {
+        // Capture the UploadRequest and assert it carries the
+        // expected MimeType / Name / Digest / Links shape (Run target,
+        // container id, Output role).
+        var sha = new string('a', 64);
+        var probe = $"3\t{sha}\t{Root}/report.pdf";
+        var b64 = Convert.ToBase64String(new byte[] { 1, 2, 3 });
+
+        var containers = MockExecPipeline(probe, b64);
+
+        UploadRequest? captured = null;
+        var docs = new Mock<IAndyDocsClient>();
+        docs.Setup(d => d.UploadAsync(It.IsAny<UploadRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<UploadRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new DocsRef(Guid.NewGuid(), Guid.NewGuid()));
+
+        var containerId = Guid.NewGuid();
+        var collector = new FilesystemOutputArtifactCollector(
+            containers.Object,
+            NullLogger<FilesystemOutputArtifactCollector>.Instance,
+            docs.Object);
+        var container = new Container
+        {
+            Id = containerId, Name = "c", OwnerId = "u", ExternalId = "ext-1",
+        };
+
+        var artifacts = await collector.CollectAsync(container);
+
+        artifacts.Should().HaveCount(1);
+        captured.Should().NotBeNull();
+        captured!.Name.Should().Be("report.pdf");
+        captured.MimeType.Should().Be("application/pdf");
+        captured.Digest.Should().Be(sha);
+        captured.Content.ToArray().Should().BeEquivalentTo(new byte[] { 1, 2, 3 });
+        captured.Links.Should().HaveCount(1);
+        captured.Links[0].TargetType.Should().Be("Run");
+        captured.Links[0].TargetId.Should().Be(containerId.ToString());
+        captured.Links[0].Role.Should().Be("Output");
+    }
+
+    [Fact]
+    public async Task Collect_WithAndyDocsClientThrowing_FallsBackToMetadataOnly()
+    {
+        // Per-artifact try/catch: one bad upload must not blow away the
+        // rest of the collection. We model that with a client that
+        // throws on every call — every emitted artifact still has its
+        // metadata, but DocsRef is null.
+        var sha1 = new string('1', 64);
+        var sha2 = new string('2', 64);
+        var probe = string.Join('\n', new[]
+        {
+            $"3\t{sha1}\t{Root}/a.txt",
+            $"3\t{sha2}\t{Root}/b.txt",
+        });
+        var b64 = Convert.ToBase64String(new byte[] { 1, 2, 3 });
+
+        var containers = MockExecPipeline(probe, b64, b64);
+
+        var docs = new Mock<IAndyDocsClient>();
+        docs.Setup(d => d.UploadAsync(It.IsAny<UploadRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("andy-docs unreachable"));
+
+        var collector = new FilesystemOutputArtifactCollector(
+            containers.Object,
+            NullLogger<FilesystemOutputArtifactCollector>.Instance,
+            docs.Object);
+        var container = new Container
+        {
+            Id = Guid.NewGuid(), Name = "c", OwnerId = "u", ExternalId = "ext-1",
+        };
+
+        var artifacts = await collector.CollectAsync(container);
+
+        artifacts.Should().HaveCount(2);
+        artifacts.Should().OnlyContain(a => a.DocsRef == null);
+        artifacts.Select(a => a.RelativePath).Should().BeEquivalentTo(new[] { "a.txt", "b.txt" });
+    }
+
+    [Fact]
+    public async Task Collect_WithAndyDocsClientReturningNull_LeavesDocsRefNull()
+    {
+        // Per the IAndyDocsClient contract, transient failure ==
+        // UploadAsync returns null (not throws). The collector must
+        // still emit the artifact, just metadata-only.
+        var sha = new string('a', 64);
+        var probe = $"3\t{sha}\t{Root}/a.txt";
+        var b64 = Convert.ToBase64String(new byte[] { 1, 2, 3 });
+
+        var containers = MockExecPipeline(probe, b64);
+
+        var docs = new Mock<IAndyDocsClient>();
+        docs.Setup(d => d.UploadAsync(It.IsAny<UploadRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DocsRef?)null);
+
+        var collector = new FilesystemOutputArtifactCollector(
+            containers.Object,
+            NullLogger<FilesystemOutputArtifactCollector>.Instance,
+            docs.Object);
+        var container = new Container
+        {
+            Id = Guid.NewGuid(), Name = "c", OwnerId = "u", ExternalId = "ext-1",
+        };
+
+        var artifacts = await collector.CollectAsync(container);
+
+        artifacts.Should().HaveCount(1);
+        artifacts[0].DocsRef.Should().BeNull();
+        artifacts[0].RelativePath.Should().Be("a.txt");
+    }
+
+    [Fact]
+    public async Task Collect_WithoutAndyDocsClient_PreservesPreCenturyBehaviour()
+    {
+        // Null IAndyDocsClient → pure metadata-only mode. No DocsRef
+        // populated, no extra exec round-trips beyond the probe.
+        var sha = new string('a', 64);
+        var probe = $"3\t{sha}\t{Root}/a.txt";
+
+        var containers = new Mock<IContainerService>();
+        containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExecResult { ExitCode = 0, StdOut = probe });
+
+        var collector = new FilesystemOutputArtifactCollector(
+            containers.Object,
+            NullLogger<FilesystemOutputArtifactCollector>.Instance,
+            andyDocs: null);
+        var container = new Container
+        {
+            Id = Guid.NewGuid(), Name = "c", OwnerId = "u", ExternalId = "ext-1",
+        };
+
+        var artifacts = await collector.CollectAsync(container);
+
+        artifacts.Should().HaveCount(1);
+        artifacts[0].DocsRef.Should().BeNull();
+        // Only the probe call, no base64 read.
+        containers.Verify(
+            c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Collect_BytesReadFailure_FallsBackToMetadataOnlyButContinues()
+    {
+        // The probe succeeds and returns two artifacts. The base64 read
+        // of the FIRST file fails (exec returns non-zero); the SECOND
+        // succeeds. The first artifact is metadata-only, the second has
+        // its DocsRef populated — proving the per-file isolation.
+        var sha1 = new string('1', 64);
+        var sha2 = new string('2', 64);
+        var probe = string.Join('\n', new[]
+        {
+            $"3\t{sha1}\t{Root}/a.txt",
+            $"3\t{sha2}\t{Root}/b.txt",
+        });
+        var b64Good = Convert.ToBase64String(new byte[] { 1, 2, 3 });
+
+        var containers = new Mock<IContainerService>();
+        var calls = 0;
+        containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                calls++;
+                return calls switch
+                {
+                    1 => new ExecResult { ExitCode = 0, StdOut = probe },
+                    2 => new ExecResult { ExitCode = 1, StdErr = "cat: no such file" },
+                    3 => new ExecResult { ExitCode = 0, StdOut = b64Good },
+                    _ => new ExecResult { ExitCode = 0, StdOut = "" },
+                };
+            });
+
+        var docs = new Mock<IAndyDocsClient>();
+        docs.Setup(d => d.UploadAsync(It.IsAny<UploadRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DocsRef(Guid.NewGuid(), Guid.NewGuid()));
+
+        var collector = new FilesystemOutputArtifactCollector(
+            containers.Object,
+            NullLogger<FilesystemOutputArtifactCollector>.Instance,
+            docs.Object);
+        var container = new Container
+        {
+            Id = Guid.NewGuid(), Name = "c", OwnerId = "u", ExternalId = "ext-1",
+        };
+
+        var artifacts = await collector.CollectAsync(container);
+
+        artifacts.Should().HaveCount(2);
+        artifacts.Single(a => a.RelativePath == "a.txt").DocsRef.Should().BeNull(
+            "first file's bytes read failed → metadata-only");
+        artifacts.Single(a => a.RelativePath == "b.txt").DocsRef.Should().NotBeNull(
+            "second file's read + upload succeeded");
+        // Upload was attempted only once (the second file).
+        docs.Verify(d => d.UploadAsync(It.IsAny<UploadRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/tests/Andy.Containers.Tests/Infrastructure/Audit/AndyDocsHttpClientTests.cs
+++ b/tests/Andy.Containers.Tests/Infrastructure/Audit/AndyDocsHttpClientTests.cs
@@ -1,0 +1,291 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Andy.Containers.Infrastructure.Audit;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Containers.Tests.Infrastructure.Audit;
+
+// rivoli-ai/andy-containers#320. HttpMessageHandler-stub tests for the
+// andy-docs upload client. The stub captures the outbound request so we
+// can assert the multipart shape, then returns whatever response the
+// test wants — happy path, 5xx, 4xx, garbage body, transport error.
+public class AndyDocsHttpClientTests
+{
+    private static readonly Uri BaseAddress = new("https://andy-docs.local/");
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? CapturedRequest { get; private set; }
+        public string? CapturedBody { get; private set; }
+        public Func<HttpRequestMessage, HttpResponseMessage> Responder { get; init; }
+            = _ => new HttpResponseMessage(HttpStatusCode.OK);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CapturedRequest = request;
+            if (request.Content is not null)
+            {
+                CapturedBody = await request.Content.ReadAsStringAsync(cancellationToken);
+            }
+            return Responder(request);
+        }
+    }
+
+    private sealed class StubFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+        public StubFactory(HttpMessageHandler handler) { _handler = handler; }
+        public HttpClient CreateClient(string name)
+        {
+            return new HttpClient(_handler, disposeHandler: false)
+            {
+                BaseAddress = BaseAddress,
+            };
+        }
+    }
+
+    private static AndyDocsHttpClient MakeClient(HttpMessageHandler handler)
+    {
+        return new AndyDocsHttpClient(
+            new StubFactory(handler),
+            NullLogger<AndyDocsHttpClient>.Instance);
+    }
+
+    private static UploadRequest MakeRequest(byte[]? content = null) =>
+        new(
+            Content: content ?? new byte[] { 1, 2, 3 },
+            MimeType: "application/pdf",
+            Name: "report.pdf",
+            Digest: new string('a', 64),
+            Links: new[]
+            {
+                new DocumentLinkDescriptor("Run", Guid.NewGuid().ToString(), "Output"),
+            });
+
+    [Fact]
+    public async Task UploadAsync_HappyPath_PostsToDocumentsPutAndReturnsDocsRef()
+    {
+        var documentId = Guid.NewGuid();
+        var linkId = Guid.NewGuid();
+        var handler = new CapturingHandler
+        {
+            Responder = _ =>
+            {
+                var json = JsonSerializer.Serialize(new { documentId, linkId });
+                var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json"),
+                };
+                return resp;
+            },
+        };
+        var client = MakeClient(handler);
+
+        var result = await client.UploadAsync(MakeRequest());
+
+        result.Should().NotBeNull();
+        result!.DocumentId.Should().Be(documentId);
+        result.LinkId.Should().Be(linkId);
+
+        handler.CapturedRequest.Should().NotBeNull();
+        handler.CapturedRequest!.Method.Should().Be(HttpMethod.Post);
+        handler.CapturedRequest.RequestUri.Should().Be(new Uri(BaseAddress, "api/documents:put"));
+    }
+
+    [Fact]
+    public async Task UploadAsync_HappyPath_BodyCarriesFileAndMetaParts()
+    {
+        var handler = new CapturingHandler
+        {
+            Responder = _ =>
+            {
+                var json = JsonSerializer.Serialize(new
+                {
+                    documentId = Guid.NewGuid(),
+                    linkId = Guid.NewGuid(),
+                });
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json"),
+                };
+            },
+        };
+        var client = MakeClient(handler);
+
+        await client.UploadAsync(MakeRequest());
+
+        handler.CapturedBody.Should().NotBeNullOrWhiteSpace();
+        // Multipart body should carry both a `file` and `meta` part —
+        // names match the andy-docs AJ5 contract.
+        handler.CapturedBody.Should().Contain("name=file");
+        handler.CapturedBody.Should().Contain("name=meta");
+        handler.CapturedBody.Should().Contain("report.pdf");
+    }
+
+    [Fact]
+    public async Task UploadAsync_MetaPart_CarriesNameAndLinks()
+    {
+        var handler = new CapturingHandler
+        {
+            Responder = _ =>
+            {
+                var json = JsonSerializer.Serialize(new
+                {
+                    documentId = Guid.NewGuid(),
+                    linkId = Guid.NewGuid(),
+                });
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json"),
+                };
+            },
+        };
+        var client = MakeClient(handler);
+
+        var runId = Guid.NewGuid();
+        var request = new UploadRequest(
+            Content: new byte[] { 7, 7, 7 },
+            MimeType: "application/json",
+            Name: "out.json",
+            Digest: new string('b', 64),
+            Links: new[]
+            {
+                new DocumentLinkDescriptor("Run", runId.ToString(), "Output"),
+            });
+
+        await client.UploadAsync(request);
+
+        handler.CapturedBody.Should().Contain("\"name\":\"out.json\"");
+        handler.CapturedBody.Should().Contain("\"targetType\":\"Run\"");
+        handler.CapturedBody.Should().Contain($"\"targetId\":\"{runId}\"");
+        handler.CapturedBody.Should().Contain("\"role\":\"Output\"");
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.GatewayTimeout)]
+    [InlineData(HttpStatusCode.RequestTimeout)]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    public async Task UploadAsync_5xxAndTransient_ReturnsNull(HttpStatusCode status)
+    {
+        var handler = new CapturingHandler
+        {
+            Responder = _ => new HttpResponseMessage(status)
+            {
+                Content = new StringContent("upstream had a moment"),
+            },
+        };
+        var client = MakeClient(handler);
+
+        var result = await client.UploadAsync(MakeRequest());
+
+        result.Should().BeNull(
+            "best-effort contract: failures collapse to null (no throw)");
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest)]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    [InlineData(HttpStatusCode.NotFound)]
+    public async Task UploadAsync_4xx_ReturnsNull(HttpStatusCode status)
+    {
+        var handler = new CapturingHandler
+        {
+            Responder = _ => new HttpResponseMessage(status),
+        };
+        var client = MakeClient(handler);
+
+        var result = await client.UploadAsync(MakeRequest());
+
+        result.Should().BeNull(
+            "even non-retryable failures must not throw — caller is best-effort");
+    }
+
+    [Fact]
+    public async Task UploadAsync_TransportError_ReturnsNull()
+    {
+        // Network-level failure (HttpRequestException from SendAsync).
+        var handler = new ThrowingHandler(
+            new HttpRequestException("connection refused"));
+        var client = MakeClient(handler);
+
+        var result = await client.UploadAsync(MakeRequest());
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UploadAsync_MalformedJsonResponse_ReturnsNull()
+    {
+        var handler = new CapturingHandler
+        {
+            Responder = _ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{not-json", Encoding.UTF8, "application/json"),
+            },
+        };
+        var client = MakeClient(handler);
+
+        var result = await client.UploadAsync(MakeRequest());
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UploadAsync_ResponseWithMissingFields_ReturnsNull()
+    {
+        // documentId=00...0 → andy-docs returned a body but the shape
+        // is incomplete (e.g. a bug or an old server). Treat as null
+        // rather than fabricating an empty Guid DocsRef downstream.
+        var handler = new CapturingHandler
+        {
+            Responder = _ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"documentId\":\"00000000-0000-0000-0000-000000000000\",\"linkId\":\"00000000-0000-0000-0000-000000000000\"}",
+                    Encoding.UTF8, "application/json"),
+            },
+        };
+        var client = MakeClient(handler);
+
+        var result = await client.UploadAsync(MakeRequest());
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UploadAsync_CallerCancellation_PropagatesOperationCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var handler = new ThrowingHandler(
+            new OperationCanceledException(cts.Token));
+        var client = MakeClient(handler);
+
+        var act = () => client.UploadAsync(MakeRequest(), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        private readonly Exception _exception;
+        public ThrowingHandler(Exception exception) { _exception = exception; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            throw _exception;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the second half of the artifact-capture chain that #316/#319 left at metadata-only. The `FilesystemOutputArtifactCollector` now reads each artifact's bytes via the container exec channel (base64) and pushes them to andy-docs's `POST /api/documents:put` (AJ5) before emitting the manifest, stamping the returned `DocsRef` onto each `RunOutputArtifact` so downstream consumers (andy-tasks#275 Phase 2) can pin `TaskNode.OutputDocRefs` in a single round-trip.

## Design

- **New surface**: `IAndyDocsClient` + `AndyDocsHttpClient` in `Andy.Containers.Infrastructure.Audit`. Multipart wire contract mirrors andy-tasks's `AndyDocsHttpUploader` (file + meta parts; meta carries name + links). Deliberately no code dep on andy-tasks — the contract is duplicated locally.
- **Failure semantics**: best-effort. `UploadAsync` returns `null` (not throws) on transient/recoverable failures (network error, 4xx/5xx, malformed body, timeout). The collector wraps each per-file upload in its own try/catch so one bad file can't kill the whole manifest. When `IAndyDocsClient` isn't registered in DI (no `AndyDocs:ApiBaseUrl`), the collector skips the upload step entirely — pure metadata-only mode, identical to the pre-#320 wire shape.
- **Auth**: registered HttpClient attaches a bearer token via a new `ServiceBearerHandler` (M2M cred-flow via the existing `IServiceTokenService`). In `AndyAuth:Authority`-bypass mode the client is anonymous, mirroring the existing AndyModels / inbound JWT-bearer posture. andy-containers doesn't use the `Andy.Auth.M2MClient` package (its outbound posture predates it), so this hand-rolls the same shape against `IServiceTokenService`.
- **Schema bump**: `RunEventPayload.SchemaVersion` 2 → 3. New `RunOutputArtifact.DocsRef` is nullable, serialised under `EventJson`'s `WhenWritingNull` policy so v2 consumers see no surprise keys. No EF migration needed — `Run.OutputArtifacts` is already JSON-serialised, and the new field round-trips through the existing converter.
- **Byte read**: per-file `base64 -w0` exec over `IContainerService.ExecAsync` (falls back to BSD `base64` if `-w` is unsupported). Whitespace-stripped before decoding to tolerate cross-platform line wrapping.
- **Caps**: per-file 64 MiB upload limit (peak RSS bound on the exec round-trip); larger artifacts log a warning and ship metadata-only.

## Tests

- `FilesystemOutputArtifactCollectorTests`: 6 new tests covering happy-path DocsRef population, UploadRequest field shape, throwing client → metadata fallback, null-returning client → metadata fallback, null DI → pre-#320 mode, per-file isolation on read failure.
- `AndyDocsHttpClientTests` (new file): 11 tests covering happy path, multipart shape, meta payload, 5xx (×6) / 4xx (×4) / transport / malformed JSON / missing-fields / caller-cancellation paths.
- `RunEventOutboxTests`: 3 new tests for DocsRef wire round-trip, omit-when-null behaviour, and end-to-end through the EF JSON column on `Run.OutputArtifacts`.

## Test plan

- [x] `dotnet build` — 0 errors / 0 warnings
- [x] Full `dotnet test` suite green (1715 passed, 9 skipped, 0 failed)
- [ ] Manual smoke test against a running andy-docs once the deployment side lands
- [ ] andy-tasks#275 Phase 2 consumer reads `RunEventPayload.OutputArtifacts[].DocsRef` and writes `TaskNode.OutputDocRefs` (follow-up PR)

## Refs

- andy-containers#316 (collector spec)
- andy-containers#319 (metadata-only producer, merged)
- andy-tasks#275 (Phase 1 metadata-only persist; Phase 2 = consume DocsRef from this payload)
- rivoli-ai/conductor#1223 (downstream task-artifacts UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)