### PR TITLE
feat(runs): propagate run/task/agent identity for token attribution (conductor#1947)

### DIFF
--- a/docs/run-configurator.md
+++ b/docs/run-configurator.md
@@ -102,6 +102,7 @@ Three layers compose the final dictionary in `RunConfigurator.MergeRunSecrets`:
     - `ANDY_TOKEN` from `ITokenIssuer.MintAsync(run.Id)`.
     - `ANDY_PROXY_URL` from `Secrets:ProxyUrl` in appsettings (skipped when null/empty).
     - `ANDY_MCP_URL` from `Secrets:McpUrl` (skipped when null/empty).
+    - **Per-run token attribution (conductor#1947):** `ANDY_RUN_ID` (= `run.Id`), `ANDY_AGENT_ID` (= `run.AgentId`), and `ANDY_TASK_ID` (= `run.CorrelationId`, skipped when `Guid.Empty`). The agent reads these and stamps `X-Andy-Run-Id` / `X-Andy-Task-Id` / `X-Andy-Agent-Id` on every andy-models call so token usage + cost is attributable per run / task / agent. The runner owns this identity (it's on the `Run`); the agent is just the carrier.
 2. **Agent-supplied (`AgentSpec.EnvVars`):** merged on top.
 3. **Collision rule:** the agent's value wins. An agent author who pins `ANDY_TOKEN` for a test fixture is not silently overridden by the platform — the collision is intentional, not the platform's call to break.
 

--- a/src/Andy.Containers/Configurator/EnvVarNames.cs
+++ b/src/Andy.Containers/Configurator/EnvVarNames.cs
@@ -18,4 +18,22 @@ public static class EnvVarNames
 
     /// <summary>Base URL of the platform's MCP server.</summary>
     public const string AndyMcpUrl = "ANDY_MCP_URL";
+
+    /// <summary>
+    /// Per-run token attribution (rivoli-ai/conductor#1947). The headless
+    /// agent reads these and stamps them as the X-Andy-Run-Id /
+    /// X-Andy-Task-Id / X-Andy-Agent-Id headers on every andy-models call
+    /// so andy-models can attribute token usage + cost to the run / task /
+    /// agent. The runner owns this identity (it's on the <c>Run</c>); the
+    /// agent is just the propagation carrier. Task is the run's
+    /// correlation id (the andy-tasks task/goal it belongs to), omitted
+    /// when the run carries none.
+    /// </summary>
+    public const string AndyRunId = "ANDY_RUN_ID";
+
+    /// <inheritdoc cref="AndyRunId"/>
+    public const string AndyTaskId = "ANDY_TASK_ID";
+
+    /// <inheritdoc cref="AndyRunId"/>
+    public const string AndyAgentId = "ANDY_AGENT_ID";
 }

--- a/src/Andy.Containers/Configurator/RunConfigurator.cs
+++ b/src/Andy.Containers/Configurator/RunConfigurator.cs
@@ -50,7 +50,7 @@ public sealed class RunConfigurator : IRunConfigurator
         // half-configured deployment surfaces as a missing var rather
         // than a misleading value.
         var token = await _tokens.MintAsync(run.Id, ct);
-        spec = spec with { EnvVars = MergeRunSecrets(spec.EnvVars, token, _secrets.Value) };
+        spec = spec with { EnvVars = MergeRunSecrets(spec.EnvVars, token, _secrets.Value, run) };
 
         HeadlessRunConfig config;
         try
@@ -94,7 +94,7 @@ public sealed class RunConfigurator : IRunConfigurator
     // double) should not be silently overridden by the issuer; the
     // collision is intentional, not the platform's call to break.
     private static IReadOnlyDictionary<string, string> MergeRunSecrets(
-        IReadOnlyDictionary<string, string>? agentEnv, RunToken token, SecretsOptions secrets)
+        IReadOnlyDictionary<string, string>? agentEnv, RunToken token, SecretsOptions secrets, Run run)
     {
         var merged = new Dictionary<string, string>(StringComparer.Ordinal)
         {
@@ -102,6 +102,23 @@ public sealed class RunConfigurator : IRunConfigurator
         };
         if (!string.IsNullOrEmpty(secrets.ProxyUrl)) merged[EnvVarNames.AndyProxyUrl] = secrets.ProxyUrl;
         if (!string.IsNullOrEmpty(secrets.McpUrl)) merged[EnvVarNames.AndyMcpUrl] = secrets.McpUrl;
+
+        // Per-run token attribution (rivoli-ai/conductor#1947). The runner
+        // owns the run/task/agent identity; surface it to the agent as env
+        // vars so andy-cli stamps X-Andy-Run-Id / X-Andy-Task-Id /
+        // X-Andy-Agent-Id on every andy-models call. Run id and agent id
+        // are always present; task id is the run's correlation id (the
+        // andy-tasks task/goal it belongs to) — omitted when the run
+        // carries none, so non-plan runs leave the dimension null.
+        merged[EnvVarNames.AndyRunId] = run.Id.ToString();
+        if (!string.IsNullOrWhiteSpace(run.AgentId))
+        {
+            merged[EnvVarNames.AndyAgentId] = run.AgentId;
+        }
+        if (run.CorrelationId != Guid.Empty)
+        {
+            merged[EnvVarNames.AndyTaskId] = run.CorrelationId.ToString();
+        }
 
         if (agentEnv is { Count: > 0 })
         {

--- a/tests/Andy.Containers.Api.Tests/Configurator/RunConfiguratorTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Configurator/RunConfiguratorTests.cs
@@ -202,6 +202,61 @@ public class RunConfiguratorTests
         captured.EnvVars.Should().NotContainKey(EnvVarNames.AndyMcpUrl);
     }
 
+    // Per-run token attribution (rivoli-ai/conductor#1947) ----------------
+
+    [Fact]
+    public async Task ConfigureAsync_InjectsRunTaskAgentAttributionEnvVars()
+    {
+        // The runner owns the run/task/agent identity; it must surface it
+        // to the agent as env vars so andy-cli can stamp the
+        // X-Andy-Run-Id / X-Andy-Task-Id / X-Andy-Agent-Id headers on
+        // every andy-models call.
+        var run = SeedRun();
+        var spec = TriageAgent();
+        AgentSpec? captured = null;
+        _agents.Setup(a => a.GetAgentAsync(run.AgentId, run.AgentRevision, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(spec);
+        _builder
+            .Setup(b => b.Build(run, It.IsAny<AgentSpec>()))
+            .Callback<Run, AgentSpec>((_, s) => captured = s)
+            .Returns(SampleConfig(run.Id));
+        _writer.Setup(w => w.WriteAsync(It.IsAny<HeadlessRunConfig>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("/tmp/x/config.json");
+
+        var result = await CreateSut().ConfigureAsync(run);
+
+        result.IsSuccess.Should().BeTrue();
+        captured!.EnvVars![EnvVarNames.AndyRunId].Should().Be(run.Id.ToString());
+        captured.EnvVars[EnvVarNames.AndyTaskId].Should().Be(run.CorrelationId.ToString());
+        captured.EnvVars[EnvVarNames.AndyAgentId].Should().Be(run.AgentId);
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_OmitsTaskAttribution_WhenRunHasNoCorrelation()
+    {
+        // A non-plan run (no andy-tasks correlation) leaves the task
+        // dimension null so andy-models won't attribute it to a task.
+        var run = SeedRun();
+        run.CorrelationId = Guid.Empty;
+        var spec = TriageAgent();
+        AgentSpec? captured = null;
+        _agents.Setup(a => a.GetAgentAsync(run.AgentId, run.AgentRevision, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(spec);
+        _builder
+            .Setup(b => b.Build(run, It.IsAny<AgentSpec>()))
+            .Callback<Run, AgentSpec>((_, s) => captured = s)
+            .Returns(SampleConfig(run.Id));
+        _writer.Setup(w => w.WriteAsync(It.IsAny<HeadlessRunConfig>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("/tmp/x/config.json");
+
+        await CreateSut().ConfigureAsync(run);
+
+        captured!.EnvVars!.Should().ContainKey(EnvVarNames.AndyRunId);
+        captured.EnvVars.Should().NotContainKey(EnvVarNames.AndyTaskId,
+            "a run without a correlation id must not emit a task attribution var");
+        captured.EnvVars![EnvVarNames.AndyAgentId].Should().Be(run.AgentId);
+    }
+
     private static Run SeedRun() => new()
     {
         Id = Guid.NewGuid(),


### PR DESCRIPTION
## Summary
Part 3 of 3 for **rivoli-ai/conductor#1947** (per-run token attribution for headless runs).

The agent runner already owns the run/task/agent identity (it's on the `Run`). This surfaces it to the headless agent (andy-cli) so the agent can stamp `X-Andy-Run-Id` / `X-Andy-Task-Id` / `X-Andy-Agent-Id` on every andy-models call — closing the attribution loop andy-models reads in PR rivoli-ai/andy-models#77.

## Changes
- `EnvVarNames` adds `ANDY_RUN_ID` / `ANDY_TASK_ID` / `ANDY_AGENT_ID`.
- `RunConfigurator.MergeRunSecrets` injects them from the `Run`:
  - `ANDY_RUN_ID` = `run.Id` (always)
  - `ANDY_AGENT_ID` = `run.AgentId` (when set)
  - `ANDY_TASK_ID` = `run.CorrelationId` (the andy-tasks task/goal it belongs to), **omitted when `Guid.Empty`** so non-plan runs leave the task dimension null.
- These flow into `HeadlessRunConfig.EnvVars` → the on-disk `config.json` (`env_vars`) → the agent. The runner is the carrier of identity it already has; it does not itself call andy-models for metered LLM turns (those are made by the agent inside the container).

## Tests
- `RunConfiguratorTests.ConfigureAsync_InjectsRunTaskAgentAttributionEnvVars` — all three vars injected from the run.
- `RunConfiguratorTests.ConfigureAsync_OmitsTaskAttribution_WhenRunHasNoCorrelation` — task var omitted when `CorrelationId == Guid.Empty`.
- `RunConfiguratorTests`: **9 passed** (7 existing + 2 new). Full `Andy.Containers.Api.Tests`: **1231 passed / 1 skipped**.

## Cross-repo PRs (conductor#1947)
- andy-telemetry: https://github.com/rivoli-ai/andy-telemetry/pull/3
- andy-models: https://github.com/rivoli-ai/andy-models/pull/77
- andy-containers: **this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)