### PR TITLE
fix(obo): include scope in token-exchange request to bound the issued token

### DIFF
--- a/config/registration.json
+++ b/config/registration.json
@@ -25,7 +25,7 @@
       "clientSecretEnvVar": "ANDY_CONTAINERS_API_SECRET",
       "displayName": "Andy Containers API",
       "description": "Service-to-service client for Andy Containers (M2M token consumer for #944).",
-      "grantTypes": ["authorization_code", "refresh_token", "client_credentials"],
+      "grantTypes": ["authorization_code", "refresh_token", "client_credentials", "token_exchange"],
       "scopes": [
         "email",
         "profile",

--- a/src/Andy.Containers.Api/Services/ServiceTokenService.cs
+++ b/src/Andy.Containers.Api/Services/ServiceTokenService.cs
@@ -203,7 +203,11 @@ public sealed class ServiceTokenService : IServiceTokenService, IDisposable
 
         // RFC 8693 §2.1 wire shape. The grant URN and token-type URN
         // are normative; the `resource` parameter names the downstream
-        // audience.
+        // audience. The `scope` parameter is included so OpenIddict's
+        // resource validator can resolve the audience through the seeded
+        // scope→resource mapping (registration-manifest-driven); without
+        // it, the embedded andy-auth — which has no `OpenIddict:Resources`
+        // config — rejects the request with `invalid_target`.
         var form = new Dictionary<string, string>
         {
             ["grant_type"] = "urn:ietf:params:oauth:grant-type:token-exchange",
@@ -212,6 +216,7 @@ public sealed class ServiceTokenService : IServiceTokenService, IDisposable
             ["subject_token"] = subjectToken,
             ["subject_token_type"] = "urn:ietf:params:oauth:token-type:access_token",
             ["resource"] = audience,
+            ["scope"] = audience,
         };
 
         using var request = new HttpRequestMessage(HttpMethod.Post, opts.TokenEndpoint)


### PR DESCRIPTION
## Summary
Three changes needed for OBO token-exchange (`andy-containers → andy-auth → urn:andy-models-api`) to succeed end-to-end. This PR carries two; the third is rivoli-ai/andy-auth#108.

1. **`config/registration.json`** — declare `token_exchange` in the andy-containers-api client's `grantTypes`. The DbSeeder in andy-auth maps that array to OpenIddict permissions; without it the client never gets `gt:urn:ietf:params:oauth:grant-type:token-exchange` and OpenIddict rejects the OBO request with `unauthorized_client` before the TokenExchangePolicies allow-list is consulted.
2. **`ServiceTokenService.MintOnBehalfOfAsync`** — send `scope=<audience>` in the form body. Without it the server-side handler defaults `effectiveScopes` to the union of the user's subject-token scopes — broader than what the container needs. Pairs with rivoli-ai/andy-auth#108 to resolve the audience through the seeded scope→resource mapping.

## Failure mode without these fixes
```
[16:38:53 ERR] Container creation failed: could not mint per-container proxy token from andy-models for assistant 'ClaudeCode'.
 ---> ProxyTokenException: Could not exchange user token for andy-models OBO bearer.
 ---> ServiceTokenException: Token endpoint returned HTTP 400 for OBO exchange (audience=urn:andy-models-api).
```
andy-auth side:
```
The token request was rejected because the application 'andy-containers-api' was not allowed to use the specified grant type: urn:ietf:params:oauth:grant-type:token-exchange.
error: unauthorized_client — error_uri: https://documentation.openiddict.com/errors/ID2064
```

## Test plan
- [ ] Apply rivoli-ai/andy-auth#108 alongside this PR; restart andy-auth so the DbSeeder re-seeds the client with the new grant permission.
- [ ] Launch workspace in Conductor; container creates successfully (no [API-SERVER-500]).
- [ ] Inspect the issued OBO token: `scope` claim contains only `urn:andy-models-api`, `act.sub` is `andy-containers-api`, `sub` is the user.
- [ ] No regression to existing andy-containers → andy-models calls under refresh.

Refs rivoli-ai/conductor#1246 (Epic IDP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)