### PR TITLE
feat(themes): expand catalog with 7 popular themes (Conductor #904 Phase 1)

### DIFF
--- a/config/themes/global/catppuccin-latte.yaml
+++ b/config/themes/global/catppuccin-latte.yaml
@@ -1,0 +1,28 @@
+# Catppuccin Latte — the light variant of the Catppuccin family.
+# Source: https://github.com/catppuccin/catppuccin (canonical palette).
+id: catppuccin-latte
+name: catppuccin-latte
+display_name: Catppuccin Latte
+kind: terminal
+version: 1
+palette:
+  background: "#eff1f5"
+  foreground: "#4c4f69"
+  cursor: "#dc8a78"
+  selection: "#acb0be"
+  ansi_0: "#5c5f77"
+  ansi_1: "#d20f39"
+  ansi_2: "#40a02b"
+  ansi_3: "#df8e1d"
+  ansi_4: "#1e66f5"
+  ansi_5: "#ea76cb"
+  ansi_6: "#179299"
+  ansi_7: "#acb0be"
+  ansi_8: "#6c6f85"
+  ansi_9: "#d20f39"
+  ansi_10: "#40a02b"
+  ansi_11: "#df8e1d"
+  ansi_12: "#1e66f5"
+  ansi_13: "#ea76cb"
+  ansi_14: "#179299"
+  ansi_15: "#bcc0cc"

--- a/config/themes/global/catppuccin-mocha.yaml
+++ b/config/themes/global/catppuccin-mocha.yaml
@@ -1,0 +1,28 @@
+# Catppuccin Mocha — the darkest of the four Catppuccin flavours.
+# Source: https://github.com/catppuccin/catppuccin (canonical palette).
+id: catppuccin-mocha
+name: catppuccin-mocha
+display_name: Catppuccin Mocha
+kind: terminal
+version: 1
+palette:
+  background: "#1e1e2e"
+  foreground: "#cdd6f4"
+  cursor: "#f5e0dc"
+  selection: "#585b70"
+  ansi_0: "#45475a"
+  ansi_1: "#f38ba8"
+  ansi_2: "#a6e3a1"
+  ansi_3: "#f9e2af"
+  ansi_4: "#89b4fa"
+  ansi_5: "#f5c2e7"
+  ansi_6: "#94e2d5"
+  ansi_7: "#bac2de"
+  ansi_8: "#585b70"
+  ansi_9: "#f38ba8"
+  ansi_10: "#a6e3a1"
+  ansi_11: "#f9e2af"
+  ansi_12: "#89b4fa"
+  ansi_13: "#f5c2e7"
+  ansi_14: "#94e2d5"
+  ansi_15: "#a6adc8"

--- a/config/themes/global/gruvbox-dark.yaml
+++ b/config/themes/global/gruvbox-dark.yaml
@@ -1,0 +1,30 @@
+# Gruvbox Dark — Pavel Pertsev's retro-warm palette.
+# Source: https://github.com/morhetz/gruvbox (canonical palette,
+# "dark medium" variant — bg0_h is darker than the standard bg,
+# bg is brighter; we use the standard bg for general legibility).
+id: gruvbox-dark
+name: gruvbox-dark
+display_name: Gruvbox Dark
+kind: terminal
+version: 1
+palette:
+  background: "#282828"
+  foreground: "#ebdbb2"
+  cursor: "#ebdbb2"
+  selection: "#504945"
+  ansi_0: "#282828"
+  ansi_1: "#cc241d"
+  ansi_2: "#98971a"
+  ansi_3: "#d79921"
+  ansi_4: "#458588"
+  ansi_5: "#b16286"
+  ansi_6: "#689d6a"
+  ansi_7: "#a89984"
+  ansi_8: "#928374"
+  ansi_9: "#fb4934"
+  ansi_10: "#b8bb26"
+  ansi_11: "#fabd2f"
+  ansi_12: "#83a598"
+  ansi_13: "#d3869b"
+  ansi_14: "#8ec07c"
+  ansi_15: "#ebdbb2"

--- a/config/themes/global/gruvbox-light.yaml
+++ b/config/themes/global/gruvbox-light.yaml
@@ -1,0 +1,29 @@
+# Gruvbox Light — the light counterpart to Gruvbox Dark.
+# Source: https://github.com/morhetz/gruvbox (canonical palette,
+# "light medium" variant).
+id: gruvbox-light
+name: gruvbox-light
+display_name: Gruvbox Light
+kind: terminal
+version: 1
+palette:
+  background: "#fbf1c7"
+  foreground: "#3c3836"
+  cursor: "#3c3836"
+  selection: "#d5c4a1"
+  ansi_0: "#fbf1c7"
+  ansi_1: "#cc241d"
+  ansi_2: "#98971a"
+  ansi_3: "#d79921"
+  ansi_4: "#458588"
+  ansi_5: "#b16286"
+  ansi_6: "#689d6a"
+  ansi_7: "#7c6f64"
+  ansi_8: "#928374"
+  ansi_9: "#9d0006"
+  ansi_10: "#79740e"
+  ansi_11: "#b57614"
+  ansi_12: "#076678"
+  ansi_13: "#8f3f71"
+  ansi_14: "#427b58"
+  ansi_15: "#3c3836"

--- a/config/themes/global/one-dark.yaml
+++ b/config/themes/global/one-dark.yaml
@@ -1,0 +1,28 @@
+# One Dark — the Atom editor's signature dark theme.
+# Source: https://github.com/atom/one-dark-ui (canonical palette).
+id: one-dark
+name: one-dark
+display_name: One Dark
+kind: terminal
+version: 1
+palette:
+  background: "#282c34"
+  foreground: "#abb2bf"
+  cursor: "#528bff"
+  selection: "#3e4451"
+  ansi_0: "#3f4451"
+  ansi_1: "#e06c75"
+  ansi_2: "#98c379"
+  ansi_3: "#e5c07b"
+  ansi_4: "#61afef"
+  ansi_5: "#c678dd"
+  ansi_6: "#56b6c2"
+  ansi_7: "#abb2bf"
+  ansi_8: "#4f5666"
+  ansi_9: "#be5046"
+  ansi_10: "#98c379"
+  ansi_11: "#d19a66"
+  ansi_12: "#61afef"
+  ansi_13: "#c678dd"
+  ansi_14: "#56b6c2"
+  ansi_15: "#e6e6e6"

--- a/config/themes/global/solarized-light.yaml
+++ b/config/themes/global/solarized-light.yaml
@@ -1,0 +1,30 @@
+# Solarized Light — Ethan Schoonover's classic palette,
+# light variant. Counterpart to the existing solarized-dark.
+# Source: https://github.com/altercation/solarized (canonical
+# palette).
+id: solarized-light
+name: solarized-light
+display_name: Solarized Light
+kind: terminal
+version: 1
+palette:
+  background: "#fdf6e3"
+  foreground: "#657b83"
+  cursor: "#586e75"
+  selection: "#eee8d5"
+  ansi_0: "#073642"
+  ansi_1: "#dc322f"
+  ansi_2: "#859900"
+  ansi_3: "#b58900"
+  ansi_4: "#268bd2"
+  ansi_5: "#d33682"
+  ansi_6: "#2aa198"
+  ansi_7: "#eee8d5"
+  ansi_8: "#002b36"
+  ansi_9: "#cb4b16"
+  ansi_10: "#586e75"
+  ansi_11: "#657b83"
+  ansi_12: "#839496"
+  ansi_13: "#6c71c4"
+  ansi_14: "#93a1a1"
+  ansi_15: "#fdf6e3"

--- a/config/themes/global/tokyo-night.yaml
+++ b/config/themes/global/tokyo-night.yaml
@@ -1,0 +1,30 @@
+# Tokyo Night — folke/tokyonight.nvim's signature palette,
+# inspired by Tokyo's neon-lit streets at night.
+# Source: https://github.com/folke/tokyonight.nvim (canonical
+# palette, "night" style).
+id: tokyo-night
+name: tokyo-night
+display_name: Tokyo Night
+kind: terminal
+version: 1
+palette:
+  background: "#1a1b26"
+  foreground: "#c0caf5"
+  cursor: "#c0caf5"
+  selection: "#33467c"
+  ansi_0: "#15161e"
+  ansi_1: "#f7768e"
+  ansi_2: "#9ece6a"
+  ansi_3: "#e0af68"
+  ansi_4: "#7aa2f7"
+  ansi_5: "#bb9af7"
+  ansi_6: "#7dcfff"
+  ansi_7: "#a9b1d6"
+  ansi_8: "#414868"
+  ansi_9: "#f7768e"
+  ansi_10: "#9ece6a"
+  ansi_11: "#e0af68"
+  ansi_12: "#7aa2f7"
+  ansi_13: "#bb9af7"
+  ansi_14: "#7dcfff"
+  ansi_15: "#c0caf5"


### PR DESCRIPTION
## Summary

Andy-containers companion to Conductor #1690. Doubles the seeded theme catalog from 5 → 12.

New themes (all sourced from canonical upstream repos):
- **Catppuccin Mocha** + **Catppuccin Latte** — catppuccin/catppuccin
- **Gruvbox Dark** + **Gruvbox Light** — morhetz/gruvbox
- **One Dark** — atom/one-dark-ui
- **Tokyo Night** — folke/tokyonight.nvim
- **Solarized Light** — altercation/solarized (companion to existing solarized-dark)

Light variants ship alongside dark so users get a proper light-mode option (previously: solarized-dark only).

No code or schema changes — only data. The existing `ThemeSeeder` upserts each YAML at API startup by `id`. Idempotent on re-run.

## Phase 1 status (cross-repo)

- [x] Client-side favourites + search (Conductor PR #1690, merged 2026-05-20)
- [x] Expanded catalog (this PR)
- [ ] `tags: [String]` field on the `Theme` entity — deserves its own PR with the EF migration

## Test plan

- [x] `dotnet build src/Andy.Containers.Api` — clean (0 warnings, 0 errors)
- [x] `dotnet test --filter ThemeSeederTests` — 6/6 passing (those tests write fixture YAMLs to a temp dir, so they're unaffected by additions here)
- [ ] Manual smoke: start the API, hit `GET /api/themes`, expect 12 entries in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)