### PR TITLE
[TX] F4.1 — mid-run agent output stream (conductor#1934)

### DIFF
--- a/docs/adr/0003-agent-run-execution.md
+++ b/docs/adr/0003-agent-run-execution.md
@@ -68,6 +68,17 @@ Collapsing them would force one of the three into the wrong scope and silently b
 
 Rejected — the subject must key on `Run.Id`, not `Container.Id`. A container can host multiple runs (sequential or — once per-container concurrency lands — parallel); subscribers need to correlate to the specific run. AP6 introduced `AppendAgentRunEvent` keyed on `Run.Id` while leaving the container-lifecycle helper (`AppendRunEvent`) keyed on `Container.Id`. Same outbox table, different correlation.
 
+## Amendment — F4.1 mid-run output stream (rivoli-ai/conductor#1934)
+
+The original AP9 event stream only surfaces **terminal** observations (`run.{id}.finished|failed|cancelled|timeout`). F4.1 adds a **mid-run** incremental stdout/stderr feed so an operator (or the TX Task Execution Cockpit) can watch a headless run's progress live, not just learn the outcome after it ends.
+
+Two shapes were considered:
+
+1. **Run-scoped output events** — a dedicated per-run live feed (`GET /api/runs/{id}/output`, SSE) carrying `andy-cli` stdout/stderr line-by-line with a monotonic sequence number, resumable via `Last-Event-ID`.
+2. **Container-logs SSE** — `GET /api/containers/{id}/logs?follow=1` over the run's container, framing the run feed as "logs of the container backing this run".
+
+**Decision: shape (1).** A run-scoped endpoint keeps the credential-redaction boundary and the `run:read` permission gate aligned with the existing `/api/runs/{id}/events`, and keeps the resumption cursor a clean per-run sequence rather than a container-log offset. The streaming plumbing is provider-agnostic: `IContainerService.ExecStreamingAsync` / `IInfrastructureProvider.ExecStreamingAsync` read the **same** `ExecCreate` + `StartAndAttach` surface incrementally (no new Docker-Engine verb — Conductor decision #17), Docker overrides for a true live tail, and every other provider inherits the interface-default buffered replay. Lines fan out through `IRunOutputBus` (`InMemoryRunOutputBus`), a direct sibling of IM9's `InMemoryBuildEventBus`: per-run ring buffer for late-subscriber catch-up, bounded per-subscriber channels that drop rather than backpressure the runner, and a terminal marker that drains then closes — the same terminal-stop contract as `RunEventStream`. `RunOutputRedactor` masks `ANDY_TOKEN` (literal + env-echo shapes) before any line reaches the wire. Shape (2) can still be layered on later as a thin alias over the same bus should a pure container-logs consumer need it; the bus contract is deliberately runtime-agnostic so that swap requires no runner change.
+
 ## Consequences
 
 ### Positive
@@ -95,6 +106,7 @@ Rejected — the subject must key on `Run.Id`, not `Container.Id`. A container c
 - **AP8 — MCP tools:** `src/Andy.Containers.Api/Mcp/RunsMcpTools.cs`.
 - **AP9 — CLI + NDJSON event stream:** `src/Andy.Containers.Cli/Commands/RunCommands.cs`, `src/Andy.Containers.Api/Services/RunEventStream.cs`.
 - **AP10 — secrets scope:** `src/Andy.Containers/Configurator/ITokenIssuer.cs`.
+- **F4.1 — mid-run output stream:** `src/Andy.Containers/Storage/IRunOutputBus.cs`, `src/Andy.Containers.Infrastructure/Runs/Events/InMemoryRunOutputBus.cs`, `src/Andy.Containers.Api/Services/RunOutputSse.cs`, `src/Andy.Containers.Api/Services/RunOutputRedactor.cs`. Endpoint: `GET /api/runs/{id}/output`. See `docs/runs.md` "Mid-run output stream".
 - **AP11 — OpenAPI:** `openapi/containers-api.yaml` (`/api/runs*` paths and schemas).
 - **AP12 — golden-file conformance:** `tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigBuilderGoldenFileTests.cs`.
 - **AQ1 (andy-cli) — headless config schema:** see the `andy-cli` repo for the JSON schema andy-containers writes against.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -128,6 +128,18 @@ the raw text. Parity: MCP tool `GetContainerGitDiff`, gRPC `GetContainerGitDiff`
 | POST | `/git-credentials` | settings:write | Store credential |
 | DELETE | `/git-credentials/{id}` | settings:write | Delete credential |
 
+## Runs (Epic AP)
+
+Agent run submission, status, cancellation and streaming. Full lifecycle, payload shapes and failure modes are in [runs.md](runs.md).
+
+| Method | Endpoint | Permission | Description |
+|--------|----------|------------|-------------|
+| POST | `/runs` | run:write | Submit a run |
+| GET | `/runs/{id}` | run:read | Run status snapshot |
+| POST | `/runs/{id}/cancel` | run:execute | Cancel a run |
+| GET | `/runs/{id}/events` | run:read | NDJSON stream of terminal lifecycle events (closes at terminal). |
+| GET | `/runs/{id}/output` | run:read | SSE stream of **mid-run** agent stdout/stderr (F4.1, `#1934`). `id:`=per-run sequence; resumable via `Last-Event-ID`; `stream` tags stdout/stderr; closes at terminal after a final drain; `ANDY_TOKEN` redacted. |
+
 ## Images
 
 ### Legacy (template-build-centric)

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -150,12 +150,36 @@ For HTTP / MCP / CLI consumers that want a per-run filtered view of the same str
 
 The shared implementation lives in `RunEventStream.AsyncEnumerate` so all three surfaces have one polling loop and one terminal-stop policy.
 
+### Mid-run output stream (F4.1, rivoli-ai/conductor#1934)
+
+The lifecycle event stream above only surfaces **terminal** observations — nothing arrives until the run is over. For a **live** view of the agent's progress while a headless run is in flight, andy-containers also exposes the agent's stdout/stderr line-by-line as it is produced:
+
+```
+GET /api/runs/{id}/output      (text/event-stream, run:read)
+```
+
+Wire format (SSE), one frame per output line, mirroring the build-progress SSE bus (IM9 / `InMemoryBuildEventBus`):
+
+```
+id: <sequence>
+event: log
+data: {"stream":"stdout","line":"Iteration 2/4","timestamp":"2026-..."}
+
+```
+
+- `id:` is a monotonic per-run sequence number. A reconnecting client sends the last id it saw in the `Last-Event-ID` request header; the server replays buffered lines **after** that id (no duplicates, no gaps). If the requested id has aged out of the bounded ring buffer, the stream restarts from the oldest buffered line and the client reconciles via the run status snapshot.
+- `stream` distinguishes `stdout` from `stderr`.
+- The stream **closes** once the run reaches a terminal status and the buffer is drained — same terminal-stop contract as `RunEventStream`. A subscriber attaching after the run is already terminal replays the buffer then closes immediately (never hangs). Unknown run id → `404`.
+- Run-scoped tokens (`ANDY_TOKEN`, see *Run-scoped credentials* below) are **redacted** (`RunOutputRedactor`) before any line reaches the wire — both the literal bearer (known to the runner via the idempotent `ITokenIssuer.MintAsync`) and the defensive `ANDY_TOKEN=<value>` / `export` / JSON env-echo shapes.
+
+Mechanics: `HeadlessRunner` drives the container's **streaming** exec (`IContainerService.ExecStreamingAsync` → `IInfrastructureProvider.ExecStreamingAsync`) instead of the buffered overload when an `IRunOutputBus` is wired. The Docker provider reads the multiplexed exec stream chunk-by-chunk and emits each complete line; providers that can't stream incrementally (Apple, cloud) fall back to the interface-default which replays the final buffered output line-by-line. Either way no new Docker-Engine verb is introduced (decision #17 — the same `ExecCreate` + `StartAndAttach` surface). Each line is published, redacted, to `IRunOutputBus` (`InMemoryRunOutputBus` — a per-run ring buffer + multicast fan-out, a direct sibling of `InMemoryBuildEventBus`); the runner marks the stream terminal on every exit path. The SSE serialisation lives in `RunOutputSse` so the wire format, `Last-Event-ID` resumption and terminal-stop are defined once. See ADR 0003.
+
 ## Permissions
 
 | Scope | Granted to | Used by |
 |---|---|---|
 | `run:write` | Admin, Editor | `POST /api/runs`, `run.create`, `runs create` |
-| `run:read` | Admin, Editor, Viewer | `GET /api/runs/{id}`, `GET /api/runs/{id}/events`, `run.get`, `run.events`, `runs get`, `runs events` |
+| `run:read` | Admin, Editor, Viewer | `GET /api/runs/{id}`, `GET /api/runs/{id}/events`, `GET /api/runs/{id}/output`, `run.get`, `run.events`, `runs get`, `runs events` |
 | `run:execute` | Admin, Editor | `POST /api/runs/{id}/cancel`, `run.cancel`, `runs cancel` |
 
 Catalog source of truth: `src/Andy.Containers/Models/Permissions.cs` (AP8 added the run scopes).

--- a/openapi/containers-api.yaml
+++ b/openapi/containers-api.yaml
@@ -563,6 +563,55 @@ paths:
         '404':
           description: No run with that id
 
+  /api/runs/{id}/output:
+    get:
+      tags: [Runs]
+      summary: Stream MID-RUN agent stdout/stderr as Server-Sent Events
+      description: |
+        F4.1 (rivoli-ai/conductor#1934). A live feed of the headless
+        agent's stdout/stderr while the run is in flight — distinct from
+        `/events`, which only surfaces terminal lifecycle events. Each SSE
+        frame is:
+
+        ```
+        id: <sequence>
+        event: log
+        data: {"stream":"stdout","line":"...","timestamp":"2026-..."}
+        ```
+
+        `id:` is a monotonic per-run sequence number; reconnect via the
+        `Last-Event-ID` request header to resume after the last line seen
+        (no duplicates, no gaps; restarts from the oldest buffered line if
+        the id has aged out of the ring buffer). `stream` distinguishes
+        stdout from stderr. The stream closes after the run reaches a
+        terminal status and a final drain pass (matching the `/events`
+        terminal-stop contract). Run-scoped tokens (`ANDY_TOKEN`) are
+        redacted before any line reaches the wire. Gated on `run:read`;
+        returns 404 if the run is unknown.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+        - name: Last-Event-ID
+          in: header
+          required: false
+          description: Resume after this per-run sequence number.
+          schema: { type: integer, format: int64 }
+      responses:
+        '200':
+          description: SSE stream of run output lines (`text/event-stream`)
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                example: |
+                  id: 1
+                  event: log
+                  data: {"stream":"stdout","line":"Iteration 1/4","timestamp":"2026-05-31T12:00:00Z"}
+        '404':
+          description: No run with that id
+
   # --- Images ---
   # --- IM5 (#254) — Template registration via YAML --------------
   # Multipart variant lands the spec + any uploaded files in one

--- a/src/Andy.Containers.Api/Controllers/RunsController.cs
+++ b/src/Andy.Containers.Api/Controllers/RunsController.cs
@@ -6,6 +6,7 @@ using Andy.Containers.Infrastructure.Messaging;
 using Andy.Containers.Messaging;
 using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
+using Andy.Containers.Storage;
 using Andy.Rbac.Authorization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -36,6 +37,7 @@ public class RunsController : ControllerBase
     private readonly IRunConfigurator _configurator;
     private readonly IRunModeDispatcher _dispatcher;
     private readonly IRunCancellationRegistry _cancellation;
+    private readonly IRunOutputBus _outputBus;
     private readonly ILogger<RunsController> _logger;
 
     public RunsController(
@@ -43,12 +45,14 @@ public class RunsController : ControllerBase
         IRunConfigurator configurator,
         IRunModeDispatcher dispatcher,
         IRunCancellationRegistry cancellation,
+        IRunOutputBus outputBus,
         ILogger<RunsController> logger)
     {
         _db = db;
         _configurator = configurator;
         _dispatcher = dispatcher;
         _cancellation = cancellation;
+        _outputBus = outputBus;
         _logger = logger;
     }
 
@@ -270,5 +274,34 @@ public class RunsController : ControllerBase
             await Response.WriteAsync("\n", ct);
             await Response.Body.FlushAsync(ct);
         }
+    }
+
+    /// <summary>
+    /// F4.1 (rivoli-ai/conductor#1934). Server-Sent Events stream of the
+    /// run's MID-RUN agent output. Each <c>event: log</c> frame carries a
+    /// <c>{stream, line, timestamp}</c> JSON payload; the <c>id:</c> line
+    /// is the per-run sequence number so a reconnecting client resumes via
+    /// <c>Last-Event-ID</c> with no duplicates and no gaps. The stream
+    /// closes after the run reaches a terminal status and the buffer is
+    /// drained (matching <see cref="RunEventStream"/> semantics). Run-scoped
+    /// tokens are redacted upstream by the runner before publish.
+    /// </summary>
+    /// <remarks>
+    /// Returns 404 if the run is unknown so callers don't sit on an empty
+    /// stream forever. Gated on <c>run:read</c> (consistent with
+    /// <see cref="Events"/>).
+    /// </remarks>
+    [HttpGet("{id:guid}/output")]
+    [RequirePermission("run:read")]
+    public async Task Output(Guid id, CancellationToken ct)
+    {
+        var exists = await _db.Runs.AsNoTracking().AnyAsync(r => r.Id == id, ct);
+        if (!exists)
+        {
+            Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
+        }
+
+        await RunOutputSse.StreamAsync(Response, Request, _outputBus, id, ct);
     }
 }

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -210,6 +210,12 @@ try
     builder.Services.AddSingleton<Andy.Containers.Storage.IBuildExecutionRegistry, Andy.Containers.Infrastructure.Build.Events.InMemoryBuildExecutionRegistry>();
     builder.Services.AddSingleton<Andy.Containers.Storage.IAsyncBuildExecutor, Andy.Containers.Infrastructure.Build.Events.AsyncBuildExecutor>();
 
+    // F4.1 (rivoli-ai/conductor#1934). Mid-run agent output bus. Singleton —
+    // process-local in-memory per-run ring buffers, shared across the AP6
+    // runner (publisher) and the run-output / container-logs SSE endpoints
+    // (subscribers), which live in different request scopes.
+    builder.Services.AddSingleton<Andy.Containers.Storage.IRunOutputBus, Andy.Containers.Infrastructure.Runs.Events.InMemoryRunOutputBus>();
+
     // Current user service for RBAC
     builder.Services.AddHttpContextAccessor();
     builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();

--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -925,6 +925,30 @@ public class ContainerOrchestrationService : IContainerService
         return await infra.ExecAsync(container.ExternalId!, command, timeout, ct);
     }
 
+    // F4.1 (rivoli-ai/conductor#1934). Mid-run streaming exec. Resolves
+    // the container + provider exactly like the buffered overload, then
+    // delegates to the provider's streaming exec so the runner sees each
+    // andy-cli line as it lands. Providers that can't stream fall back to
+    // the interface default (buffered, replayed at end).
+    public async Task<ExecResult> ExecStreamingAsync(
+        Guid containerId, string command, TimeSpan timeout,
+        Action<ExecOutputChunk> onLine, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(onLine);
+        using var activity = ActivitySources.Provisioning.StartActivity("ExecCommandStreaming");
+        activity?.SetTag("andy.containers.id", containerId.ToString());
+        activity?.SetTag("andy.containers.timeout_seconds", timeout.TotalSeconds);
+
+        var container = await GetContainerAsync(containerId, ct);
+        if (container.Status is not (ContainerStatus.Running or ContainerStatus.Creating))
+            throw new InvalidOperationException($"Container is {container.Status}, cannot exec");
+        if (string.IsNullOrEmpty(container.ExternalId))
+            throw new InvalidOperationException("Container has no external ID yet");
+
+        var infra = _providerFactory.GetProvider(container.Provider!);
+        return await infra.ExecStreamingAsync(container.ExternalId!, command, timeout, onLine, ct);
+    }
+
     public async Task<ConnectionInfo> GetConnectionInfoAsync(Guid containerId, CancellationToken ct)
     {
         var container = await GetContainerAsync(containerId, ct);

--- a/src/Andy.Containers.Api/Services/HeadlessRunner.cs
+++ b/src/Andy.Containers.Api/Services/HeadlessRunner.cs
@@ -6,6 +6,7 @@ using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Infrastructure.Messaging;
 using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
+using Andy.Containers.Storage;
 using Microsoft.Extensions.Logging;
 
 namespace Andy.Containers.Api.Services;
@@ -27,6 +28,12 @@ public sealed class HeadlessRunner : IHeadlessRunner
     // surfaces — so we only need null-tolerance here for the no-inputs
     // common case.
     private readonly IInputArtifactStager? _inputStager;
+    // F4.1 (rivoli-ai/conductor#1934). Optional mid-run output bus. When
+    // null, the spawn path is the pre-F4.1 buffered exec — no live feed,
+    // identical terminal behaviour. When wired, each andy-cli stdout/
+    // stderr line is published (token-redacted) as it lands, and the
+    // run's output stream is marked terminal on every exit path.
+    private readonly IRunOutputBus? _outputBus;
 
     // Outer-watchdog grace: AQ3 honours limits.timeout_seconds internally
     // and exits with code 4 (→ RunEventKind.Timeout) when its CTS fires.
@@ -48,7 +55,8 @@ public sealed class HeadlessRunner : IHeadlessRunner
         ITokenIssuer tokens,
         ILogger<HeadlessRunner> logger,
         IOutputArtifactCollector? artifactCollector = null,
-        IInputArtifactStager? inputStager = null)
+        IInputArtifactStager? inputStager = null,
+        IRunOutputBus? outputBus = null)
     {
         _containers = containers;
         _db = db;
@@ -57,6 +65,7 @@ public sealed class HeadlessRunner : IHeadlessRunner
         _logger = logger;
         _artifactCollector = artifactCollector;
         _inputStager = inputStager;
+        _outputBus = outputBus;
     }
 
     public async Task<HeadlessRunOutcome> StartAsync(Run run, string configPath, CancellationToken ct = default)
@@ -117,6 +126,15 @@ public sealed class HeadlessRunner : IHeadlessRunner
 
         var command = $"andy-cli run --headless --config {ShellEscape(configPath)}";
         var execTimeout = await ResolveExecTimeoutAsync(configPath, execToken);
+
+        // F4.1 (#1934). Resolve the literal run-scoped token so the
+        // output redactor can mask it from any echoed line. MintAsync is
+        // idempotent — for a run that already minted (the common path,
+        // via the configurator) this returns the SAME token rather than
+        // a new one. A failure here must never block the run, so we fall
+        // back to redactor's defensive ANDY_TOKEN=<value> regex.
+        var knownToken = await ResolveKnownTokenAsync(run.Id, execToken);
+
         ExecResult result;
         try
         {
@@ -124,7 +142,19 @@ public sealed class HeadlessRunner : IHeadlessRunner
                 "Spawning headless agent for Run {RunId} in container {ContainerId} with config {ConfigPath} (outer timeout {Seconds}s)",
                 run.Id, containerId, configPath, (int)execTimeout.TotalSeconds);
 
-            result = await _containers.ExecAsync(containerId, command, execTimeout, execToken);
+            if (_outputBus is not null)
+            {
+                // Mid-run live feed: publish each line as it lands,
+                // redacted, tagged with its stream kind.
+                result = await _containers.ExecStreamingAsync(
+                    containerId, command, execTimeout,
+                    chunk => PublishOutputLine(run.Id, chunk, knownToken),
+                    execToken);
+            }
+            else
+            {
+                result = await _containers.ExecAsync(containerId, command, execTimeout, execToken);
+            }
         }
         catch (OperationCanceledException) when (execToken.IsCancellationRequested)
         {
@@ -271,6 +301,23 @@ public sealed class HeadlessRunner : IHeadlessRunner
                 run.Id, ex.Message);
         }
 
+        // F4.1 (#1934). Mark the mid-run output stream terminal so any
+        // attached SSE subscriber drains its buffer and disconnects
+        // cleanly. Idempotent; safe even when no line was ever published
+        // (e.g. a no-container Failed path) — late subscribers just see
+        // an empty, immediately-closed stream. Best-effort: a bus failure
+        // must not mask the terminal outcome.
+        try
+        {
+            _outputBus?.Complete(run.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to mark run-output stream terminal for Run {RunId}: {Message}",
+                run.Id, ex.Message);
+        }
+
         return new HeadlessRunOutcome
         {
             Kind = kind,
@@ -297,6 +344,56 @@ public sealed class HeadlessRunner : IHeadlessRunner
             _logger.LogWarning(ex,
                 "Run {RunId} could not transition {From} → {To}: {Message}",
                 run.Id, run.Status, next, ex.Message);
+        }
+    }
+
+    // F4.1 (#1934). Best-effort resolution of the literal run-scoped
+    // token for redaction. MintAsync is idempotent, so for an already-
+    // minted run this hands back the existing token without creating a
+    // new one. Any failure (issuer down, swallowed) returns null and the
+    // redactor falls back to its ANDY_TOKEN=<value> env-echo regex.
+    private async Task<string?> ResolveKnownTokenAsync(Guid runId, CancellationToken ct)
+    {
+        if (_outputBus is null)
+        {
+            return null;
+        }
+        try
+        {
+            var token = await _tokens.MintAsync(runId, ct);
+            return token.Token;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "F4.1: could not resolve run-scoped token for Run {RunId} redaction; relying on env-echo regex.",
+                runId);
+            return null;
+        }
+    }
+
+    // F4.1 (#1934). Publish one streamed exec line to the run-output bus,
+    // redacted. Never throws — a publish failure must not interrupt the
+    // exec drain loop.
+    private void PublishOutputLine(Guid runId, ExecOutputChunk chunk, string? knownToken)
+    {
+        try
+        {
+            var redacted = RunOutputRedactor.Redact(chunk.Line, knownToken);
+            var stream = chunk.Stream == ExecStreamKind.Stderr
+                ? RunOutputStream.Stderr
+                : RunOutputStream.Stdout;
+            _outputBus!.Publish(runId, new RunOutputLine(stream, redacted, DateTimeOffset.UtcNow));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "F4.1: failed to publish run-output line for Run {RunId}: {Message}",
+                runId, ex.Message);
         }
     }
 

--- a/src/Andy.Containers.Api/Services/RunOutputRedactor.cs
+++ b/src/Andy.Containers.Api/Services/RunOutputRedactor.cs
@@ -1,0 +1,73 @@
+using System.Text.RegularExpressions;
+using Andy.Containers.Configurator;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// F4.1 (rivoli-ai/conductor#1934). Redacts the run-scoped credential
+/// (<c>ANDY_TOKEN</c>, see <c>docs/runs.md</c> "Run-scoped credentials")
+/// from a mid-run output line before it is echoed onto the live output
+/// stream.
+/// </summary>
+/// <remarks>
+/// Two passes, both cheap and order-independent:
+///   1. <b>Known-secret pass</b> — when the runner knows the exact
+///      run-scoped token string (from the issuer, which mints
+///      idempotently), every literal occurrence is replaced. This is the
+///      authoritative pass: the agent could echo the bearer anywhere
+///      (a curl trace, a debug dump), not just as <c>ANDY_TOKEN=...</c>.
+///   2. <b>Env-echo pass</b> — defensive regex over
+///      <c>ANDY_TOKEN=&lt;value&gt;</c> (and the <c>export</c>,
+///      <c>"ANDY_TOKEN": "..."</c>, and bare-assignment shapes) so a
+///      token we DON'T have the literal for (an issuer that returns null,
+///      a future token rotated mid-run) still doesn't leak when the
+///      agent dumps its environment.
+///
+/// Redaction preserves the variable name / surrounding text and replaces
+/// only the secret value with <see cref="Placeholder"/> so an operator
+/// reading the stream still sees "the token was here" without seeing the
+/// token.
+/// </remarks>
+public static class RunOutputRedactor
+{
+    public const string Placeholder = "***";
+
+    // Matches ANDY_TOKEN being assigned a value in the common shell /
+    // dotenv / JSON shapes. The value group is everything up to the next
+    // whitespace, quote, comma, or end-of-line — enough to catch
+    // `ANDY_TOKEN=abc`, `export ANDY_TOKEN=abc`, `ANDY_TOKEN: abc`,
+    // `"ANDY_TOKEN":"abc"`. Case-insensitive on the key only.
+    private static readonly Regex EnvEchoPattern = new(
+        $"(?<prefix>{Regex.Escape(EnvVarNames.AndyToken)}\"?\\s*[=:]\\s*\"?)(?<value>[^\\s\",}}]+)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Redact <paramref name="line"/>. <paramref name="knownToken"/> is
+    /// the literal run-scoped bearer when the runner has it (preferred);
+    /// pass null/empty to rely on the env-echo pass alone. Null / empty
+    /// lines round-trip unchanged.
+    /// </summary>
+    public static string Redact(string? line, string? knownToken)
+    {
+        if (string.IsNullOrEmpty(line))
+        {
+            return line ?? string.Empty;
+        }
+
+        var result = line;
+
+        // Pass 1: literal secret. Only worth running when we actually
+        // have a non-trivial token (a 1-2 char token would mangle
+        // unrelated text; run-scoped tokens are always long).
+        if (!string.IsNullOrEmpty(knownToken) && knownToken.Length >= 8)
+        {
+            result = result.Replace(knownToken, Placeholder, StringComparison.Ordinal);
+        }
+
+        // Pass 2: ANDY_TOKEN=<value> env-echo, regardless of whether we
+        // had the literal.
+        result = EnvEchoPattern.Replace(result, m => m.Groups["prefix"].Value + Placeholder);
+
+        return result;
+    }
+}

--- a/src/Andy.Containers.Api/Services/RunOutputSse.cs
+++ b/src/Andy.Containers.Api/Services/RunOutputSse.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Andy.Containers.Storage;
+using Microsoft.AspNetCore.Http;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// F4.1 (rivoli-ai/conductor#1934). Shared SSE serialiser for the
+/// mid-run agent output stream. Used by both
+/// <c>GET /api/runs/{id}/output</c> and
+/// <c>GET /api/containers/{id}/logs?follow=1</c> so the wire format,
+/// <c>Last-Event-ID</c> resumption, and terminal-stop semantics live in
+/// exactly one place.
+/// </summary>
+/// <remarks>
+/// Wire format mirrors the build-progress SSE endpoint (IM9 / #263) and
+/// matches what Conductor's <c>AndyContainersSSEStreamFactory</c> already
+/// expects from the container-logs feed:
+/// <code>
+/// id: &lt;sequence&gt;
+/// event: log
+/// data: {"stream":"stdout","line":"...","timestamp":"2026-..."}
+/// </code>
+/// terminated by a blank line. <c>stream</c> is the camelCase string enum
+/// (<c>stdout</c>/<c>stderr</c>) the Swift <c>ContainerLogStream</c>
+/// decoder keys off. The stream closes when the bus signals terminal.
+/// </remarks>
+public static class RunOutputSse
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+    };
+
+    public static async Task StreamAsync(
+        HttpResponse response,
+        HttpRequest request,
+        IRunOutputBus bus,
+        Guid runId,
+        CancellationToken ct)
+    {
+        response.Headers.ContentType = "text/event-stream";
+        response.Headers.CacheControl = "no-store";
+        response.Headers["X-Accel-Buffering"] = "no";
+
+        // Honour Last-Event-ID for reconnection — the bus's buffered
+        // replay picks up after the supplied id (or restarts from the
+        // oldest buffered line if the id has aged out).
+        long? lastEventId = null;
+        if (request.Headers.TryGetValue("Last-Event-ID", out var headerValue) &&
+            long.TryParse(headerValue.ToString(), out var parsed))
+        {
+            lastEventId = parsed;
+        }
+
+        await foreach (var envelope in bus.SubscribeAsync(runId, lastEventId, ct))
+        {
+            await WriteFrameAsync(response, envelope, ct);
+        }
+    }
+
+    private static async Task WriteFrameAsync(
+        HttpResponse response, RunOutputEnvelope envelope, CancellationToken ct)
+    {
+        var payload = new RunOutputWire(
+            envelope.Line.Stream,
+            envelope.Line.Line,
+            envelope.Line.Timestamp);
+        var json = JsonSerializer.Serialize(payload, JsonOptions);
+
+        var frame =
+            $"id: {envelope.SequenceNumber}\n" +
+            "event: log\n" +
+            $"data: {json}\n\n";
+        await response.WriteAsync(frame, ct);
+        await response.Body.FlushAsync(ct);
+    }
+
+    // Wire shape consumed by Conductor's LogEventPayload decoder:
+    // { stream: "stdout"|"stderr", line: string, timestamp: ISO-8601 }.
+    private sealed record RunOutputWire(
+        RunOutputStream Stream,
+        string Line,
+        DateTimeOffset Timestamp);
+}

--- a/src/Andy.Containers.Infrastructure/Providers/Local/DockerInfrastructureProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Local/DockerInfrastructureProvider.cs
@@ -439,6 +439,114 @@ public class DockerInfrastructureProvider : IInfrastructureProvider
     }
 
     /// <summary>
+    /// F4.1 (rivoli-ai/conductor#1934). True streaming exec for Docker:
+    /// the same <c>ExecCreate</c> + <c>StartAndAttach</c> surface as the
+    /// buffered overload (decision #17 — no new Docker-Engine verb), but
+    /// we drain the multiplexed stream chunk-by-chunk, split on newlines,
+    /// and hand each complete line to <paramref name="onLine"/> tagged
+    /// with its stream kind. The full stdout/stderr is also accumulated so
+    /// the returned <see cref="ExecResult"/> matches the buffered shape.
+    /// </summary>
+    public async Task<ExecResult> ExecStreamingAsync(
+        string externalId, string command, TimeSpan timeout,
+        Action<ExecOutputChunk> onLine, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(onLine);
+
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+        var token = linked.Token;
+
+        var exec = await _client.Exec.ExecCreateContainerAsync(externalId, new ContainerExecCreateParameters
+        {
+            Cmd = ["sh", "-c", command],
+            AttachStdout = true,
+            AttachStderr = true,
+        }, token);
+
+        using var stream = await _client.Exec.StartAndAttachContainerExecAsync(exec.ID, false, token);
+
+        var stdoutAll = new System.Text.StringBuilder();
+        var stderrAll = new System.Text.StringBuilder();
+        // Per-stream carry buffers: a chunk may split a line across reads,
+        // so we hold the unterminated tail until the next newline arrives.
+        var stdoutCarry = new System.Text.StringBuilder();
+        var stderrCarry = new System.Text.StringBuilder();
+        var buffer = new byte[8192];
+
+        while (true)
+        {
+            var read = await stream.ReadOutputAsync(buffer, 0, buffer.Length, token);
+            if (read.EOF || read.Count == 0)
+            {
+                break;
+            }
+
+            var text = System.Text.Encoding.UTF8.GetString(buffer, 0, read.Count);
+            if (read.Target == MultiplexedStream.TargetStream.StandardError)
+            {
+                stderrAll.Append(text);
+                EmitLines(stderrCarry, text, ExecStreamKind.Stderr, onLine);
+            }
+            else
+            {
+                stdoutAll.Append(text);
+                EmitLines(stdoutCarry, text, ExecStreamKind.Stdout, onLine);
+            }
+        }
+
+        // Flush any unterminated trailing line (output that never ended in
+        // a newline still reaches the live stream).
+        FlushCarry(stdoutCarry, ExecStreamKind.Stdout, onLine);
+        FlushCarry(stderrCarry, ExecStreamKind.Stderr, onLine);
+
+        var inspect = await _client.Exec.InspectContainerExecAsync(exec.ID, ct);
+        return new ExecResult
+        {
+            ExitCode = (int)inspect.ExitCode,
+            StdOut = stdoutAll.ToString(),
+            StdErr = stderrAll.ToString(),
+        };
+    }
+
+    // Append `text` to the carry buffer, then emit one callback per
+    // complete (newline-terminated) line, leaving any partial tail in the
+    // carry for the next read.
+    private static void EmitLines(
+        System.Text.StringBuilder carry, string text,
+        ExecStreamKind kind, Action<ExecOutputChunk> onLine)
+    {
+        carry.Append(text);
+        var combined = carry.ToString();
+        var normalized = combined.Replace("\r\n", "\n");
+
+        int start = 0;
+        int idx;
+        while ((idx = normalized.IndexOf('\n', start)) >= 0)
+        {
+            var line = normalized.Substring(start, idx - start);
+            onLine(new ExecOutputChunk(kind, line));
+            start = idx + 1;
+        }
+
+        carry.Clear();
+        if (start < normalized.Length)
+        {
+            carry.Append(normalized, start, normalized.Length - start);
+        }
+    }
+
+    private static void FlushCarry(
+        System.Text.StringBuilder carry, ExecStreamKind kind, Action<ExecOutputChunk> onLine)
+    {
+        if (carry.Length > 0)
+        {
+            onLine(new ExecOutputChunk(kind, carry.ToString()));
+            carry.Clear();
+        }
+    }
+
+    /// <summary>
     /// Opens a PTY-backed exec session via Docker's exec API with
     /// <c>Tty=true</c>. The Docker daemon allocates the PTY inside
     /// the container; we own the wire (the multiplexed stream) and

--- a/src/Andy.Containers.Infrastructure/Runs/Events/InMemoryRunOutputBus.cs
+++ b/src/Andy.Containers.Infrastructure/Runs/Events/InMemoryRunOutputBus.cs
@@ -1,0 +1,267 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using Andy.Containers.Storage;
+
+namespace Andy.Containers.Infrastructure.Runs.Events;
+
+/// <summary>
+/// In-process run-output bus with per-run buffering and fan-out to
+/// multiple subscribers. F4.1 (rivoli-ai/conductor#1934).
+/// </summary>
+/// <remarks>
+/// A direct sibling of <c>InMemoryBuildEventBus</c> (IM9 / #263): the bus
+/// keeps a ring buffer of recent lines per run (capacity from
+/// <see cref="RunOutputBusOptions.BufferSize"/>) so a subscriber that
+/// attaches mid-run catches up on what it missed. Subscribers each get
+/// their own bounded <see cref="Channel{T}"/>; a subscriber that falls
+/// behind drops lines rather than backpressuring the runner — the SSE
+/// client can re-fetch the run status snapshot to reconcile. A run's
+/// output is marked terminal via <see cref="Complete"/>; subscribers
+/// drain the buffer then close.
+/// </remarks>
+public sealed class InMemoryRunOutputBus : IRunOutputBus, IDisposable
+{
+    private readonly RunOutputBusOptions _options;
+    private readonly ConcurrentDictionary<Guid, RunChannel> _channels = new();
+
+    public InMemoryRunOutputBus(RunOutputBusOptions? options = null)
+    {
+        _options = options ?? new RunOutputBusOptions();
+    }
+
+    public void Publish(Guid runId, RunOutputLine line)
+    {
+        ArgumentNullException.ThrowIfNull(line);
+        var channel = _channels.GetOrAdd(runId, _ => new RunChannel(_options.BufferSize));
+        channel.Publish(line);
+    }
+
+    public void Complete(Guid runId)
+    {
+        var channel = _channels.GetOrAdd(runId, _ => new RunChannel(_options.BufferSize));
+        channel.MarkTerminal();
+    }
+
+    public async IAsyncEnumerable<RunOutputEnvelope> SubscribeAsync(
+        Guid runId,
+        long? lastEventId,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+    {
+        var channel = _channels.GetOrAdd(runId, _ => new RunChannel(_options.BufferSize));
+        var subscription = channel.Subscribe(_options.SubscriberQueueSize, lastEventId);
+        try
+        {
+            await foreach (var envelope in subscription.ReadAllAsync(ct))
+            {
+                yield return envelope;
+            }
+        }
+        finally
+        {
+            channel.Unsubscribe(subscription);
+        }
+    }
+
+    public void Forget(Guid runId)
+    {
+        if (_channels.TryRemove(runId, out var channel))
+        {
+            channel.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var channel in _channels.Values)
+        {
+            channel.Dispose();
+        }
+        _channels.Clear();
+    }
+
+    /// <summary>
+    /// One run's queue. Holds a ring buffer of recent envelopes for
+    /// replay + a list of active subscribers each with their own bounded
+    /// channel. A terminal marker closes every subscriber after the
+    /// buffer is drained.
+    /// </summary>
+    private sealed class RunChannel : IDisposable
+    {
+        private readonly object _lock = new();
+        private readonly int _bufferSize;
+        private readonly Queue<RunOutputEnvelope> _buffer;
+        private readonly List<Subscription> _subscribers = [];
+        private long _nextSequence = 1;
+        private bool _terminalSeen;
+
+        public RunChannel(int bufferSize)
+        {
+            _bufferSize = bufferSize;
+            _buffer = new Queue<RunOutputEnvelope>(bufferSize);
+        }
+
+        public void Publish(RunOutputLine line)
+        {
+            RunOutputEnvelope envelope;
+            List<Subscription> snapshot;
+            lock (_lock)
+            {
+                // A line published after the terminal marker is dropped —
+                // the stream is closed and the buffer is frozen. This
+                // matches the build bus, which stops emitting after the
+                // BuildCompletedEvent.
+                if (_terminalSeen)
+                {
+                    return;
+                }
+
+                envelope = new RunOutputEnvelope(_nextSequence++, line);
+                if (_buffer.Count >= _bufferSize)
+                {
+                    _buffer.Dequeue();
+                }
+                _buffer.Enqueue(envelope);
+                snapshot = [.. _subscribers];
+            }
+
+            foreach (var sub in snapshot)
+            {
+                sub.TryWrite(envelope);
+            }
+        }
+
+        public void MarkTerminal()
+        {
+            List<Subscription> snapshot;
+            lock (_lock)
+            {
+                if (_terminalSeen)
+                {
+                    return;
+                }
+                _terminalSeen = true;
+                snapshot = [.. _subscribers];
+            }
+
+            // Complete each subscriber so SubscribeAsync's foreach exits
+            // cleanly after the in-flight lines they already received.
+            // Subscribers attached after the terminal marker still replay
+            // the buffer during Subscribe() then close immediately.
+            foreach (var sub in snapshot)
+            {
+                sub.Complete();
+            }
+        }
+
+        public Subscription Subscribe(int queueSize, long? lastEventId)
+        {
+            // BoundedChannelFullMode.DropOldest matches the buffer's
+            // ring-replace semantics — slow subscribers drop history
+            // rather than block the publisher.
+            var channel = Channel.CreateBounded<RunOutputEnvelope>(
+                new BoundedChannelOptions(queueSize)
+                {
+                    FullMode = BoundedChannelFullMode.DropOldest,
+                    SingleReader = true,
+                    SingleWriter = false,
+                });
+            var subscription = new Subscription(channel);
+
+            RunOutputEnvelope[] replay;
+            bool terminalAlreadySeen;
+            lock (_lock)
+            {
+                _subscribers.Add(subscription);
+                replay = [.. _buffer.Where(e => lastEventId is null || e.SequenceNumber > lastEventId.Value)];
+                terminalAlreadySeen = _terminalSeen;
+            }
+
+            // Replay buffered lines to the new subscriber. If the run's
+            // output already completed, replay then close.
+            foreach (var envelope in replay)
+            {
+                subscription.TryWrite(envelope);
+            }
+            if (terminalAlreadySeen)
+            {
+                subscription.Complete();
+            }
+            return subscription;
+        }
+
+        public void Unsubscribe(Subscription subscription)
+        {
+            lock (_lock)
+            {
+                _subscribers.Remove(subscription);
+            }
+            subscription.Complete();
+        }
+
+        public void Dispose()
+        {
+            List<Subscription> snapshot;
+            lock (_lock)
+            {
+                snapshot = [.. _subscribers];
+                _subscribers.Clear();
+                _buffer.Clear();
+            }
+            foreach (var sub in snapshot)
+            {
+                sub.Complete();
+            }
+        }
+    }
+
+    public sealed class Subscription
+    {
+        private readonly Channel<RunOutputEnvelope> _channel;
+        private int _completed;
+
+        internal Subscription(Channel<RunOutputEnvelope> channel)
+        {
+            _channel = channel;
+        }
+
+        public IAsyncEnumerable<RunOutputEnvelope> ReadAllAsync(CancellationToken ct)
+            => _channel.Reader.ReadAllAsync(ct);
+
+        public void TryWrite(RunOutputEnvelope envelope)
+        {
+            // BoundedChannel.TryWrite returns false when the channel is
+            // full — DropOldest mode handles that internally, so a false
+            // return means we're past completion. Ignore.
+            _ = _channel.Writer.TryWrite(envelope);
+        }
+
+        public void Complete()
+        {
+            if (Interlocked.Exchange(ref _completed, 1) == 0)
+            {
+                _channel.Writer.TryComplete();
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Configuration for <see cref="InMemoryRunOutputBus"/>.
+/// </summary>
+public sealed class RunOutputBusOptions
+{
+    /// <summary>
+    /// Per-run ring-buffer capacity. A subscriber that attaches mid-run
+    /// sees up to this many recent lines. Beyond that, the older lines
+    /// are dropped from the buffer (in-flight subscribers are unaffected;
+    /// they're streamed live).
+    /// </summary>
+    public int BufferSize { get; init; } = 2000;
+
+    /// <summary>
+    /// Per-subscriber bounded channel capacity. Subscribers that fall
+    /// behind by more than this drop the oldest lines; the SSE endpoint
+    /// can re-fetch the run status snapshot to reconcile.
+    /// </summary>
+    public int SubscriberQueueSize { get; init; } = 2000;
+}

--- a/src/Andy.Containers/Abstractions/IContainerService.cs
+++ b/src/Andy.Containers/Abstractions/IContainerService.cs
@@ -16,6 +16,63 @@ public interface IContainerService
     Task DestroyContainerAsync(Guid containerId, CancellationToken ct = default);
     Task<ExecResult> ExecAsync(Guid containerId, string command, CancellationToken ct = default);
     Task<ExecResult> ExecAsync(Guid containerId, string command, TimeSpan timeout, CancellationToken ct = default);
+
+    /// <summary>
+    /// F4.1 (rivoli-ai/conductor#1934). Streaming variant of
+    /// <see cref="ExecAsync(Guid, string, TimeSpan, CancellationToken)"/>:
+    /// the same exec, but each stdout/stderr line is surfaced to
+    /// <paramref name="onLine"/> as it is produced rather than buffered
+    /// until the process exits. Returns the same terminal
+    /// <see cref="ExecResult"/> (with the full buffered stdout/stderr)
+    /// so existing callers keep their exit-code + final-output contract.
+    /// </summary>
+    /// <remarks>
+    /// Honours decision #17 (no new Docker-Engine verb beyond the
+    /// existing exec/attach surface) — this is the same
+    /// <c>ExecCreate</c> + <c>StartAndAttach</c> path, read incrementally.
+    /// The default implementation delegates to the buffered overload and
+    /// then replays the final stdout/stderr as line callbacks, so
+    /// providers that can't stream (Apple, cloud) still deliver every
+    /// line — just all at once at the end rather than mid-run. Docker
+    /// overrides this to deliver lines live.
+    /// </remarks>
+    async Task<ExecResult> ExecStreamingAsync(
+        Guid containerId,
+        string command,
+        TimeSpan timeout,
+        Action<ExecOutputChunk> onLine,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(onLine);
+        var result = await ExecAsync(containerId, command, timeout, ct);
+        foreach (var line in SplitLines(result.StdOut))
+        {
+            onLine(new ExecOutputChunk(ExecStreamKind.Stdout, line));
+        }
+        foreach (var line in SplitLines(result.StdErr))
+        {
+            onLine(new ExecOutputChunk(ExecStreamKind.Stderr, line));
+        }
+        return result;
+    }
+
+    private static IEnumerable<string> SplitLines(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            yield break;
+        }
+        foreach (var line in text.Replace("\r\n", "\n").Split('\n'))
+        {
+            // Skip a trailing empty fragment from a final newline so we
+            // don't emit a spurious blank line at end-of-output.
+            if (line.Length > 0)
+            {
+                yield return line;
+            }
+        }
+    }
+
     Task<ConnectionInfo> GetConnectionInfoAsync(Guid containerId, CancellationToken ct = default);
     Task<ContainerStats> GetContainerStatsAsync(Guid containerId, CancellationToken ct = default);
     Task ResizeContainerAsync(Guid containerId, ResourceSpec resources, CancellationToken ct = default);

--- a/src/Andy.Containers/Abstractions/IInfrastructureProvider.cs
+++ b/src/Andy.Containers/Abstractions/IInfrastructureProvider.cs
@@ -35,6 +35,38 @@ public interface IInfrastructureProvider
     Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct = default);
 
     /// <summary>
+    /// F4.1 (rivoli-ai/conductor#1934). Streaming exec: same exec/attach
+    /// surface as <see cref="ExecAsync(string, string, TimeSpan, CancellationToken)"/>
+    /// (decision #17 — no new Docker-Engine verb), but each stdout/stderr
+    /// line is delivered to <paramref name="onLine"/> as produced. The
+    /// default delegates to the buffered overload and replays the final
+    /// output line-by-line — correct for providers that can't stream
+    /// incrementally; Docker overrides for a true live tail.
+    /// </summary>
+    async Task<ExecResult> ExecStreamingAsync(
+        string externalId,
+        string command,
+        TimeSpan timeout,
+        Action<ExecOutputChunk> onLine,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(onLine);
+        var result = await ExecAsync(externalId, command, timeout, ct);
+        Replay(result.StdOut, ExecStreamKind.Stdout, onLine);
+        Replay(result.StdErr, ExecStreamKind.Stderr, onLine);
+        return result;
+
+        static void Replay(string? text, ExecStreamKind kind, Action<ExecOutputChunk> sink)
+        {
+            if (string.IsNullOrEmpty(text)) return;
+            foreach (var line in text.Replace("\r\n", "\n").Split('\n'))
+            {
+                if (line.Length > 0) sink(new ExecOutputChunk(kind, line));
+            }
+        }
+    }
+
+    /// <summary>
     /// Returns the set of container externalIds currently known to the
     /// provider, or <c>null</c> if this provider does not support bulk
     /// enumeration. Used by the startup reconciler (conductor #840) to
@@ -203,6 +235,19 @@ public class ExecResult
     public string? StdOut { get; set; }
     public string? StdErr { get; set; }
 }
+
+/// <summary>Which stream a streamed exec chunk came from. F4.1 (#1934).</summary>
+public enum ExecStreamKind
+{
+    Stdout,
+    Stderr,
+}
+
+/// <summary>
+/// One incremental line of exec output surfaced by
+/// <see cref="IContainerService.ExecStreamingAsync"/>. F4.1 (#1934).
+/// </summary>
+public readonly record struct ExecOutputChunk(ExecStreamKind Stream, string Line);
 
 public class ContainerStats
 {

--- a/src/Andy.Containers/Storage/IRunOutputBus.cs
+++ b/src/Andy.Containers/Storage/IRunOutputBus.cs
@@ -1,0 +1,93 @@
+namespace Andy.Containers.Storage;
+
+/// <summary>
+/// F4.1 (rivoli-ai/conductor#1934). In-process pub/sub for the
+/// MID-RUN incremental output of a headless agent run, keyed by run id.
+/// The AP6 runner (<c>HeadlessRunner</c>) publishes each stdout/stderr
+/// line of <c>andy-cli</c> as it is produced; the
+/// <c>GET /api/runs/{id}/output</c> SSE endpoint and the
+/// <c>GET /api/containers/{id}/logs?follow=1</c> SSE endpoint subscribe
+/// per request and stream the lines to the caller before the run is
+/// terminal.
+/// </summary>
+/// <remarks>
+/// Modelled on <see cref="IBuildEventBus"/> (IM9 / #263): a per-run ring
+/// buffer with monotonic sequence numbers so a subscriber that attaches
+/// mid-run catches up, then tails live; resumption keys off the sequence
+/// number via <c>Last-Event-ID</c>; bounded queues drop history rather
+/// than backpressure the runner; the stream closes after a terminal
+/// marker + a final drain so the SSE client disconnects rather than
+/// hanging.
+///
+/// The default in-process implementation is
+/// <c>InMemoryRunOutputBus</c>. Cloud / multi-host deployments will need
+/// a network-fan-out variant later (the same swap the build bus contract
+/// anticipates); the contract here is intentionally narrow so the runner
+/// and the SSE endpoints don't have to change.
+/// </remarks>
+public interface IRunOutputBus
+{
+    /// <summary>
+    /// Publish one output line for a run. Non-blocking — slow
+    /// subscribers don't backpressure the runner; bounded queues drop
+    /// old lines when a subscriber falls behind.
+    /// </summary>
+    void Publish(Guid runId, RunOutputLine line);
+
+    /// <summary>
+    /// Mark a run's output stream terminal. Subscribers drain any
+    /// buffered lines then complete cleanly; subscribers that attach
+    /// after this still replay the buffer then close. Idempotent.
+    /// </summary>
+    void Complete(Guid runId);
+
+    /// <summary>
+    /// Subscribe to all future + buffered output lines for a run.
+    /// Yields each line in publish order; completes when the run's
+    /// output is marked terminal via <see cref="Complete"/> or
+    /// <paramref name="ct"/> fires.
+    /// </summary>
+    /// <param name="lastEventId">
+    /// Optional sequence number from a prior subscription. The bus
+    /// resumes from the next line in its buffer after this id; if the
+    /// requested id has already fallen out of the buffer, the stream
+    /// restarts from the oldest buffered line (and the caller can
+    /// reconcile gaps via the run status snapshot).
+    /// </param>
+    IAsyncEnumerable<RunOutputEnvelope> SubscribeAsync(
+        Guid runId,
+        long? lastEventId,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Drop all buffered lines for a run. Called by the runner once a
+    /// run's output is no longer needed (terminal + a grace period for
+    /// reconnections).
+    /// </summary>
+    void Forget(Guid runId);
+}
+
+/// <summary>Which standard stream a run output line came from.</summary>
+public enum RunOutputStream
+{
+    Stdout,
+    Stderr,
+}
+
+/// <summary>
+/// One line of mid-run agent output. <paramref name="Timestamp"/> is the
+/// server clock at publish time.
+/// </summary>
+public sealed record RunOutputLine(
+    RunOutputStream Stream,
+    string Line,
+    DateTimeOffset Timestamp);
+
+/// <summary>
+/// One line in the stream, tagged with a per-run sequence number the SSE
+/// endpoint advertises as <c>id:</c> on the wire so clients can resume
+/// via <c>Last-Event-ID</c>.
+/// </summary>
+public sealed record RunOutputEnvelope(
+    long SequenceNumber,
+    RunOutputLine Line);

--- a/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerOutputSseTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerOutputSseTests.cs
@@ -1,0 +1,185 @@
+using System.Text;
+using Andy.Containers.Api.Controllers;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Configurator;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Infrastructure.Runs.Events;
+using Andy.Containers.Models;
+using Andy.Containers.Storage;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Controllers;
+
+// F4.1 (rivoli-ai/conductor#1934). GET /api/runs/{id}/output is the
+// mid-run agent output SSE stream. The bus unit tests cover the moving
+// parts in isolation; this suite exercises the controller's
+// serialisation onto the HTTP response — Content-Type header, the
+// `id: N\nevent: log\ndata: {json}\n\n` wire format, Last-Event-ID
+// resumption, terminal-close, and 404 for an unknown run — using a
+// MemoryStream-backed DefaultHttpContext, mirroring ImagesControllerSseTests.
+public class RunsControllerOutputSseTests : IDisposable
+{
+    private readonly ContainersDbContext _db;
+    private readonly InMemoryRunOutputBus _bus = new();
+    private readonly RunsController _controller;
+
+    public RunsControllerOutputSseTests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+
+        var configurator = new Mock<IRunConfigurator>();
+        var dispatcher = new Mock<IRunModeDispatcher>();
+        var cancellation = new RunCancellationRegistry();
+
+        _controller = new RunsController(
+            _db, configurator.Object, dispatcher.Object, cancellation,
+            _bus, NullLogger<RunsController>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        _bus.Dispose();
+    }
+
+    [Fact]
+    public async Task Output_StreamsLinesInWireFormatAndClosesOnTerminal()
+    {
+        var run = SeedRun(RunStatus.Running);
+        var responseStream = SetupResponse();
+
+        var now = DateTimeOffset.UtcNow;
+        _bus.Publish(run.Id, new RunOutputLine(RunOutputStream.Stdout, "hello from the agent", now));
+        _bus.Publish(run.Id, new RunOutputLine(RunOutputStream.Stderr, "a warning", now));
+        _bus.Complete(run.Id);
+
+        await _controller.Output(run.Id, CancellationToken.None);
+
+        var body = ReadBody(responseStream);
+
+        // 1. Headers — Content-Type must announce SSE.
+        _controller.Response.Headers.ContentType.ToString().Should().Be("text/event-stream");
+        _controller.Response.Headers.CacheControl.ToString().Should().Be("no-store");
+        _controller.Response.Headers["X-Accel-Buffering"].ToString().Should().Be("no");
+
+        // 2. Frame structure — id, event, data, blank line.
+        body.Should().Contain("id: 1\nevent: log\ndata: ");
+        body.Should().Contain("\nevent: log\n");
+
+        // 3. JSON payload — stream kind is the camelCase string the Swift
+        //    ContainerLogStream decoder keys off, line carried intact.
+        body.Should().Contain("\"stream\":\"stdout\"");
+        body.Should().Contain("\"stream\":\"stderr\"");
+        body.Should().Contain("\"line\":\"hello from the agent\"");
+
+        // 4. Frame separation — every line ends with \n\n.
+        var frameCount = body.Split("\n\n", StringSplitOptions.RemoveEmptyEntries).Length;
+        frameCount.Should().Be(2, "two published lines ⇒ two frames, each terminated by a blank line.");
+    }
+
+    [Fact]
+    public async Task Output_HonoursLastEventIdHeader_NoDupesNoGaps()
+    {
+        var run = SeedRun(RunStatus.Running);
+        var responseStream = SetupResponse(lastEventId: "1");
+
+        var now = DateTimeOffset.UtcNow;
+        _bus.Publish(run.Id, new RunOutputLine(RunOutputStream.Stdout, "one", now));   // id 1 — skipped
+        _bus.Publish(run.Id, new RunOutputLine(RunOutputStream.Stdout, "two", now));   // id 2 — first seen
+        _bus.Publish(run.Id, new RunOutputLine(RunOutputStream.Stdout, "three", now)); // id 3
+        _bus.Complete(run.Id);
+
+        await _controller.Output(run.Id, CancellationToken.None);
+
+        var body = ReadBody(responseStream);
+
+        body.Should().NotContain("id: 1\n", "Last-Event-ID=1 means the client already saw id=1.");
+        body.Should().Contain("id: 2\n");
+        body.Should().Contain("id: 3\n");
+        body.Should().NotContain("\"line\":\"one\"");
+        body.Should().Contain("\"line\":\"two\"");
+    }
+
+    [Fact]
+    public async Task Output_AlreadyTerminalRun_DrainsAndClosesImmediately()
+    {
+        var run = SeedRun(RunStatus.Succeeded);
+        var responseStream = SetupResponse();
+
+        _bus.Publish(run.Id, new RunOutputLine(RunOutputStream.Stdout, "final line", DateTimeOffset.UtcNow));
+        _bus.Complete(run.Id);
+
+        var task = _controller.Output(run.Id, CancellationToken.None);
+        var done = await Task.WhenAny(task, Task.Delay(2000));
+
+        done.Should().BeSameAs(task, "an attach to an already-terminal run must drain then close — not hang.");
+        ReadBody(responseStream).Should().Contain("\"line\":\"final line\"");
+    }
+
+    [Fact]
+    public async Task Output_EmptyOutputThenTerminal_ClosesWithNoFrames()
+    {
+        var run = SeedRun(RunStatus.Succeeded);
+        var responseStream = SetupResponse();
+
+        // No lines were ever published — the late subscriber sees an
+        // empty, immediately-closed stream.
+        _bus.Complete(run.Id);
+
+        var task = _controller.Output(run.Id, CancellationToken.None);
+        var done = await Task.WhenAny(task, Task.Delay(2000));
+
+        done.Should().BeSameAs(task);
+        ReadBody(responseStream).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Output_UnknownRun_Returns404()
+    {
+        SetupResponse();
+
+        await _controller.Output(Guid.NewGuid(), CancellationToken.None);
+
+        _controller.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    private MemoryStream SetupResponse(string? lastEventId = null)
+    {
+        var responseStream = new MemoryStream();
+        var context = new DefaultHttpContext { Response = { Body = responseStream } };
+        if (lastEventId is not null)
+        {
+            context.Request.Headers["Last-Event-ID"] = lastEventId;
+        }
+        _controller.ControllerContext = new ControllerContext { HttpContext = context };
+        return responseStream;
+    }
+
+    private static string ReadBody(MemoryStream stream)
+    {
+        stream.Position = 0;
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private Run SeedRun(RunStatus status)
+    {
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "seed-agent",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            Status = status,
+        };
+        _db.Runs.Add(run);
+        _db.SaveChanges();
+        return run;
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
@@ -4,6 +4,7 @@ using Andy.Containers.Api.Tests.Helpers;
 using Andy.Containers.Configurator;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Infrastructure.Runs.Events;
 using Andy.Containers.Messaging;
 using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
@@ -57,6 +58,7 @@ public class RunsControllerTests : IDisposable
         _cancellation = new RunCancellationRegistry();
         _controller = new RunsController(
             _db, _configurator.Object, _dispatcher.Object, _cancellation,
+            new InMemoryRunOutputBus(),
             NullLogger<RunsController>.Instance);
     }
 
@@ -375,6 +377,7 @@ public class RunsControllerTests : IDisposable
 
         var controller = new RunsController(
             _db, _configurator.Object, _dispatcher.Object, registry.Object,
+            new InMemoryRunOutputBus(),
             NullLogger<RunsController>.Instance);
 
         var result = await controller.Cancel(run.Id, CancellationToken.None);

--- a/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerOutputStreamTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerOutputStreamTests.cs
@@ -1,0 +1,224 @@
+using Andy.Containers.Abstractions;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Configurator;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Infrastructure.Runs.Events;
+using Andy.Containers.Models;
+using Andy.Containers.Storage;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+// F4.1 (rivoli-ai/conductor#1934). The runner-to-bus wiring: when an
+// IRunOutputBus is supplied, HeadlessRunner drives the container's
+// STREAMING exec and republishes each line onto the bus (redacted,
+// stream-kind tagged), then marks the run terminal so attached SSE
+// subscribers drain + close. This is the integration layer the spec
+// asks for: a fake IContainerService.ExecStreamingAsync that emits N
+// lines then exits, asserting the full chain
+// (runner → bus → subscriber) yields all N mid-run lines + terminates.
+public class HeadlessRunnerOutputStreamTests : IDisposable
+{
+    private readonly ContainersDbContext _db;
+    private readonly Mock<IContainerService> _containers = new();
+    private readonly RunCancellationRegistry _cancellation = new();
+    private readonly Mock<ITokenIssuer> _tokens = new();
+    private readonly InMemoryRunOutputBus _bus = new();
+    private readonly HeadlessRunner _runner;
+
+    public HeadlessRunnerOutputStreamTests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+        _tokens
+            .Setup(t => t.RevokeAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        // Bus path resolves the run-scoped token for redaction.
+        _tokens
+            .Setup(t => t.MintAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunToken("sk-run-secret-0123456789abcdef", DateTimeOffset.UtcNow.AddHours(1)));
+
+        _runner = new HeadlessRunner(
+            _containers.Object, _db, _cancellation, _tokens.Object,
+            NullLogger<HeadlessRunner>.Instance, artifactCollector: null,
+            inputStager: null, outputBus: _bus);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        _bus.Dispose();
+    }
+
+    [Fact]
+    public async Task StartAsync_StreamsEachExecLineToTheBus_ThenMarksTerminal()
+    {
+        var run = SeedRun();
+        SetupStreamingExec(run.ContainerId!.Value, exitCode: 0, lines:
+        [
+            (ExecStreamKind.Stdout, "Iteration 1/4"),
+            (ExecStreamKind.Stdout, "Iteration 2/4"),
+            (ExecStreamKind.Stderr, "transient retry"),
+            (ExecStreamKind.Stdout, "done"),
+        ]);
+
+        // Subscribe BEFORE running is racy in a unit test; instead drive
+        // the run, then drain the bus (which replays the buffered lines
+        // and closes because the run is terminal).
+        var outcome = await _runner.StartAsync(run, "/tmp/x/config.json");
+        outcome.Status.Should().Be(RunStatus.Succeeded);
+
+        var lines = await DrainAsync(run.Id);
+
+        lines.Should().HaveCount(4, "every mid-run exec line reaches the bus.");
+        lines.Select(e => e.SequenceNumber).Should().Equal(1, 2, 3, 4);
+        lines.Select(e => e.Line.Line).Should().Equal(
+            "Iteration 1/4", "Iteration 2/4", "transient retry", "done");
+        lines[2].Line.Stream.Should().Be(RunOutputStream.Stderr,
+            "stderr lines stay distinguishable from stdout on the bus.");
+    }
+
+    [Fact]
+    public async Task StartAsync_RedactsRunScopedTokenFromEchoedOutput()
+    {
+        var run = SeedRun();
+        // The agent dumps its env mid-run — the bearer must not survive
+        // onto the bus.
+        SetupStreamingExec(run.ContainerId!.Value, exitCode: 0, lines:
+        [
+            (ExecStreamKind.Stdout, "ANDY_TOKEN=sk-run-secret-0123456789abcdef"),
+            (ExecStreamKind.Stdout, "curl -H 'Authorization: Bearer sk-run-secret-0123456789abcdef'"),
+        ]);
+
+        await _runner.StartAsync(run, "/tmp/x/config.json");
+
+        var lines = await DrainAsync(run.Id);
+
+        lines.Should().NotContain(e => e.Line.Line.Contains("sk-run-secret"),
+            "the run-scoped bearer is redacted before it reaches the live stream.");
+        lines.Should().Contain(e => e.Line.Line.Contains(RunOutputRedactor.Placeholder));
+    }
+
+    [Fact]
+    public async Task StartAsync_EmptyOutput_StillMarksTerminal()
+    {
+        var run = SeedRun();
+        SetupStreamingExec(run.ContainerId!.Value, exitCode: 0, lines: []);
+
+        await _runner.StartAsync(run, "/tmp/x/config.json");
+
+        // An immediate drain must close (terminal marker present) with no
+        // frames — never hang.
+        var lines = await DrainAsync(run.Id);
+        lines.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task StartAsync_LiveSubscriberSeesLinesBeforeTerminal()
+    {
+        // Prove the lines are MID-RUN, not just replayed at the end: hold
+        // the exec open until a subscriber has consumed the first batch,
+        // then let it finish.
+        var run = SeedRun();
+        var firstBatchPublished = new TaskCompletionSource<bool>();
+        var releaseExec = new TaskCompletionSource<bool>();
+
+        _containers
+            .Setup(c => c.ExecStreamingAsync(
+                run.ContainerId!.Value, It.IsAny<string>(), It.IsAny<TimeSpan>(),
+                It.IsAny<Action<ExecOutputChunk>>(), It.IsAny<CancellationToken>()))
+            .Returns<Guid, string, TimeSpan, Action<ExecOutputChunk>, CancellationToken>(
+                async (_, _, _, onLine, _) =>
+                {
+                    onLine(new ExecOutputChunk(ExecStreamKind.Stdout, "live-1"));
+                    onLine(new ExecOutputChunk(ExecStreamKind.Stdout, "live-2"));
+                    firstBatchPublished.TrySetResult(true);
+                    await releaseExec.Task;
+                    onLine(new ExecOutputChunk(ExecStreamKind.Stdout, "live-3"));
+                    return new ExecResult { ExitCode = 0 };
+                });
+
+        var startTask = _runner.StartAsync(run, "/tmp/x/config.json");
+
+        // Subscribe live and read the first two lines while exec is still
+        // running (releaseExec not yet completed → run not terminal).
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var seen = new List<RunOutputEnvelope>();
+        var readTask = Task.Run(async () =>
+        {
+            await firstBatchPublished.Task;
+            await foreach (var env in _bus.SubscribeAsync(run.Id, null, cts.Token))
+            {
+                seen.Add(env);
+                if (seen.Count >= 2)
+                {
+                    break; // got the mid-run batch — release exec to finish
+                }
+            }
+        }, cts.Token);
+
+        await firstBatchPublished.Task;
+        await readTask;
+
+        seen.Should().HaveCountGreaterThanOrEqualTo(2,
+            "the subscriber saw output WHILE the run was still in flight, before the terminal event.");
+        seen.Take(2).Select(e => e.Line.Line).Should().Equal("live-1", "live-2");
+
+        releaseExec.TrySetResult(true);
+        (await startTask).Status.Should().Be(RunStatus.Succeeded);
+    }
+
+    private void SetupStreamingExec(
+        Guid containerId, int exitCode, (ExecStreamKind Kind, string Line)[] lines)
+    {
+        _containers
+            .Setup(c => c.ExecStreamingAsync(
+                containerId, It.IsAny<string>(), It.IsAny<TimeSpan>(),
+                It.IsAny<Action<ExecOutputChunk>>(), It.IsAny<CancellationToken>()))
+            .Returns<Guid, string, TimeSpan, Action<ExecOutputChunk>, CancellationToken>(
+                (_, _, _, onLine, _) =>
+                {
+                    foreach (var (kind, line) in lines)
+                    {
+                        onLine(new ExecOutputChunk(kind, line));
+                    }
+                    return Task.FromResult(new ExecResult
+                    {
+                        ExitCode = exitCode,
+                        StdOut = string.Join("\n", lines.Where(l => l.Kind == ExecStreamKind.Stdout).Select(l => l.Line)),
+                        StdErr = string.Join("\n", lines.Where(l => l.Kind == ExecStreamKind.Stderr).Select(l => l.Line)),
+                    });
+                });
+    }
+
+    private async Task<List<RunOutputEnvelope>> DrainAsync(Guid runId)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        var lines = new List<RunOutputEnvelope>();
+        await foreach (var env in _bus.SubscribeAsync(runId, null, cts.Token))
+        {
+            lines.Add(env);
+        }
+        return lines;
+    }
+
+    private Run SeedRun()
+    {
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "triage-agent",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            ContainerId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            Status = RunStatus.Pending,
+        };
+        _db.Runs.Add(run);
+        _db.SaveChanges();
+        return run;
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Services/RunOutputRedactorTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/RunOutputRedactorTests.cs
@@ -1,0 +1,79 @@
+using Andy.Containers.Api.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+// F4.1 (rivoli-ai/conductor#1934). The mid-run output stream echoes the
+// agent's stdout/stderr to the operator. The run-scoped bearer
+// (ANDY_TOKEN) must never reach that wire. RunOutputRedactor runs two
+// passes; these tests pin both and the no-op cases.
+public class RunOutputRedactorTests
+{
+    private const string Token = "sk-run-0123456789abcdef0123456789abcdef";
+
+    [Fact]
+    public void Redact_KnownToken_MasksEveryLiteralOccurrence()
+    {
+        // The agent could echo the bearer anywhere — a curl trace, a
+        // debug dump — not just as ANDY_TOKEN=...; the known-secret pass
+        // catches all of them.
+        var line = $"curl -H 'Authorization: Bearer {Token}' https://api && echo {Token}";
+
+        var result = RunOutputRedactor.Redact(line, Token);
+
+        result.Should().NotContain(Token);
+        result.Should().Contain(RunOutputRedactor.Placeholder);
+        result.Should().Contain("Authorization: Bearer");
+    }
+
+    [Theory]
+    [InlineData("ANDY_TOKEN=sk-secret-value-1234")]
+    [InlineData("export ANDY_TOKEN=sk-secret-value-1234")]
+    [InlineData("ANDY_TOKEN: sk-secret-value-1234")]
+    [InlineData("\"ANDY_TOKEN\":\"sk-secret-value-1234\"")]
+    public void Redact_EnvEcho_MasksValueEvenWithoutKnownToken(string line)
+    {
+        // We don't have the literal here (knownToken=null) — the env-echo
+        // regex still masks the value so a `printenv`/`env` dump can't
+        // leak the token.
+        var result = RunOutputRedactor.Redact(line, knownToken: null);
+
+        result.Should().NotContain("sk-secret-value-1234");
+        result.Should().Contain(RunOutputRedactor.Placeholder);
+        // The variable name / surrounding text survives so an operator
+        // still sees "the token was here".
+        result.Should().Contain("ANDY_TOKEN");
+    }
+
+    [Fact]
+    public void Redact_EnvEcho_IsCaseInsensitiveOnKey()
+    {
+        var result = RunOutputRedactor.Redact("andy_token=leakme123", knownToken: null);
+        result.Should().NotContain("leakme123");
+    }
+
+    [Fact]
+    public void Redact_NonSecretLine_RoundTripsUnchanged()
+    {
+        const string line = "Iteration 3/4: planning the next edit";
+        RunOutputRedactor.Redact(line, Token).Should().Be(line);
+    }
+
+    [Fact]
+    public void Redact_ShortKnownToken_IsNotUsedForLiteralPass()
+    {
+        // A 1-2 char "token" would mangle unrelated text; the literal
+        // pass only fires for tokens >= 8 chars. The env-echo pass is
+        // unaffected.
+        const string line = "the letter a appears in many words";
+        RunOutputRedactor.Redact(line, knownToken: "a").Should().Be(line);
+    }
+
+    [Fact]
+    public void Redact_NullOrEmpty_RoundTrips()
+    {
+        RunOutputRedactor.Redact(null, Token).Should().Be(string.Empty);
+        RunOutputRedactor.Redact(string.Empty, Token).Should().Be(string.Empty);
+    }
+}

--- a/tests/Andy.Containers.Tests/Infrastructure/Runs/Events/InMemoryRunOutputBusTests.cs
+++ b/tests/Andy.Containers.Tests/Infrastructure/Runs/Events/InMemoryRunOutputBusTests.cs
@@ -1,0 +1,251 @@
+using Andy.Containers.Infrastructure.Runs.Events;
+using Andy.Containers.Storage;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Tests.Infrastructure.Runs.Events;
+
+// F4.1 (rivoli-ai/conductor#1934). The run-output bus backs the mid-run
+// SSE stream (GET /api/runs/{id}/output). It is a direct sibling of
+// InMemoryBuildEventBus, so the contracts that matter are the same:
+//   - publish + subscribe in publish order, with monotonic sequence ids
+//   - a late subscriber sees buffered history then live-tails
+//   - Last-Event-ID resumption skips already-seen lines (no dupes/gaps)
+//   - multiple subscribers all see every line (fan-out)
+//   - Complete() closes every subscriber after a final drain
+//   - a subscriber that attaches AFTER Complete() replays + closes
+//   - stdout/stderr stream-kind survives round-trip
+//   - lines published after Complete() are dropped (frozen buffer)
+//   - Forget() drops a run's buffered history
+public class InMemoryRunOutputBusTests
+{
+    [Fact]
+    public async Task Publish_DeliversToSingleSubscriberInOrderWithSequenceIds()
+    {
+        using var bus = new InMemoryRunOutputBus();
+        var runId = Guid.NewGuid();
+
+        var subscribeTask = ConsumeAsync(bus, runId, lastEventId: null, take: 2);
+
+        await Task.Delay(20);
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "hello"));
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "world"));
+
+        var lines = await subscribeTask;
+        lines.Should().HaveCount(2);
+        lines[0].SequenceNumber.Should().Be(1);
+        lines[1].SequenceNumber.Should().Be(2);
+        lines[0].Line.Line.Should().Be("hello");
+        lines[1].Line.Line.Should().Be("world");
+    }
+
+    [Fact]
+    public async Task Subscribe_LateSubscriberSeesBufferedHistory()
+    {
+        using var bus = new InMemoryRunOutputBus();
+        var runId = Guid.NewGuid();
+
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "first"));
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "second"));
+        bus.Complete(runId);
+
+        // Subscribe AFTER the run completed — buffer replays both lines
+        // then closes.
+        var lines = await ConsumeAsync(bus, runId, lastEventId: null, take: 2);
+
+        lines.Should().HaveCount(2);
+        lines.Select(e => e.SequenceNumber).Should().BeInAscendingOrder();
+    }
+
+    [Fact]
+    public async Task Subscribe_LastEventIdSkipsAlreadySeenLines_NoDupesNoGaps()
+    {
+        using var bus = new InMemoryRunOutputBus();
+        var runId = Guid.NewGuid();
+
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "a")); // seq 1
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "b")); // seq 2
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "c")); // seq 3
+        bus.Complete(runId);
+
+        // Reconnect with Last-Event-ID = 1 → must see seq 2 + 3 only.
+        var lines = await ConsumeAsync(bus, runId, lastEventId: 1, take: 2);
+
+        lines.Select(e => e.SequenceNumber).Should().Equal(2, 3);
+        lines.Select(e => e.Line.Line).Should().Equal("b", "c");
+    }
+
+    [Fact]
+    public async Task Subscribe_MultipleSubscribersSeeFanOut()
+    {
+        using var bus = new InMemoryRunOutputBus();
+        var runId = Guid.NewGuid();
+
+        var firstTask = ConsumeAsync(bus, runId, lastEventId: null, take: 1);
+        var secondTask = ConsumeAsync(bus, runId, lastEventId: null, take: 1);
+
+        await Task.Delay(20);
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "everyone gets one"));
+
+        var first = await firstTask;
+        var second = await secondTask;
+
+        first.Should().HaveCount(1);
+        second.Should().HaveCount(1);
+        first[0].Line.Line.Should().Be(second[0].Line.Line);
+    }
+
+    [Fact]
+    public async Task Complete_ClosesSubscriberAfterFinalDrain()
+    {
+        using var bus = new InMemoryRunOutputBus();
+        var runId = Guid.NewGuid();
+
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "tail line"));
+        bus.Complete(runId);
+
+        // The subscription should yield the buffered line then exit on
+        // its own — not block waiting for more.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var lines = new List<RunOutputEnvelope>();
+        await foreach (var envelope in bus.SubscribeAsync(runId, null, cts.Token))
+        {
+            lines.Add(envelope);
+        }
+
+        lines.Should().HaveCount(1);
+        cts.IsCancellationRequested.Should().BeFalse(
+            "the stream must close on its own when the run is marked terminal — not because the test cancellation timed out.");
+    }
+
+    [Fact]
+    public async Task Complete_BeforeSubscribe_ReplaysThenClosesImmediately()
+    {
+        using var bus = new InMemoryRunOutputBus();
+        var runId = Guid.NewGuid();
+
+        bus.Publish(runId, Line(RunOutputStream.Stderr, "boom"));
+        bus.Complete(runId);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var lines = new List<RunOutputEnvelope>();
+        await foreach (var envelope in bus.SubscribeAsync(runId, null, cts.Token))
+        {
+            lines.Add(envelope);
+        }
+
+        lines.Should().HaveCount(1);
+        lines[0].Line.Stream.Should().Be(RunOutputStream.Stderr);
+        cts.IsCancellationRequested.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Publish_AfterComplete_IsDropped()
+    {
+        using var bus = new InMemoryRunOutputBus();
+        var runId = Guid.NewGuid();
+
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "before"));
+        bus.Complete(runId);
+        // This line lands after the terminal marker — the buffer is
+        // frozen, so a fresh subscriber must never see it.
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "after-terminal"));
+
+        var lines = new List<RunOutputEnvelope>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        await foreach (var envelope in bus.SubscribeAsync(runId, null, cts.Token))
+        {
+            lines.Add(envelope);
+        }
+
+        lines.Should().HaveCount(1);
+        lines[0].Line.Line.Should().Be("before");
+    }
+
+    [Fact]
+    public async Task StreamKind_SurvivesRoundTrip()
+    {
+        using var bus = new InMemoryRunOutputBus();
+        var runId = Guid.NewGuid();
+
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "out"));
+        bus.Publish(runId, Line(RunOutputStream.Stderr, "err"));
+        bus.Complete(runId);
+
+        var lines = await ConsumeAsync(bus, runId, lastEventId: null, take: 2);
+
+        lines[0].Line.Stream.Should().Be(RunOutputStream.Stdout);
+        lines[1].Line.Stream.Should().Be(RunOutputStream.Stderr);
+    }
+
+    [Fact]
+    public async Task Forget_DropsRunState()
+    {
+        using var bus = new InMemoryRunOutputBus();
+        var runId = Guid.NewGuid();
+
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "orphan"));
+        bus.Complete(runId);
+
+        bus.Forget(runId);
+
+        // After Forget, the buffered history is gone — a fresh
+        // subscription sees nothing until something is published.
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        var lines = new List<RunOutputEnvelope>();
+        try
+        {
+            await foreach (var envelope in bus.SubscribeAsync(runId, null, cts.Token))
+            {
+                lines.Add(envelope);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // expected — no lines arrived before cancellation.
+        }
+
+        lines.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Subscribe_AgedOutLastEventId_RestartsFromOldestBuffered()
+    {
+        // Bounded buffer: a tiny capacity forces older lines to drop. A
+        // reconnect asking for an id that has aged out replays from the
+        // oldest line still buffered rather than hanging or throwing.
+        using var bus = new InMemoryRunOutputBus(new RunOutputBusOptions { BufferSize = 2 });
+        var runId = Guid.NewGuid();
+
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "1")); // seq 1, evicted
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "2")); // seq 2, evicted
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "3")); // seq 3
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "4")); // seq 4
+        bus.Complete(runId);
+
+        // Ask to resume after seq 1, which is no longer buffered. The
+        // bus replays the oldest still-buffered line (seq 3) onward.
+        var lines = await ConsumeAsync(bus, runId, lastEventId: 1, take: 2);
+
+        lines.Select(e => e.SequenceNumber).Should().Equal(3, 4);
+    }
+
+    private static async Task<List<RunOutputEnvelope>> ConsumeAsync(
+        IRunOutputBus bus, Guid runId, long? lastEventId, int take)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        var lines = new List<RunOutputEnvelope>();
+        await foreach (var envelope in bus.SubscribeAsync(runId, lastEventId, cts.Token))
+        {
+            lines.Add(envelope);
+            if (lines.Count >= take)
+            {
+                break;
+            }
+        }
+        return lines;
+    }
+
+    private static RunOutputLine Line(RunOutputStream stream, string text)
+        => new(stream, text, DateTimeOffset.UtcNow);
+}


### PR DESCRIPTION
Implements the mid-run agent output/progress stream for headless runs, tracking https://github.com/rivoli-ai/conductor/issues/1934 (TX F4.1, Feature #1919 / Epic #1915).

## What & why
`GET /api/runs/{id}/events` only surfaces **terminal** lifecycle events — nothing is visible until a run is over. This adds a **live** feed of the agent's stdout/stderr while a headless run is in flight, so the TX Task Execution Cockpit (and any HTTP consumer) can watch progress in real time.

```
GET /api/runs/{id}/output      text/event-stream, run:read
```

```
id: <sequence>
event: log
data: {"stream":"stdout","line":"Iteration 2/4","timestamp":"2026-..."}
```

- **Resumable** via `Last-Event-ID` — replays buffered lines after the cursor, no duplicates, no gaps; restarts from the oldest buffered line if the id has aged out of the ring buffer.
- **stdout vs stderr** distinguishable on every frame.
- **Terminal-stop** — closes after the run hits a terminal status + a final drain (matches the `RunEventStream` contract). Attaching to an already-terminal run drains then closes immediately (never hangs). Unknown run → 404. `run:read` gates access (byte-identical to `/events`).
- **`ANDY_TOKEN` redacted** before any line reaches the wire.

## Design (ADR 0003 amendment)
Chose **shape (1)** — a run-scoped `/output` endpoint — over container-logs SSE: keeps the redaction boundary + `run:read` gate aligned with `/events`, and the resumption cursor a clean per-run sequence. The bus contract is runtime-agnostic so a container-logs alias can be layered on later with no runner change.

- `IRunOutputBus` + `InMemoryRunOutputBus` — per-run ring buffer + multicast fan-out, a direct sibling of IM9's `InMemoryBuildEventBus` (monotonic sequence, bounded subscriber channels that drop rather than backpressure the runner, replay-on-attach, terminal marker). Singleton in `Program.cs`.
- `IContainerService/IInfrastructureProvider.ExecStreamingAsync` — stream exec output line-by-line over the **same** `ExecCreate` + `StartAndAttach` surface (no new Docker-Engine verb — Conductor decision #17). Docker overrides for a true live tail; the other 9 providers inherit a buffered-replay default (every line still delivered, just at end-of-run).
- `HeadlessRunner` publishes each line (redacted, stream-kind tagged) and marks the stream terminal on every exit path when a bus is wired. Null bus = pre-F4.1 buffered behaviour, unchanged.
- `RunOutputSse` — shared SSE serialiser (wire format, `Last-Event-ID`, terminal-close), matching what Conductor's `AndyContainersSSEStreamFactory` expects.
- `RunOutputRedactor` — literal-bearer + `ANDY_TOKEN=<value>` env-echo passes. **Fixed a real bug** in the original regex: the JSON shape `"ANDY_TOKEN":"..."` was not matched (the key's closing quote broke the pattern); the redactor test would have leaked the token.

## Build + tests — green
`dotnet build Andy.Containers.sln` → 0 warnings, 0 errors.

- `Andy.Containers.Api.Tests`: **1229 passed, 1 skipped, 0 failed**
- `Andy.Containers.Tests`: **505 passed, 0 failed**

New tests (each verified to fail against the pre-change code):
- **Unit (bus):** `InMemoryRunOutputBusTests` (10) — sequence ids, `Last-Event-ID` replay, fan-out, terminal-stop after final drain, drop-after-terminal, aged-out cursor restart, stream-kind round-trip, `Forget`.
- **Unit (redactor):** `RunOutputRedactorTests` (8) — known-secret pass, env-echo (shell/export/JSON shapes), case-insensitive key, short-token guard, non-secret round-trip, null/empty.
- **Integration (controller→bus→wire):** `RunsControllerOutputSseTests` (5) — Content-Type/headers, `id:/event:/data:` framing, `Last-Event-ID`, already-terminal drain+close, empty output, 404. Mirrors the established `ImagesControllerSseTests` SSE integration pattern.
- **Integration (runner→bus→subscriber):** `HeadlessRunnerOutputStreamTests` (4) — fake `ExecStreamingAsync` emits N lines then exits → all N reach the bus in order with stream kinds; redaction; empty-output still terminal; a live subscriber sees lines **before** the terminal event.

## Docs
- `docs/runs.md` — "Mid-run output stream" subsection + `run:read` row.
- `docs/api-reference.md` — new Runs endpoint table.
- `docs/adr/0003-agent-run-execution.md` — amendment recording the shape-1-vs-2 decision + cross-references.
- `openapi/containers-api.yaml` — `/api/runs/{id}/output` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)