### PR TITLE
EX.7 — AQ1 inputs staging for cross-container artifact handoff (#328)

### DIFF
--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -472,6 +472,17 @@ try
     // (no AndyDocs:ApiBaseUrl) the collector emits metadata-only.
     builder.Services.AddScoped<IOutputArtifactCollector, FilesystemOutputArtifactCollector>();
 
+    // EX.7 (rivoli-ai/andy-containers#328). Input-artifact stager: the
+    // inverse of the collector. Before andy-cli spawns, it downloads each
+    // declared input's andy-docs document and writes it under
+    // /workspace/.andy/inputs/ inside the container. Scoped for the same
+    // reason as the collector (request-scoped IContainerService + logger).
+    // The optional IAndyDocsClient is shared with the collector; when no
+    // andy-docs is configured a run that declares inputs fails the run
+    // start (staging is impossible) — but a run with no inputs is
+    // unaffected.
+    builder.Services.AddScoped<IInputArtifactStager, FilesystemInputArtifactStager>();
+
     // AP5 (rivoli-ai/andy-containers#107). Mode dispatcher: selects the
     // run's container, transitions Pending → Provisioning, and routes
     // headless runs to the runner above (terminal/desktop modes branch

--- a/src/Andy.Containers.Api/Services/FilesystemInputArtifactStager.cs
+++ b/src/Andy.Containers.Api/Services/FilesystemInputArtifactStager.cs
@@ -1,0 +1,263 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Abstractions;
+using Andy.Containers.Configurator;
+using Andy.Containers.Infrastructure.Audit;
+using Andy.Containers.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// Default <see cref="IInputArtifactStager"/> for rivoli-ai/andy-containers#328
+/// (EX.7). Inverse of <see cref="FilesystemOutputArtifactCollector"/>:
+///
+/// <list type="number">
+///   <item>Download each input's andy-docs document bytes via
+///   <see cref="IAndyDocsClient.DownloadAsync"/>.</item>
+///   <item>Stage them under <c>/workspace/.andy/inputs/&lt;dest&gt;</c>
+///   inside the container by shelling out through
+///   <see cref="IContainerService.ExecAsync(Guid, string, TimeSpan, CancellationToken)"/>
+///   and decoding base64 in-container (the same exec/base64 transport the
+///   collector uses for reads, run in reverse).</item>
+/// </list>
+///
+/// <para>
+/// Staging is on the run-START critical path: any input that can't be
+/// fetched, is oversized, or can't be written throws
+/// <see cref="InputStagingException"/> so the runner fails the run with a
+/// clear, typed error rather than starting the agent against an empty
+/// input. No inputs → no-op.
+/// </para>
+///
+/// <para>
+/// <see cref="IContainerService"/> is resolved lazily through the service
+/// provider to mirror the collector's break of the
+/// <c>IContainerService → collector/stager</c> registration cycle that
+/// otherwise deadlocks <c>ValidateOnBuild</c>.
+/// </para>
+/// </summary>
+public sealed class FilesystemInputArtifactStager : IInputArtifactStager
+{
+    // Symmetric with FilesystemOutputArtifactCollector.OutputsRoot. The
+    // agent SDK reads inputs from here; changing it requires a coordinated
+    // bump on the agent side.
+    public const string InputsRoot = "/workspace/.andy/inputs";
+
+    // Hard cap per input artifact. Mirrors the collector's 64 MiB upload
+    // cap: the exec-channel base64 round-trip materialises the payload in
+    // memory (decoded byte[] + base64 string), so cap to keep peak RSS
+    // bounded. An oversized input fails the run (TooLarge) rather than
+    // silently truncating.
+    public const long MaxInputSizeBytes = 64L * 1024 * 1024;
+
+    // Wall-clock cap on the in-container write exec. Generous for a
+    // multi-hundred-MB base64 payload streamed through the exec channel.
+    private static readonly TimeSpan WriteTimeout = TimeSpan.FromSeconds(60);
+
+    private readonly IServiceProvider _services;
+    private IContainerService? _containersCache;
+    private IContainerService Containers
+    {
+        get
+        {
+            _containersCache ??= _services.GetRequiredService<IContainerService>();
+            return _containersCache;
+        }
+    }
+    private readonly IAndyDocsClient? _andyDocs;
+    private readonly ILogger<FilesystemInputArtifactStager> _logger;
+
+    /// <summary>
+    /// DI constructor. Resolves <see cref="IContainerService"/> lazily to
+    /// break the registration cycle (see class remarks). The andy-docs
+    /// client is optional — when null, declaring inputs fails the run
+    /// (<see cref="InputStagingFailure.DocsClientUnavailable"/>) since
+    /// staging is impossible without it.
+    /// </summary>
+    public FilesystemInputArtifactStager(
+        IServiceProvider services,
+        ILogger<FilesystemInputArtifactStager> logger,
+        IAndyDocsClient? andyDocs = null)
+    {
+        _services = services;
+        _logger = logger;
+        _andyDocs = andyDocs;
+    }
+
+    /// <summary>
+    /// Test-only overload. <c>internal</c> so DI never scans it during
+    /// <c>ValidateOnBuild</c>; visible to <c>Andy.Containers.Api.Tests</c>
+    /// via <c>InternalsVisibleTo</c>. Lets unit tests inject a mock
+    /// <see cref="IContainerService"/> directly.
+    /// </summary>
+    internal FilesystemInputArtifactStager(
+        IContainerService containers,
+        ILogger<FilesystemInputArtifactStager> logger,
+        IAndyDocsClient? andyDocs = null)
+    {
+        _services = new SingleServiceProvider(containers);
+        _containersCache = containers;
+        _logger = logger;
+        _andyDocs = andyDocs;
+    }
+
+    private sealed class SingleServiceProvider(IContainerService containers) : IServiceProvider
+    {
+        public object? GetService(Type serviceType) =>
+            serviceType == typeof(IContainerService) ? containers : null;
+    }
+
+    public async Task StageAsync(
+        Container container,
+        IReadOnlyList<HeadlessInput> inputs,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(container);
+        ArgumentNullException.ThrowIfNull(inputs);
+
+        if (inputs.Count == 0)
+        {
+            // No-op: behaviour identical to pre-EX.7.
+            return;
+        }
+
+        if (_andyDocs is null)
+        {
+            // Inputs were declared but we have no way to fetch them. This
+            // is a misconfiguration, not a transient fault — fail loudly
+            // on the first input so the run doesn't start half-staged.
+            var first = inputs[0];
+            throw new InputStagingException(
+                first.DocsRef, first.DestRelativePath, InputStagingFailure.DocsClientUnavailable,
+                "Run declares inputs but no andy-docs client is configured (AndyDocs:ApiBaseUrl unset); cannot stage cross-container artifacts.");
+        }
+
+        foreach (var input in inputs)
+        {
+            await StageOneAsync(container, input, ct).ConfigureAwait(false);
+        }
+
+        _logger.LogInformation(
+            "EX.7: staged {Count} input artifact(s) under {Root} in container {ContainerId}.",
+            inputs.Count, InputsRoot, container.Id);
+    }
+
+    private async Task StageOneAsync(Container container, HeadlessInput input, CancellationToken ct)
+    {
+        // Defence in depth: the configurator's builder already validated
+        // the dest path (traversal guard) at config-build time, but
+        // re-validate here so a hand-constructed HeadlessInput that
+        // bypassed the builder can't escape the inputs root.
+        string dest;
+        try
+        {
+            dest = HeadlessConfigBuilder.ValidateDestRelativePath(input.DestRelativePath);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new InputStagingException(
+                input.DocsRef, input.DestRelativePath, InputStagingFailure.WriteFailed,
+                $"EX.7: input dest path '{input.DestRelativePath}' is invalid: {ex.Message}", ex);
+        }
+
+        var download = await _andyDocs!
+            .DownloadAsync(input.DocsRef, MaxInputSizeBytes, ct)
+            .ConfigureAwait(false);
+
+        if (!download.IsSuccess)
+        {
+            var (failure, reason) = download.Failure switch
+            {
+                DocumentDownloadFailure.NotFound =>
+                    (InputStagingFailure.NotFound, "document not found in andy-docs"),
+                DocumentDownloadFailure.TooLarge =>
+                    (InputStagingFailure.TooLarge, $"document exceeds the {MaxInputSizeBytes}-byte input cap"),
+                _ =>
+                    (InputStagingFailure.FetchFailed, "fetch from andy-docs failed"),
+            };
+            throw new InputStagingException(
+                input.DocsRef, dest, failure,
+                $"EX.7: cannot stage input '{dest}' from docs-ref {input.DocsRef}: {reason}.");
+        }
+
+        await WriteIntoContainerAsync(container, input.DocsRef, dest, download.Content, ct)
+            .ConfigureAwait(false);
+    }
+
+    // Write the decoded bytes into the container at
+    // /workspace/.andy/inputs/<dest>. We pipe base64 over the exec channel
+    // and decode in-container — the exact inverse of the collector's read
+    // path — because raw binary over an exec stdin/stdout channel gets
+    // mangled (LF/CR translation) on the providers we ship.
+    private async Task WriteIntoContainerAsync(
+        Container container, Guid docsRef, string dest, ReadOnlyMemory<byte> content, CancellationToken ct)
+    {
+        var absolutePath = InputsRoot + "/" + dest;
+        var quotedPath = ShellSingleQuote(absolutePath);
+        var quotedDir = ShellSingleQuote(ParentDir(absolutePath));
+        var base64 = Convert.ToBase64String(content.Span);
+
+        // mkdir -p the parent, then base64 -d the heredoc-fed payload into
+        // the target. `base64 -d` (GNU) / `base64 -D` (BSD) — we try -d
+        // first and fall back to -D so the script is portable across the
+        // base images we ship. The payload is fed via stdin from a
+        // here-doc so a very large base64 string doesn't blow the ARG_MAX
+        // command-line limit.
+        var script =
+            $"mkdir -p {quotedDir} && " +
+            $"{{ printf '%s' \"$ANDY_INPUT_B64\" | base64 -d > {quotedPath} 2>/dev/null || " +
+            $"printf '%s' \"$ANDY_INPUT_B64\" | base64 -D > {quotedPath}; }}";
+
+        // Pass the base64 through an env var rather than inlining it in the
+        // command string so neither ARG_MAX nor shell-quoting of a huge
+        // payload is a concern. ExecAsync takes a single command string, so
+        // we prefix an `export` of the payload. The payload is base64 — no
+        // shell metacharacters survive — so single-quoting it is safe.
+        var command = $"sh -c '{("export ANDY_INPUT_B64=" + ShellSingleQuote(base64) + "; " + script).Replace("'", "'\\''")}'";
+
+        ExecResult exec;
+        try
+        {
+            exec = await Containers.ExecAsync(container.Id, command, WriteTimeout, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new InputStagingException(
+                docsRef, dest, InputStagingFailure.WriteFailed,
+                $"EX.7: failed to write input '{dest}' into container {container.Id}: {ex.Message}", ex);
+        }
+
+        if (exec.ExitCode != 0)
+        {
+            throw new InputStagingException(
+                docsRef, dest, InputStagingFailure.WriteFailed,
+                $"EX.7: writing input '{dest}' into container {container.Id} exited {exec.ExitCode}: {Truncate(exec.StdErr, 200)}");
+        }
+    }
+
+    // POSIX single-quote escape, identical to HeadlessRunner.ShellEscape.
+    private static string ShellSingleQuote(string value)
+        => "'" + value.Replace("'", "'\\''") + "'";
+
+    // Parent directory of a forward-slash POSIX path. Always has at least
+    // the inputs root as a prefix (dest is relative + non-empty), so this
+    // never returns "".
+    private static string ParentDir(string path)
+    {
+        var idx = path.LastIndexOf('/');
+        return idx <= 0 ? "/" : path[..idx];
+    }
+
+    private static string? Truncate(string? value, int max)
+    {
+        if (string.IsNullOrEmpty(value)) return value;
+        return value.Length <= max ? value : value[..max] + "...";
+    }
+}

--- a/src/Andy.Containers.Api/Services/HeadlessRunner.cs
+++ b/src/Andy.Containers.Api/Services/HeadlessRunner.cs
@@ -21,6 +21,12 @@ public sealed class HeadlessRunner : IHeadlessRunner
     // When null, terminal events publish without an OutputArtifacts
     // manifest — pre-#316 wire shape exactly.
     private readonly IOutputArtifactCollector? _artifactCollector;
+    // EX.7 (#328). Optional. When null (or when a run declares no
+    // inputs) the spawn path is unchanged. When a run DOES declare inputs
+    // but no stager is wired, that's a misconfiguration the stager itself
+    // surfaces — so we only need null-tolerance here for the no-inputs
+    // common case.
+    private readonly IInputArtifactStager? _inputStager;
 
     // Outer-watchdog grace: AQ3 honours limits.timeout_seconds internally
     // and exits with code 4 (→ RunEventKind.Timeout) when its CTS fires.
@@ -41,7 +47,8 @@ public sealed class HeadlessRunner : IHeadlessRunner
         IRunCancellationRegistry cancellation,
         ITokenIssuer tokens,
         ILogger<HeadlessRunner> logger,
-        IOutputArtifactCollector? artifactCollector = null)
+        IOutputArtifactCollector? artifactCollector = null,
+        IInputArtifactStager? inputStager = null)
     {
         _containers = containers;
         _db = db;
@@ -49,6 +56,7 @@ public sealed class HeadlessRunner : IHeadlessRunner
         _tokens = tokens;
         _logger = logger;
         _artifactCollector = artifactCollector;
+        _inputStager = inputStager;
     }
 
     public async Task<HeadlessRunOutcome> StartAsync(Run run, string configPath, CancellationToken ct = default)
@@ -92,6 +100,20 @@ public sealed class HeadlessRunner : IHeadlessRunner
         // throw) wakes RunsController.Cancel's WaitForTerminalAsync.
         using var registration = _cancellation.Register(run.Id, ct);
         var execToken = registration.Token;
+
+        // EX.7 (rivoli-ai/andy-containers#328). Stage cross-container input
+        // artifacts into /workspace/.andy/inputs/ BEFORE spawning andy-cli.
+        // A missing/oversized/failed input fails the run start with a clear
+        // typed error — the agent must never start against an empty input.
+        // No inputs → no-op, spawn path unchanged.
+        var stagingFailure = await StageInputsAsync(run, containerId, configPath, execToken);
+        if (stagingFailure is not null)
+        {
+            sw.Stop();
+            return await TerminateAsync(run, RunEventKind.Failed, RunStatus.Failed,
+                exitCode: null, durationSeconds: sw.Elapsed.TotalSeconds, error: stagingFailure,
+                CancellationToken.None);
+        }
 
         var command = $"andy-cli run --headless --config {ShellEscape(configPath)}";
         var execTimeout = await ResolveExecTimeoutAsync(configPath, execToken);
@@ -275,6 +297,84 @@ public sealed class HeadlessRunner : IHeadlessRunner
             _logger.LogWarning(ex,
                 "Run {RunId} could not transition {From} → {To}: {Message}",
                 run.Id, run.Status, next, ex.Message);
+        }
+    }
+
+    // EX.7 (rivoli-ai/andy-containers#328). Stage the run's declared input
+    // artifacts into the container before andy-cli spawns. Returns null on
+    // success (including the no-inputs / no-stager common case) or an
+    // actionable error string on failure (which the caller turns into a
+    // Failed terminal outcome). We source the inputs from the on-disk
+    // config the configurator just wrote — they went through the builder's
+    // path-traversal validation there.
+    private async Task<string?> StageInputsAsync(
+        Run run, Guid containerId, string configPath, CancellationToken ct)
+    {
+        IReadOnlyList<HeadlessInput>? inputs;
+        try
+        {
+            var json = await File.ReadAllTextAsync(configPath, ct);
+            var config = JsonSerializer.Deserialize<HeadlessRunConfig>(json, HeadlessConfigJson.Options);
+            inputs = config?.Inputs;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // The config was unreadable. If the run declared inputs we
+            // cannot honour them, so fail rather than start without them;
+            // if it declared none, there's nothing to stage and we let the
+            // spawn proceed (a malformed config will surface as an andy-cli
+            // exit-code mismatch).
+            if (run.Inputs is { Count: > 0 })
+            {
+                _logger.LogError(ex,
+                    "EX.7: could not read inputs from config {Path} for Run {RunId}; failing run start.",
+                    configPath, run.Id);
+                return $"Could not read input config: {ex.Message}";
+            }
+            return null;
+        }
+
+        if (inputs is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        if (_inputStager is null)
+        {
+            _logger.LogError(
+                "EX.7: Run {RunId} declares {Count} input(s) but no input stager is wired; failing run start.",
+                run.Id, inputs.Count);
+            return "Run declares input artifacts but input staging is not available on this deployment.";
+        }
+
+        var container = await _db.Containers.FindAsync(new object[] { containerId }, ct);
+        if (container is null)
+        {
+            _logger.LogError(
+                "EX.7: Run {RunId} container {ContainerId} not found; cannot stage inputs.",
+                run.Id, containerId);
+            return $"Run container {containerId} not found; cannot stage inputs.";
+        }
+
+        try
+        {
+            await _inputStager.StageAsync(container, inputs, ct);
+            return null;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (InputStagingException ex)
+        {
+            _logger.LogError(ex,
+                "EX.7: input staging failed for Run {RunId} (docs-ref {DocsRef}, dest '{Dest}', {Failure}): {Message}",
+                run.Id, ex.DocsRef, ex.DestRelativePath, ex.Failure, ex.Message);
+            return ex.Message;
         }
     }
 

--- a/src/Andy.Containers.Infrastructure/Audit/AndyDocsHttpClient.cs
+++ b/src/Andy.Containers.Infrastructure/Audit/AndyDocsHttpClient.cs
@@ -173,6 +173,150 @@ public sealed class AndyDocsHttpClient : IAndyDocsClient
         }
     }
 
+    public async Task<DocumentDownloadResult> DownloadAsync(
+        Guid documentId, long maxSizeBytes, CancellationToken ct = default)
+    {
+        if (documentId == Guid.Empty)
+        {
+            throw new ArgumentException("documentId must be a non-empty document id.", nameof(documentId));
+        }
+        if (maxSizeBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxSizeBytes), maxSizeBytes,
+                "maxSizeBytes must be positive.");
+        }
+
+        var http = _httpClientFactory.CreateClient(HttpClientName);
+
+        // Step 1: resolve the document's head content-hash. A 404 here is
+        // a genuine "no such document" — the caller maps it to a clear
+        // run-start error. Any other non-success / mis-shaped body is a
+        // transient fetch failure.
+        DocumentMetaDto? meta;
+        try
+        {
+            using var metaResponse = await http
+                .GetAsync($"api/documents/{documentId}", ct)
+                .ConfigureAwait(false);
+
+            if (metaResponse.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                _logger.LogWarning("andy-docs download: document {DocumentId} not found (404).", documentId);
+                return DocumentDownloadResult.Fail(DocumentDownloadFailure.NotFound);
+            }
+            if (!metaResponse.IsSuccessStatusCode)
+            {
+                var body = await SafeReadAsync(metaResponse.Content, ct).ConfigureAwait(false);
+                _logger.LogWarning(
+                    "andy-docs download: metadata fetch for {DocumentId} returned HTTP {Status}. Body preview: {Body}",
+                    documentId, (int)metaResponse.StatusCode, Truncate(body, 200));
+                return DocumentDownloadResult.Fail(DocumentDownloadFailure.FetchFailed);
+            }
+
+            meta = await metaResponse.Content
+                .ReadFromJsonAsync<DocumentMetaDto>(DocsResponseJson, ct)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException or NotSupportedException)
+        {
+            _logger.LogWarning(ex,
+                "andy-docs download: metadata fetch for {DocumentId} failed: {Message}", documentId, ex.Message);
+            return DocumentDownloadResult.Fail(DocumentDownloadFailure.FetchFailed);
+        }
+
+        if (meta is null || string.IsNullOrWhiteSpace(meta.ContentHash))
+        {
+            _logger.LogWarning(
+                "andy-docs download: document {DocumentId} has no head content-hash (empty document?).", documentId);
+            return DocumentDownloadResult.Fail(DocumentDownloadFailure.FetchFailed);
+        }
+
+        // Step 2: fetch the blob for the resolved head hash. Stream so we
+        // can enforce the size cap without materialising an oversized
+        // payload into memory.
+        try
+        {
+            using var blobResponse = await http
+                .GetAsync($"api/documents/{documentId}/at/{Uri.EscapeDataString(meta.ContentHash)}:blob",
+                    HttpCompletionOption.ResponseHeadersRead, ct)
+                .ConfigureAwait(false);
+
+            if (blobResponse.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                _logger.LogWarning(
+                    "andy-docs download: blob for {DocumentId}@{Hash} not found (404).", documentId, meta.ContentHash);
+                return DocumentDownloadResult.Fail(DocumentDownloadFailure.NotFound);
+            }
+            if (!blobResponse.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "andy-docs download: blob fetch for {DocumentId}@{Hash} returned HTTP {Status}.",
+                    documentId, meta.ContentHash, (int)blobResponse.StatusCode);
+                return DocumentDownloadResult.Fail(DocumentDownloadFailure.FetchFailed);
+            }
+
+            // Reject up-front if the server advertises an oversized
+            // Content-Length, before reading a single byte.
+            var declaredLength = blobResponse.Content.Headers.ContentLength;
+            if (declaredLength is { } len && len > maxSizeBytes)
+            {
+                _logger.LogWarning(
+                    "andy-docs download: blob for {DocumentId} is {Length} bytes — exceeds input cap ({Max}).",
+                    documentId, len, maxSizeBytes);
+                return DocumentDownloadResult.Fail(DocumentDownloadFailure.TooLarge);
+            }
+
+            var mimeType = blobResponse.Content.Headers.ContentType?.MediaType;
+
+            await using var stream = await blobResponse.Content
+                .ReadAsStreamAsync(ct).ConfigureAwait(false);
+            var bytes = await ReadCappedAsync(stream, maxSizeBytes, ct).ConfigureAwait(false);
+            if (bytes is null)
+            {
+                _logger.LogWarning(
+                    "andy-docs download: blob for {DocumentId} exceeded input cap ({Max}) while streaming.",
+                    documentId, maxSizeBytes);
+                return DocumentDownloadResult.Fail(DocumentDownloadFailure.TooLarge);
+            }
+
+            return DocumentDownloadResult.Ok(bytes.Value, mimeType);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or IOException)
+        {
+            _logger.LogWarning(ex,
+                "andy-docs download: blob fetch for {DocumentId} failed: {Message}", documentId, ex.Message);
+            return DocumentDownloadResult.Fail(DocumentDownloadFailure.FetchFailed);
+        }
+    }
+
+    // Read at most maxSizeBytes+1 from the stream. Returns null the moment
+    // we read past the cap (so the caller maps to TooLarge rather than
+    // OOMing on an unbounded body the Content-Length header lied about).
+    private static async Task<ReadOnlyMemory<byte>?> ReadCappedAsync(
+        Stream stream, long maxSizeBytes, CancellationToken ct)
+    {
+        using var buffer = new MemoryStream();
+        var chunk = new byte[81920];
+        int read;
+        while ((read = await stream.ReadAsync(chunk, ct).ConfigureAwait(false)) > 0)
+        {
+            if (buffer.Length + read > maxSizeBytes)
+            {
+                return null;
+            }
+            buffer.Write(chunk, 0, read);
+        }
+        return buffer.ToArray();
+    }
+
     // The `meta` part is a JSON document carrying the upload's name and
     // links. Schema mirrors andy-tasks's BuildMeta — keep these in sync
     // by hand; both target the same andy-docs endpoint.
@@ -236,4 +380,14 @@ public sealed class AndyDocsHttpClient : IAndyDocsClient
     private sealed record DocsRefWireDto(
         Guid DocumentId,
         Guid LinkId);
+
+    /// <summary>
+    /// EX.7 (rivoli-ai/andy-containers#328). Subset of andy-docs's
+    /// <c>DocumentDto</c> (<c>GET /api/documents/{id}</c>) we need to
+    /// resolve a document's head blob: <c>contentHash</c> identifies the
+    /// current version whose bytes the <c>:blob</c> endpoint serves. Other
+    /// fields (name, title, content, parentFolderId, createdAt) are present
+    /// on the wire but unused here.
+    /// </summary>
+    private sealed record DocumentMetaDto(string? ContentHash);
 }

--- a/src/Andy.Containers.Infrastructure/Audit/IAndyDocsClient.cs
+++ b/src/Andy.Containers.Infrastructure/Audit/IAndyDocsClient.cs
@@ -32,6 +32,66 @@ namespace Andy.Containers.Infrastructure.Audit;
 public interface IAndyDocsClient
 {
     Task<DocsRef?> UploadAsync(UploadRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// EX.7 (rivoli-ai/andy-containers#328). Download the current-version
+    /// bytes of an andy-docs document by id. Resolves the document's head
+    /// content-hash (<c>GET /api/documents/{id}</c>) and fetches that blob
+    /// (<c>GET /api/documents/{id}/at/{hash}:blob</c>).
+    ///
+    /// <para>
+    /// Unlike <see cref="UploadAsync"/> (best-effort, null-on-failure),
+    /// download is on the run-START critical path: a missing or failed
+    /// fetch MUST fail the run rather than start the agent with an empty
+    /// input. The return type therefore distinguishes the failure modes so
+    /// the caller can map each to a clear, typed run-start error:
+    /// <see cref="DocumentDownloadResult"/> carries either the bytes or a
+    /// <see cref="DocumentDownloadFailure"/>. The method throws only on
+    /// caller-initiated cancellation or programmer error.
+    /// </para>
+    /// </summary>
+    /// <param name="maxSizeBytes">
+    /// Hard cap on the downloaded payload. A document whose declared or
+    /// streamed size exceeds this returns
+    /// <see cref="DocumentDownloadFailure.TooLarge"/>.
+    /// </param>
+    Task<DocumentDownloadResult> DownloadAsync(
+        Guid documentId, long maxSizeBytes, CancellationToken ct = default);
+}
+
+/// <summary>
+/// EX.7 download outcome. Exactly one of <see cref="Content"/> /
+/// <see cref="Failure"/> is set: <see cref="Failure"/> is
+/// <see cref="DocumentDownloadFailure.None"/> on success.
+/// </summary>
+public sealed record DocumentDownloadResult(
+    DocumentDownloadFailure Failure,
+    ReadOnlyMemory<byte> Content,
+    string? MimeType)
+{
+    public bool IsSuccess => Failure == DocumentDownloadFailure.None;
+
+    public static DocumentDownloadResult Ok(ReadOnlyMemory<byte> content, string? mimeType) =>
+        new(DocumentDownloadFailure.None, content, mimeType);
+
+    public static DocumentDownloadResult Fail(DocumentDownloadFailure failure) =>
+        new(failure, ReadOnlyMemory<byte>.Empty, null);
+}
+
+/// <summary>EX.7 download failure classes, mapped to typed run-start errors by the stager.</summary>
+public enum DocumentDownloadFailure
+{
+    /// <summary>No failure — the result carries content.</summary>
+    None = 0,
+
+    /// <summary>Document id (or its head version) not found in andy-docs (404).</summary>
+    NotFound,
+
+    /// <summary>Document exceeds the configured input size cap.</summary>
+    TooLarge,
+
+    /// <summary>Transient / unexpected fetch failure (network error, 5xx, timeout, mis-shaped body).</summary>
+    FetchFailed,
 }
 
 /// <summary>

--- a/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
+++ b/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
@@ -386,6 +386,31 @@ public class ContainersDbContext : DbContext, IDataProtectionKeyContext
             {
                 e.Property(r => r.OutputArtifacts).HasColumnType(jsonColumnType);
             }
+
+            // Inputs (EX.7, rivoli-ai/andy-containers#328). Same JSON-column
+            // posture as OutputArtifacts: the declared cross-container input
+            // handoff is an append-only-ish list set by the caller, so a
+            // single JSON column avoids a per-field migration as RunInput
+            // grows. Mirrors the converter + sequence-equality comparer
+            // above.
+            var inputsConverter = new Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter<
+                IReadOnlyList<RunInput>?, string?>(
+                v => v == null ? null : JsonSerializer.Serialize(v, jsonOpts),
+                v => string.IsNullOrEmpty(v)
+                    ? null
+                    : JsonSerializer.Deserialize<List<RunInput>>(v, jsonOpts));
+            var inputsComparer = new ValueComparer<IReadOnlyList<RunInput>?>(
+                (a, b) => ReferenceEquals(a, b) || (a != null && b != null && a.SequenceEqual(b)),
+                v => v == null ? 0 : v.Aggregate(0, (h, x) => HashCode.Combine(h, x.GetHashCode())),
+                v => v == null ? null : v.ToList());
+            var inputsProp = e.Property(r => r.Inputs)
+                .HasConversion(inputsConverter)
+                .Metadata;
+            inputsProp.SetValueComparer(inputsComparer);
+            if (jsonColumnType != null)
+            {
+                e.Property(r => r.Inputs).HasColumnType(jsonColumnType);
+            }
         });
 
         // EnvironmentProfile — catalog of runtime shapes (X1, rivoli-ai/andy-containers#90).

--- a/src/Andy.Containers.Infrastructure/Migrations/20260529160732_AddRunInputs.Designer.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260529160732_AddRunInputs.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Andy.Containers.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Containers.Infrastructure.Migrations
 {
     [DbContext(typeof(ContainersDbContext))]
-    partial class ContainersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260529160732_AddRunInputs")]
+    partial class AddRunInputs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Containers.Infrastructure/Migrations/20260529160732_AddRunInputs.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260529160732_AddRunInputs.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Containers.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRunInputs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Inputs",
+                table: "Runs",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Inputs",
+                table: "Runs");
+        }
+    }
+}

--- a/src/Andy.Containers/Abstractions/IInputArtifactStager.cs
+++ b/src/Andy.Containers/Abstractions/IInputArtifactStager.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Configurator;
+using Andy.Containers.Models;
+
+namespace Andy.Containers.Abstractions;
+
+/// <summary>
+/// EX.7 (rivoli-ai/andy-containers#328). Stages cross-container input
+/// artifacts into a container's well-known inputs directory
+/// (<c>/workspace/.andy/inputs/</c>) BEFORE the agent starts. Inverse of
+/// <see cref="IOutputArtifactCollector"/>: outputs are collected and pushed
+/// to andy-docs at terminal-event time; inputs are pulled from andy-docs
+/// and written into the container at run-start time.
+///
+/// <para>
+/// <strong>Failure semantics:</strong> unlike output collection (best
+/// effort, never blocks), input staging is on the run-START critical path.
+/// A missing, oversized, or failed input fetch MUST fail the run rather
+/// than start the agent against an empty input. Implementations therefore
+/// throw <see cref="InputStagingException"/> on any input that cannot be
+/// staged; the runner maps that to a Failed run with a clear, typed error.
+/// </para>
+///
+/// <para>
+/// No inputs (<c>null</c>/empty list) → no-op, no error, no exec round-trip
+/// — behaviour identical to pre-EX.7.
+/// </para>
+/// </summary>
+public interface IInputArtifactStager
+{
+    /// <summary>
+    /// Download each input's andy-docs document and write its bytes under
+    /// <c>/workspace/.andy/inputs/&lt;dest_relative_path&gt;</c> inside the
+    /// container. Throws <see cref="InputStagingException"/> if any input
+    /// is missing, oversized, or otherwise un-fetchable.
+    /// </summary>
+    Task StageAsync(
+        Container container,
+        IReadOnlyList<HeadlessInput> inputs,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// EX.7 typed failure: an input artifact could not be staged, so the run
+/// must not start. Carries the offending document id and the failure class
+/// so the runner can surface an actionable error.
+/// </summary>
+public sealed class InputStagingException : Exception
+{
+    public Guid DocsRef { get; }
+    public string DestRelativePath { get; }
+    public InputStagingFailure Failure { get; }
+
+    public InputStagingException(
+        Guid docsRef, string destRelativePath, InputStagingFailure failure, string message, Exception? inner = null)
+        : base(message, inner)
+    {
+        DocsRef = docsRef;
+        DestRelativePath = destRelativePath;
+        Failure = failure;
+    }
+}
+
+/// <summary>EX.7 input-staging failure classes.</summary>
+public enum InputStagingFailure
+{
+    /// <summary>The andy-docs document (or its head version) was not found.</summary>
+    NotFound,
+
+    /// <summary>The document exceeds the configured input size cap.</summary>
+    TooLarge,
+
+    /// <summary>Transient / unexpected fetch failure (network, 5xx, timeout, mis-shaped body).</summary>
+    FetchFailed,
+
+    /// <summary>The bytes could not be written into the container (exec error, non-zero exit).</summary>
+    WriteFailed,
+
+    /// <summary>No andy-docs client is configured but inputs were declared — staging is impossible.</summary>
+    DocsClientUnavailable,
+}

--- a/src/Andy.Containers/Configurator/HeadlessConfigBuilder.cs
+++ b/src/Andy.Containers/Configurator/HeadlessConfigBuilder.cs
@@ -95,7 +95,102 @@ public sealed class HeadlessConfigBuilder : IHeadlessConfigBuilder
                 MaxIterations = agent.Limits.MaxIterations,
                 TimeoutSeconds = agent.Limits.TimeoutSeconds,
             },
+            // EX.7 (rivoli-ai/andy-containers#328). Map + validate the
+            // cross-container input handoff. Empty collapses to null (same
+            // posture as env_vars / boundaries) so a run without inputs
+            // emits no `inputs` key — wire shape identical to pre-EX.7.
+            Inputs = MapInputs(run.Inputs),
         };
+    }
+
+    // EX.7 (rivoli-ai/andy-containers#328). Validate + project the run's
+    // declared inputs onto the headless config. A malformed dest path
+    // throws ArgumentException here — RunConfigurator turns that into a
+    // RunConfiguratorResult.Fail, so a bad handoff fails the run START
+    // rather than staging into an unexpected location (or escaping the
+    // inputs root). Returns null for the empty/absent case.
+    private static IReadOnlyList<HeadlessInput>? MapInputs(IReadOnlyList<RunInput>? inputs)
+    {
+        if (inputs is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        var mapped = new List<HeadlessInput>(inputs.Count);
+        foreach (var input in inputs)
+        {
+            if (input.DocsRef == Guid.Empty)
+            {
+                throw new ArgumentException(
+                    "RunInput.DocsRef must be a non-empty andy-docs document id.", nameof(inputs));
+            }
+
+            var dest = ValidateDestRelativePath(input.DestRelativePath);
+            mapped.Add(new HeadlessInput { DocsRef = input.DocsRef, DestRelativePath = dest });
+        }
+
+        return mapped;
+    }
+
+    // EX.7 path-traversal guard. The dest must be a normalised relative
+    // path that stays under /workspace/.andy/inputs/. We reject — rather
+    // than sanitise — so an upstream bug surfaces as a clear run-start
+    // error instead of silently relocating a file. Mirrors the defensive
+    // posture FilesystemOutputArtifactCollector takes on the output side
+    // (paths-outside-root are skipped).
+    public static string ValidateDestRelativePath(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            throw new ArgumentException(
+                "RunInput.DestRelativePath is required (the staging destination under /workspace/.andy/inputs/).",
+                nameof(raw));
+        }
+
+        // Normalise separators to forward slashes; the inputs root is a
+        // POSIX path inside the container.
+        var normalised = raw.Replace('\\', '/').Trim();
+
+        if (normalised.StartsWith('/'))
+        {
+            throw new ArgumentException(
+                $"RunInput.DestRelativePath '{raw}' must be relative — no leading slash.", nameof(raw));
+        }
+
+        // Reject Windows drive / UNC prefixes that survive separator
+        // normalisation (e.g. "C:/x", "//host/share").
+        if (normalised.Length >= 2 && normalised[1] == ':')
+        {
+            throw new ArgumentException(
+                $"RunInput.DestRelativePath '{raw}' must be relative — no drive prefix.", nameof(raw));
+        }
+
+        var segments = normalised.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0)
+        {
+            throw new ArgumentException(
+                $"RunInput.DestRelativePath '{raw}' resolves to an empty path.", nameof(raw));
+        }
+
+        foreach (var segment in segments)
+        {
+            if (segment == "..")
+            {
+                throw new ArgumentException(
+                    $"RunInput.DestRelativePath '{raw}' must not contain a '..' traversal segment.", nameof(raw));
+            }
+            if (segment == ".")
+            {
+                // A bare "." segment is meaningless noise; reject so the
+                // staged path is unambiguous.
+                throw new ArgumentException(
+                    $"RunInput.DestRelativePath '{raw}' must not contain a '.' segment.", nameof(raw));
+            }
+        }
+
+        // Re-join from the validated segments so the stager works against
+        // a canonical, collapsed relative path.
+        return string.Join('/', segments);
     }
 
     private static HeadlessTool MapTool(AgentSpecTool tool)

--- a/src/Andy.Containers/Configurator/HeadlessRunConfig.cs
+++ b/src/Andy.Containers/Configurator/HeadlessRunConfig.cs
@@ -29,6 +29,42 @@ public sealed record HeadlessRunConfig
     public Guid? PolicyId { get; init; }
     public IReadOnlyList<string>? Boundaries { get; init; }
     public HeadlessLimits Limits { get; init; } = new();
+
+    /// <summary>
+    /// EX.7 (rivoli-ai/andy-containers#328). Optional cross-container
+    /// artifact handoff. Each entry names an andy-docs document
+    /// (<see cref="HeadlessInput.DocsRef"/>) and a destination path,
+    /// relative to <c>/workspace/.andy/inputs/</c>, where its bytes are
+    /// staged inside the container <em>before</em> andy-cli is spawned.
+    /// Symmetric with the outputs collector's
+    /// <c>/workspace/.andy/outputs/</c>. <c>null</c> (and the empty list,
+    /// which the builder collapses to <c>null</c>) means "no input
+    /// staging" — behaviour identical to pre-EX.7.
+    /// </summary>
+    public IReadOnlyList<HeadlessInput>? Inputs { get; init; }
+}
+
+/// <summary>
+/// EX.7 (rivoli-ai/andy-containers#328). One cross-container input: the
+/// andy-docs document to fetch and where to land it under the inputs root.
+/// </summary>
+public sealed record HeadlessInput
+{
+    /// <summary>
+    /// andy-docs document id whose current-version bytes are staged. The
+    /// stager resolves the document's head content-hash and downloads that
+    /// blob (see <c>FilesystemInputArtifactStager</c>).
+    /// </summary>
+    public Guid DocsRef { get; init; }
+
+    /// <summary>
+    /// Destination path relative to <c>/workspace/.andy/inputs/</c>. Must
+    /// be a normalised relative path — no leading slash, no <c>..</c>
+    /// segment, no drive/UNC prefix. The builder rejects traversal at
+    /// config-build time so a malformed handoff fails the run start rather
+    /// than escaping the inputs root.
+    /// </summary>
+    public string DestRelativePath { get; init; } = string.Empty;
 }
 
 public sealed record HeadlessAgent

--- a/src/Andy.Containers/Models/Run.cs
+++ b/src/Andy.Containers/Models/Run.cs
@@ -67,6 +67,18 @@ public class Run
     public IReadOnlyList<RunOutputArtifact>? OutputArtifacts { get; set; }
 
     /// <summary>
+    /// EX.7 (rivoli-ai/andy-containers#328). Cross-container input
+    /// handoff: andy-docs documents to stage under
+    /// <c>/workspace/.andy/inputs/</c> before the agent starts. Set by the
+    /// caller (e.g. andy-tasks EX.4 ContextHandoffBuilder) when a run
+    /// depends on artifacts produced by a prior task in a different
+    /// container. <c>null</c>/empty means no staging — behaviour
+    /// unchanged. Flows into <c>HeadlessRunConfig.Inputs</c> via the
+    /// configurator and is consumed by the runner's input stager.
+    /// </summary>
+    public IReadOnlyList<RunInput>? Inputs { get; set; }
+
+    /// <summary>
     /// Transition the run to <paramref name="next"/> according to AP1's state-machine
     /// invariants. Throws <see cref="InvalidOperationException"/> for illegal
     /// transitions so callers cannot silently corrupt history.

--- a/src/Andy.Containers/Models/RunInput.cs
+++ b/src/Andy.Containers/Models/RunInput.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Containers.Models;
+
+/// <summary>
+/// EX.7 (rivoli-ai/andy-containers#328). One declared cross-container
+/// input for a run: an andy-docs document to fetch and a destination path
+/// (relative to <c>/workspace/.andy/inputs/</c>) to stage it at inside the
+/// container before the agent starts.
+///
+/// <para>
+/// This is the inverse of <see cref="RunOutputArtifact"/>: outputs are
+/// <em>collected</em> from <c>/workspace/.andy/outputs/</c> and pushed to
+/// andy-docs at terminal-event time; inputs are <em>pulled</em> from
+/// andy-docs and staged under <c>/workspace/.andy/inputs/</c> at run-start
+/// time. Together they form the cross-container artifact-handoff path
+/// consumed by andy-tasks EX.4 (ContextHandoffBuilder).
+/// </para>
+///
+/// <para>
+/// <see cref="DocsRef"/> is the andy-docs document id (the
+/// <c>DocumentId</c> half of a <see cref="Models.DocsRef"/>); the stager
+/// resolves the document's head content-hash and downloads that blob.
+/// <see cref="DestRelativePath"/> must be a normalised relative path — the
+/// configurator rejects absolute paths and <c>..</c> traversal at
+/// config-build time so a malformed handoff fails the run start rather
+/// than escaping the inputs root.
+/// </para>
+/// </summary>
+public sealed record RunInput(Guid DocsRef, string DestRelativePath);

--- a/tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigBuilderTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigBuilderTests.cs
@@ -175,6 +175,116 @@ public class HeadlessConfigBuilderTests
         act.Should().Throw<ArgumentException>().WithMessage("*Run.Id*");
     }
 
+    // ----- EX.7 (rivoli-ai/andy-containers#328) inputs mapping -----
+
+    [Fact]
+    public void Build_NoInputs_OmitsInputsAndSerializesWithoutKey()
+    {
+        var run = SeedRun();
+        var spec = TriageAgent();
+
+        var config = _builder.Build(run, spec);
+
+        config.Inputs.Should().BeNull("a run without inputs carries no inputs section");
+
+        var json = HeadlessConfigJson.Serialize(config);
+        json.Should().NotContain("\"inputs\"",
+            "the WhenWritingNull policy must drop the absent inputs key entirely");
+    }
+
+    [Fact]
+    public void Build_EmptyInputsCollapseToNull()
+    {
+        var run = SeedRun();
+        run.Inputs = Array.Empty<RunInput>();
+        var spec = TriageAgent();
+
+        var config = _builder.Build(run, spec);
+
+        config.Inputs.Should().BeNull(
+            "empty inputs collapse to null, matching env_vars/boundaries posture");
+    }
+
+    [Fact]
+    public void Build_WithInputs_MapsAndSerializesSnakeCase()
+    {
+        var run = SeedRun();
+        var docA = Guid.NewGuid();
+        var docB = Guid.NewGuid();
+        run.Inputs = new[]
+        {
+            new RunInput(docA, "prior/report.json"),
+            new RunInput(docB, "context.md"),
+        };
+        var spec = TriageAgent();
+
+        var config = _builder.Build(run, spec);
+
+        config.Inputs.Should().HaveCount(2);
+        config.Inputs![0].DocsRef.Should().Be(docA);
+        config.Inputs[0].DestRelativePath.Should().Be("prior/report.json");
+        config.Inputs[1].DocsRef.Should().Be(docB);
+        config.Inputs[1].DestRelativePath.Should().Be("context.md");
+
+        // Round-trips through the configurator's snake_case serializer with
+        // the AQ1 wire names docs_ref / dest_relative_path.
+        var json = HeadlessConfigJson.Serialize(config);
+        json.Should().Contain("\"inputs\"");
+        json.Should().Contain("\"docs_ref\"");
+        json.Should().Contain("\"dest_relative_path\"");
+        json.Should().Contain(docA.ToString());
+
+        // And deserializes back into an equivalent shape.
+        var roundTripped = System.Text.Json.JsonSerializer.Deserialize<HeadlessRunConfig>(
+            json, HeadlessConfigJson.Options);
+        roundTripped!.Inputs.Should().HaveCount(2);
+        roundTripped.Inputs![0].DocsRef.Should().Be(docA);
+        roundTripped.Inputs[0].DestRelativePath.Should().Be("prior/report.json");
+    }
+
+    [Fact]
+    public void Build_InputWithEmptyDocsRef_Throws()
+    {
+        var run = SeedRun();
+        run.Inputs = new[] { new RunInput(Guid.Empty, "x.json") };
+        var spec = TriageAgent();
+
+        var act = () => _builder.Build(run, spec);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*DocsRef*");
+    }
+
+    [Theory]
+    [InlineData("/etc/passwd")]            // absolute path
+    [InlineData("../escape.txt")]          // leading traversal
+    [InlineData("a/../../b.txt")]          // mid-path traversal
+    [InlineData("..")]                     // bare traversal
+    [InlineData("C:/windows/x")]           // drive prefix
+    [InlineData("\\\\host\\share\\x")]     // UNC prefix
+    [InlineData("")]                       // empty
+    [InlineData("   ")]                    // whitespace
+    public void Build_InputWithTraversalOrAbsoluteDest_Throws(string dest)
+    {
+        var run = SeedRun();
+        run.Inputs = new[] { new RunInput(Guid.NewGuid(), dest) };
+        var spec = TriageAgent();
+
+        var act = () => _builder.Build(run, spec);
+
+        act.Should().Throw<ArgumentException>(
+            "a traversal/absolute dest must fail the run start, not escape the inputs root");
+    }
+
+    [Theory]
+    [InlineData("report.json", "report.json")]
+    [InlineData("sub/dir/data.bin", "sub/dir/data.bin")]
+    [InlineData("a//b.txt", "a/b.txt")]              // collapses empty segments
+    [InlineData("dir\\file.txt", "dir/file.txt")]    // backslash normalised
+    public void ValidateDestRelativePath_AcceptsAndCanonicalises(string raw, string expected)
+    {
+        HeadlessConfigBuilder.ValidateDestRelativePath(raw).Should().Be(expected);
+    }
+
     private static Run SeedRun() => new()
     {
         Id = Guid.NewGuid(),

--- a/tests/Andy.Containers.Api.Tests/Services/FilesystemInputArtifactStagerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/FilesystemInputArtifactStagerTests.cs
@@ -1,0 +1,259 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text;
+using Andy.Containers.Abstractions;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Configurator;
+using Andy.Containers.Infrastructure.Audit;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+// EX.7 (rivoli-ai/andy-containers#328). Stager orchestration over
+// IAndyDocsClient.DownloadAsync (fetch) + IContainerService.ExecAsync
+// (write). The "integration" path here drives the full chain end-to-end
+// with the test exec fakes: a docref is downloaded, base64-staged into the
+// container via the exec channel, and we assert both the command shape
+// (mkdir + base64 -d into the inputs root) and the failure mappings
+// (missing / oversized / fetch-failed / write-failed → typed
+// InputStagingException → run-start failure).
+public class FilesystemInputArtifactStagerTests
+{
+    private const string Root = FilesystemInputArtifactStager.InputsRoot;
+
+    private static Container ContainerFixture() => new()
+    {
+        Id = Guid.NewGuid(), Name = "c", OwnerId = "u", ExternalId = "ext-1",
+    };
+
+    // ----- no-op / unchanged behaviour -----
+
+    [Fact]
+    public async Task Stage_EmptyInputs_IsNoOp_NoExecNoDownload()
+    {
+        var containers = new Mock<IContainerService>();
+        var docs = new Mock<IAndyDocsClient>();
+        var stager = new FilesystemInputArtifactStager(
+            containers.Object, NullLogger<FilesystemInputArtifactStager>.Instance, docs.Object);
+
+        await stager.StageAsync(ContainerFixture(), Array.Empty<HeadlessInput>());
+
+        containers.Verify(c => c.ExecAsync(
+            It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        docs.Verify(d => d.DownloadAsync(
+            It.IsAny<Guid>(), It.IsAny<long>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Stage_InputsButNoDocsClient_ThrowsDocsClientUnavailable()
+    {
+        var containers = new Mock<IContainerService>();
+        var stager = new FilesystemInputArtifactStager(
+            containers.Object, NullLogger<FilesystemInputArtifactStager>.Instance, andyDocs: null);
+
+        var inputs = new[] { new HeadlessInput { DocsRef = Guid.NewGuid(), DestRelativePath = "a.txt" } };
+
+        var act = () => stager.StageAsync(ContainerFixture(), inputs);
+
+        var ex = (await act.Should().ThrowAsync<InputStagingException>()).Which;
+        ex.Failure.Should().Be(InputStagingFailure.DocsClientUnavailable);
+    }
+
+    // ----- happy path (integration over the exec fakes) -----
+
+    [Fact]
+    public async Task Stage_OneInput_DownloadsAndWritesIntoInputsRoot()
+    {
+        var docId = Guid.NewGuid();
+        var payload = Encoding.UTF8.GetBytes("hello prior task");
+        var expectedB64 = Convert.ToBase64String(payload);
+
+        var docs = new Mock<IAndyDocsClient>();
+        docs.Setup(d => d.DownloadAsync(docId, It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DocumentDownloadResult.Ok(payload, "text/plain"));
+
+        string? capturedCommand = null;
+        var containers = new Mock<IContainerService>();
+        containers.Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, CancellationToken>((_, cmd, _, _) => capturedCommand = cmd)
+            .ReturnsAsync(new ExecResult { ExitCode = 0 });
+
+        var stager = new FilesystemInputArtifactStager(
+            containers.Object, NullLogger<FilesystemInputArtifactStager>.Instance, docs.Object);
+
+        var inputs = new[]
+        {
+            new HeadlessInput { DocsRef = docId, DestRelativePath = "prior/report.json" },
+        };
+
+        await stager.StageAsync(ContainerFixture(), inputs);
+
+        // Downloaded exactly once, with the configured size cap.
+        docs.Verify(d => d.DownloadAsync(
+            docId, FilesystemInputArtifactStager.MaxInputSizeBytes, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // The write command mkdir -p's the parent and decodes base64 into
+        // the target path under the inputs root, carrying the exact bytes.
+        capturedCommand.Should().NotBeNull();
+        capturedCommand!.Should().Contain("mkdir -p");
+        capturedCommand.Should().Contain($"{Root}/prior/report.json");
+        capturedCommand.Should().Contain("base64 -d");
+        capturedCommand.Should().Contain(expectedB64,
+            "the decoded-in-container payload must match the downloaded bytes");
+    }
+
+    [Fact]
+    public async Task Stage_MultipleInputs_WritesEach()
+    {
+        var d1 = Guid.NewGuid();
+        var d2 = Guid.NewGuid();
+        var docs = new Mock<IAndyDocsClient>();
+        docs.Setup(d => d.DownloadAsync(It.IsAny<Guid>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DocumentDownloadResult.Ok(new byte[] { 1, 2, 3 }, "application/octet-stream"));
+
+        var containers = new Mock<IContainerService>();
+        containers.Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExecResult { ExitCode = 0 });
+
+        var stager = new FilesystemInputArtifactStager(
+            containers.Object, NullLogger<FilesystemInputArtifactStager>.Instance, docs.Object);
+
+        var inputs = new[]
+        {
+            new HeadlessInput { DocsRef = d1, DestRelativePath = "a.bin" },
+            new HeadlessInput { DocsRef = d2, DestRelativePath = "sub/b.bin" },
+        };
+
+        await stager.StageAsync(ContainerFixture(), inputs);
+
+        docs.Verify(d => d.DownloadAsync(It.IsAny<Guid>(), It.IsAny<long>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+        containers.Verify(c => c.ExecAsync(
+            It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    // ----- failure mapping -----
+
+    [Fact]
+    public async Task Stage_DocumentNotFound_ThrowsNotFound()
+    {
+        var docId = Guid.NewGuid();
+        var docs = new Mock<IAndyDocsClient>();
+        docs.Setup(d => d.DownloadAsync(docId, It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DocumentDownloadResult.Fail(DocumentDownloadFailure.NotFound));
+
+        var containers = new Mock<IContainerService>();
+        var stager = new FilesystemInputArtifactStager(
+            containers.Object, NullLogger<FilesystemInputArtifactStager>.Instance, docs.Object);
+
+        var inputs = new[] { new HeadlessInput { DocsRef = docId, DestRelativePath = "a.txt" } };
+
+        var ex = (await FluentActions.Awaiting(() => stager.StageAsync(ContainerFixture(), inputs))
+            .Should().ThrowAsync<InputStagingException>()).Which;
+
+        ex.Failure.Should().Be(InputStagingFailure.NotFound);
+        ex.DocsRef.Should().Be(docId);
+        // A failed fetch must not attempt to write into the container.
+        containers.Verify(c => c.ExecAsync(
+            It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Stage_DocumentTooLarge_ThrowsTooLarge()
+    {
+        var docId = Guid.NewGuid();
+        var docs = new Mock<IAndyDocsClient>();
+        docs.Setup(d => d.DownloadAsync(docId, It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DocumentDownloadResult.Fail(DocumentDownloadFailure.TooLarge));
+
+        var containers = new Mock<IContainerService>();
+        var stager = new FilesystemInputArtifactStager(
+            containers.Object, NullLogger<FilesystemInputArtifactStager>.Instance, docs.Object);
+
+        var inputs = new[] { new HeadlessInput { DocsRef = docId, DestRelativePath = "big.bin" } };
+
+        var ex = (await FluentActions.Awaiting(() => stager.StageAsync(ContainerFixture(), inputs))
+            .Should().ThrowAsync<InputStagingException>()).Which;
+
+        ex.Failure.Should().Be(InputStagingFailure.TooLarge);
+    }
+
+    [Fact]
+    public async Task Stage_FetchFailed_ThrowsFetchFailed()
+    {
+        var docId = Guid.NewGuid();
+        var docs = new Mock<IAndyDocsClient>();
+        docs.Setup(d => d.DownloadAsync(docId, It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DocumentDownloadResult.Fail(DocumentDownloadFailure.FetchFailed));
+
+        var containers = new Mock<IContainerService>();
+        var stager = new FilesystemInputArtifactStager(
+            containers.Object, NullLogger<FilesystemInputArtifactStager>.Instance, docs.Object);
+
+        var inputs = new[] { new HeadlessInput { DocsRef = docId, DestRelativePath = "a.txt" } };
+
+        var ex = (await FluentActions.Awaiting(() => stager.StageAsync(ContainerFixture(), inputs))
+            .Should().ThrowAsync<InputStagingException>()).Which;
+
+        ex.Failure.Should().Be(InputStagingFailure.FetchFailed);
+    }
+
+    [Fact]
+    public async Task Stage_ContainerWriteNonZeroExit_ThrowsWriteFailed()
+    {
+        var docId = Guid.NewGuid();
+        var docs = new Mock<IAndyDocsClient>();
+        docs.Setup(d => d.DownloadAsync(docId, It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DocumentDownloadResult.Ok(new byte[] { 1, 2, 3 }, "text/plain"));
+
+        var containers = new Mock<IContainerService>();
+        containers.Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExecResult { ExitCode = 1, StdErr = "mkdir: permission denied" });
+
+        var stager = new FilesystemInputArtifactStager(
+            containers.Object, NullLogger<FilesystemInputArtifactStager>.Instance, docs.Object);
+
+        var inputs = new[] { new HeadlessInput { DocsRef = docId, DestRelativePath = "a.txt" } };
+
+        var ex = (await FluentActions.Awaiting(() => stager.StageAsync(ContainerFixture(), inputs))
+            .Should().ThrowAsync<InputStagingException>()).Which;
+
+        ex.Failure.Should().Be(InputStagingFailure.WriteFailed);
+    }
+
+    [Fact]
+    public async Task Stage_TraversalDestThatBypassedBuilder_ThrowsWriteFailed()
+    {
+        // Defence in depth: a hand-constructed HeadlessInput that escaped
+        // the builder's validation is re-checked by the stager and must
+        // not write outside the inputs root.
+        var docId = Guid.NewGuid();
+        var docs = new Mock<IAndyDocsClient>();
+        var containers = new Mock<IContainerService>();
+        var stager = new FilesystemInputArtifactStager(
+            containers.Object, NullLogger<FilesystemInputArtifactStager>.Instance, docs.Object);
+
+        var inputs = new[] { new HeadlessInput { DocsRef = docId, DestRelativePath = "../../etc/passwd" } };
+
+        var ex = (await FluentActions.Awaiting(() => stager.StageAsync(ContainerFixture(), inputs))
+            .Should().ThrowAsync<InputStagingException>()).Which;
+
+        ex.Failure.Should().Be(InputStagingFailure.WriteFailed);
+        // Never downloaded, never wrote.
+        docs.Verify(d => d.DownloadAsync(It.IsAny<Guid>(), It.IsAny<long>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
@@ -560,6 +560,110 @@ public class HeadlessRunnerTests : IDisposable
             });
     }
 
+    // ----- EX.7 (rivoli-ai/andy-containers#328) input staging -----
+
+    [Fact]
+    public async Task StartAsync_RunWithInputs_StagesBeforeSpawningAndyCli()
+    {
+        var containerId = Guid.NewGuid();
+        var run = SeedRun(containerId);
+        SeedContainer(containerId);
+        SetupExec(containerId, exitCode: 0, stdOut: "ok");
+
+        var docId = Guid.NewGuid();
+        var configPath = WriteRealConfigWithInputs(
+            new HeadlessInput { DocsRef = docId, DestRelativePath = "prior/report.json" });
+
+        var stager = new Mock<IInputArtifactStager>();
+        var runner = new HeadlessRunner(
+            _containers.Object, _db, _cancellation, _tokens.Object,
+            NullLogger<HeadlessRunner>.Instance, artifactCollector: null, inputStager: stager.Object);
+
+        var outcome = await runner.StartAsync(run, configPath);
+
+        outcome.Status.Should().Be(RunStatus.Succeeded);
+        // The stager was invoked with the config's declared input.
+        stager.Verify(s => s.StageAsync(
+            It.Is<Container>(c => c.Id == containerId),
+            It.Is<IReadOnlyList<HeadlessInput>>(i => i.Count == 1 && i[0].DocsRef == docId),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+        File.Delete(configPath);
+    }
+
+    [Fact]
+    public async Task StartAsync_StagingFails_RunFailsWithoutSpawningAndyCli()
+    {
+        var containerId = Guid.NewGuid();
+        var run = SeedRun(containerId);
+        SeedContainer(containerId);
+
+        string? spawnCommand = null;
+        _containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, CancellationToken>((_, cmd, _, _) => spawnCommand = cmd)
+            .ReturnsAsync(new ExecResult { ExitCode = 0 });
+
+        var docId = Guid.NewGuid();
+        var configPath = WriteRealConfigWithInputs(
+            new HeadlessInput { DocsRef = docId, DestRelativePath = "a.txt" });
+
+        var stager = new Mock<IInputArtifactStager>();
+        stager.Setup(s => s.StageAsync(
+                It.IsAny<Container>(), It.IsAny<IReadOnlyList<HeadlessInput>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InputStagingException(
+                docId, "a.txt", InputStagingFailure.NotFound, "EX.7: cannot stage input 'a.txt': document not found."));
+
+        var runner = new HeadlessRunner(
+            _containers.Object, _db, _cancellation, _tokens.Object,
+            NullLogger<HeadlessRunner>.Instance, artifactCollector: null, inputStager: stager.Object);
+
+        var outcome = await runner.StartAsync(run, configPath);
+
+        outcome.Status.Should().Be(RunStatus.Failed);
+        outcome.Error.Should().Contain("a.txt");
+        spawnCommand.Should().BeNull("staging failure must short-circuit before andy-cli spawns");
+
+        var persisted = await _db.Runs.FindAsync(run.Id);
+        persisted!.Status.Should().Be(RunStatus.Failed);
+        File.Delete(configPath);
+    }
+
+    [Fact]
+    public async Task StartAsync_NoInputs_DoesNotInvokeStager()
+    {
+        var run = SeedRun();
+        SetupExec(run.ContainerId!.Value, exitCode: 0);
+        var configPath = WriteRealConfig(timeoutSeconds: 60); // no inputs
+
+        var stager = new Mock<IInputArtifactStager>();
+        var runner = new HeadlessRunner(
+            _containers.Object, _db, _cancellation, _tokens.Object,
+            NullLogger<HeadlessRunner>.Instance, artifactCollector: null, inputStager: stager.Object);
+
+        var outcome = await runner.StartAsync(run, configPath);
+
+        outcome.Status.Should().Be(RunStatus.Succeeded);
+        stager.Verify(s => s.StageAsync(
+            It.IsAny<Container>(), It.IsAny<IReadOnlyList<HeadlessInput>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        File.Delete(configPath);
+    }
+
+    private static string WriteRealConfigWithInputs(params HeadlessInput[] inputs)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"ex7-test-{Guid.NewGuid():N}.json");
+        var config = new HeadlessRunConfig
+        {
+            RunId = Guid.NewGuid(),
+            Limits = new HeadlessLimits { MaxIterations = 4, TimeoutSeconds = 60 },
+            Inputs = inputs,
+        };
+        File.WriteAllText(path, HeadlessConfigJson.Serialize(config));
+        return path;
+    }
+
     private Run SeedRun(Guid? containerId = null, Guid? correlationId = null)
         => SeedRunCore(containerId ?? Guid.NewGuid(), correlationId);
 

--- a/tests/Andy.Containers.Tests/Infrastructure/Audit/AndyDocsHttpClientTests.cs
+++ b/tests/Andy.Containers.Tests/Infrastructure/Audit/AndyDocsHttpClientTests.cs
@@ -288,4 +288,207 @@ public class AndyDocsHttpClientTests
             throw _exception;
         }
     }
+
+    // ----- EX.7 (rivoli-ai/andy-containers#328) DownloadAsync -----
+    //
+    // Download is a two-hop fetch against the REAL andy-docs wire shape:
+    //   GET /api/documents/{id}          -> DocumentDto { contentHash, ... }
+    //   GET /api/documents/{id}/at/{h}:blob -> raw bytes
+    // The router handler below impersonates both endpoints (including the
+    // 404 / non-JSON / oversized failure modes the real server emits) so
+    // the whole client chain is exercised, not just a mocked happy path.
+
+    private sealed class RouterHandler : HttpMessageHandler
+    {
+        public Func<HttpRequestMessage, HttpResponseMessage> Route { get; init; }
+            = _ => new HttpResponseMessage(HttpStatusCode.OK);
+        public List<string> Paths { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Paths.Add(request.RequestUri!.AbsolutePath);
+            return Task.FromResult(Route(request));
+        }
+    }
+
+    private static HttpResponseMessage MetaResponse(string contentHash) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(new
+                {
+                    id = Guid.NewGuid(),
+                    parentFolderId = (Guid?)null,
+                    name = "prior.json",
+                    contentHash,
+                    title = "Prior output",
+                    content = (string?)null,
+                    createdAt = DateTime.UtcNow,
+                }),
+                Encoding.UTF8, "application/json"),
+        };
+
+    private static HttpResponseMessage BlobResponse(byte[] bytes, string mime = "text/plain", long? contentLength = null)
+    {
+        var content = new ByteArrayContent(bytes);
+        content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(mime);
+        if (contentLength is { } len) content.Headers.ContentLength = len;
+        return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+    }
+
+    [Fact]
+    public async Task DownloadAsync_HappyPath_ResolvesHashThenFetchesBlob()
+    {
+        var docId = Guid.NewGuid();
+        var hash = new string('f', 64);
+        var payload = Encoding.UTF8.GetBytes("prior task output");
+
+        var handler = new RouterHandler
+        {
+            Route = req => req.RequestUri!.AbsolutePath.EndsWith(":blob")
+                ? BlobResponse(payload, "application/json")
+                : MetaResponse(hash),
+        };
+        var client = MakeClient(handler);
+
+        var result = await client.DownloadAsync(docId, maxSizeBytes: 1024);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Content.ToArray().Should().BeEquivalentTo(payload);
+        result.MimeType.Should().Be("application/json");
+
+        // Two hops, in order, against the real andy-docs paths.
+        handler.Paths.Should().HaveCount(2);
+        handler.Paths[0].Should().Be($"/api/documents/{docId}");
+        handler.Paths[1].Should().Be($"/api/documents/{docId}/at/{hash}:blob");
+    }
+
+    [Fact]
+    public async Task DownloadAsync_DocumentNotFound_ReturnsNotFound_WithoutBlobFetch()
+    {
+        var docId = Guid.NewGuid();
+        var handler = new RouterHandler
+        {
+            Route = _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+        };
+        var client = MakeClient(handler);
+
+        var result = await client.DownloadAsync(docId, maxSizeBytes: 1024);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Failure.Should().Be(DocumentDownloadFailure.NotFound);
+        handler.Paths.Should().ContainSingle("the metadata 404 must short-circuit before the blob hop");
+    }
+
+    [Fact]
+    public async Task DownloadAsync_BlobNotFound_ReturnsNotFound()
+    {
+        var docId = Guid.NewGuid();
+        var hash = new string('a', 64);
+        var handler = new RouterHandler
+        {
+            Route = req => req.RequestUri!.AbsolutePath.EndsWith(":blob")
+                ? new HttpResponseMessage(HttpStatusCode.NotFound)
+                : MetaResponse(hash),
+        };
+        var client = MakeClient(handler);
+
+        var result = await client.DownloadAsync(docId, maxSizeBytes: 1024);
+
+        result.Failure.Should().Be(DocumentDownloadFailure.NotFound);
+    }
+
+    [Fact]
+    public async Task DownloadAsync_DeclaredContentLengthOverCap_ReturnsTooLarge()
+    {
+        var docId = Guid.NewGuid();
+        var hash = new string('a', 64);
+        var handler = new RouterHandler
+        {
+            Route = req => req.RequestUri!.AbsolutePath.EndsWith(":blob")
+                ? BlobResponse(new byte[] { 1, 2, 3 }, contentLength: 10_000)
+                : MetaResponse(hash),
+        };
+        var client = MakeClient(handler);
+
+        var result = await client.DownloadAsync(docId, maxSizeBytes: 100);
+
+        result.Failure.Should().Be(DocumentDownloadFailure.TooLarge);
+    }
+
+    [Fact]
+    public async Task DownloadAsync_StreamedBytesExceedCap_ReturnsTooLarge()
+    {
+        // No Content-Length advertised (server lied / chunked) but the
+        // streamed body blows the cap — the capped reader must catch it.
+        var docId = Guid.NewGuid();
+        var hash = new string('a', 64);
+        var big = new byte[500];
+        var handler = new RouterHandler
+        {
+            Route = req => req.RequestUri!.AbsolutePath.EndsWith(":blob")
+                ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(big) }
+                : MetaResponse(hash),
+        };
+        var client = MakeClient(handler);
+
+        var result = await client.DownloadAsync(docId, maxSizeBytes: 100);
+
+        result.Failure.Should().Be(DocumentDownloadFailure.TooLarge);
+    }
+
+    [Fact]
+    public async Task DownloadAsync_MetadataMissingContentHash_ReturnsFetchFailed()
+    {
+        // Empty document (no head version) → no contentHash to fetch.
+        var docId = Guid.NewGuid();
+        var handler = new RouterHandler
+        {
+            Route = _ => MetaResponse(contentHash: ""),
+        };
+        var client = MakeClient(handler);
+
+        var result = await client.DownloadAsync(docId, maxSizeBytes: 1024);
+
+        result.Failure.Should().Be(DocumentDownloadFailure.FetchFailed);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    public async Task DownloadAsync_Metadata5xx_ReturnsFetchFailed(HttpStatusCode status)
+    {
+        var docId = Guid.NewGuid();
+        var handler = new RouterHandler
+        {
+            Route = _ => new HttpResponseMessage(status) { Content = new StringContent("boom") },
+        };
+        var client = MakeClient(handler);
+
+        var result = await client.DownloadAsync(docId, maxSizeBytes: 1024);
+
+        result.Failure.Should().Be(DocumentDownloadFailure.FetchFailed);
+    }
+
+    [Fact]
+    public async Task DownloadAsync_TransportError_ReturnsFetchFailed()
+    {
+        var client = MakeClient(new ThrowingHandler(new HttpRequestException("connection refused")));
+
+        var result = await client.DownloadAsync(Guid.NewGuid(), maxSizeBytes: 1024);
+
+        result.Failure.Should().Be(DocumentDownloadFailure.FetchFailed);
+    }
+
+    [Fact]
+    public async Task DownloadAsync_EmptyDocumentId_Throws()
+    {
+        var client = MakeClient(new RouterHandler());
+
+        var act = () => client.DownloadAsync(Guid.Empty, maxSizeBytes: 1024);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
 }


### PR DESCRIPTION
Implements **EX.7** (rivoli-ai/andy-containers#328), part of **Epic EX** (rivoli-ai/conductor#1888): the cross-container artifact-passing case.

## What
Adds an optional `inputs` array to the AQ1 headless config so a run can declare a dependency on artifacts produced by a prior task in a different container, and have them staged before the agent starts. Symmetric with the output collector: outputs are collected from `/workspace/.andy/outputs/` and pushed to andy-docs; inputs are pulled from andy-docs and staged under `/workspace/.andy/inputs/`.

### AQ1 `inputs` schema shape
```jsonc
"inputs": [
  { "docs_ref": "<andy-docs document id (uuid)>", "dest_relative_path": "prior/report.json" }
]
```
- `docs_ref` — andy-docs document id; the stager resolves its head content-hash and downloads that blob.
- `dest_relative_path` — path under `/workspace/.andy/inputs/`; no leading slash, no `..`, no drive/UNC prefix.
- Absent / empty `inputs` → no `inputs` key emitted, run is byte-for-byte unchanged.

## How
- `HeadlessRunConfig.Inputs` + `HeadlessInput` (snake_case `docs_ref` / `dest_relative_path`); `Run.Inputs` + `RunInput` model + JSON-column EF migration `AddRunInputs`.
- `HeadlessConfigBuilder` maps + validates inputs at config-build time. Path-traversal / absolute / drive / UNC dests throw `ArgumentException` → `RunConfiguratorResult.Fail`, so a malformed handoff fails the run **start** rather than escaping the inputs root. Empty collapses to null.
- `IAndyDocsClient.DownloadAsync` — two-hop fetch (`GET /api/documents/{id}` → head content-hash, then `/at/{hash}:blob` → bytes) with a size cap and typed `NotFound` / `TooLarge` / `FetchFailed` outcomes.
- `FilesystemInputArtifactStager` (inverse of `FilesystemOutputArtifactCollector`): downloads each `docs_ref` and base64-stages it into the container via `ExecAsync`; re-validates the dest defensively; missing/oversized/failed/write-failed throw a typed `InputStagingException`.
- `HeadlessRunner` stages inputs before spawning `andy-cli`; any staging failure fails the run with a clear error and never spawns the agent.

## Acceptance criteria
- ✅ A run with `inputs: [{docs_ref, dest}]` has those files staged under `/workspace/.andy/inputs/` before the agent starts.
- ✅ Missing / oversized / failed input fetch fails the run start with a clear, typed error.
- ✅ No `inputs` → behaviour unchanged (no key emitted, no exec round-trip, stager not invoked).
- ✅ Path traversal in `dest_relative_path` is rejected.

## Tests
- `HeadlessConfigBuilderTests` — `inputs` (de)serialization, snake_case wire names, empty-collapse, traversal/absolute/drive/UNC guard, dest canonicalisation.
- `FilesystemInputArtifactStagerTests` — download→base64-write into the inputs root, multi-input, no-op/empty, no-docs-client, and every failure mapping (NotFound / TooLarge / FetchFailed / WriteFailed / traversal-bypass).
- `AndyDocsHttpClientTests` — `DownloadAsync` two-hop wire contract over an `HttpMessageHandler` stub against the real andy-docs response shapes (happy path, doc/blob 404, declared + streamed oversize, missing content-hash, 5xx, transport error).
- `HeadlessRunnerTests` — staging invoked before spawn, staging failure fails the run without spawning andy-cli, no-inputs skips the stager.

96 API + 28 core tests green. The single unrelated failure in the full suite is a pre-existing telemetry static-init issue (`ActivitySources` type-initializer) requiring a live Postgres — untouched by this change.

## Deps
Consumed by andy-tasks EX.4 (`ContextHandoffBuilder`) for cross-container handoff.

Closes #328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)