### PR TITLE
[Containers] Inject per-run attribution env into headless containers (#1947)

### DIFF
--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -473,6 +473,19 @@ public class ContainerOrchestrationService : IContainerService
                 envVars[kv.Key] = kv.Value;
         }
 
+        // rivoli-ai/conductor#1947. Per-run token attribution. Inject the
+        // run/task/agent identity this container is executing so the
+        // in-container agent can forward them as X-Andy-Run-Id /
+        // X-Andy-Task-Id / X-Andy-Agent-Id on every andy-models proxy
+        // call — that's what makes a single headless run's token+cost
+        // usage queryable per run/task in the andy-models ledger and on
+        // the gen_ai metric stream. Nullable: a container with no run
+        // context leaves them unset and the env vars are omitted. We
+        // don't overwrite a value a caller already supplied explicitly.
+        InjectAttributionEnv(ref envVars, "ANDY_RUN_ID", request.RunId);
+        InjectAttributionEnv(ref envVars, "ANDY_TASK_ID", request.TaskId);
+        InjectAttributionEnv(ref envVars, "ANDY_AGENT_ID", request.AttributionAgentId);
+
         // #944. Inject the proxy URL + service token so a code
         // assistant installed inside the container can authenticate
         // against andy-models without the user supplying a token.
@@ -1007,4 +1020,18 @@ public class ContainerOrchestrationService : IContainerService
         CodeAssistantType.CodexCli => "OPENAI_MODEL",
         _ => "LLM_MODEL"
     };
+
+    // rivoli-ai/conductor#1947. Set a per-run attribution env var when a
+    // value is present, never overwriting one a caller already supplied.
+    // Blank/whitespace values are treated as "unset" so the env var is
+    // omitted rather than emitting an empty header downstream.
+    private static void InjectAttributionEnv(ref Dictionary<string, string>? envVars, string envVarName, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return;
+        envVars ??= new Dictionary<string, string>();
+        if (!envVars.ContainsKey(envVarName))
+        {
+            envVars[envVarName] = value.Trim();
+        }
+    }
 }

--- a/src/Andy.Containers/Abstractions/IContainerService.cs
+++ b/src/Andy.Containers/Abstractions/IContainerService.cs
@@ -119,6 +119,18 @@ public class CreateContainerRequest
     // the caller (e.g. andy-issues) can tie the run back to a UserStory.
     public Guid? StoryId { get; set; }
 
+    // rivoli-ai/conductor#1947. Per-run token attribution for headless
+    // agent runs. When set, these are injected into the container env as
+    // ANDY_RUN_ID / ANDY_TASK_ID / ANDY_AGENT_ID. The in-container agent
+    // forwards them as X-Andy-Run-Id / X-Andy-Task-Id / X-Andy-Agent-Id
+    // on every andy-models proxy call, so the resulting UsageEvent ledger
+    // rows and gen_ai.client.* metric records are attributable to this
+    // run/task/agent. All nullable — non-headless / non-run containers
+    // leave them unset and the env vars are simply omitted.
+    public string? RunId { get; set; }
+    public string? TaskId { get; set; }
+    public string? AttributionAgentId { get; set; }
+
     /// <summary>
     /// X4 (rivoli-ai/andy-containers#93). When set, the bound
     /// <c>EnvironmentProfile</c> overrides the template's base image

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServicePerToolEnvTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerOrchestrationServicePerToolEnvTests.cs
@@ -213,6 +213,82 @@ public class ContainerOrchestrationServicePerToolEnvTests : IDisposable
             "the per-container token still lands — it's useful for scripts that read it directly.");
     }
 
+    // rivoli-ai/conductor#1947. Per-run token attribution. The run/task/
+    // agent identity must be injected as ANDY_RUN_ID / ANDY_TASK_ID /
+    // ANDY_AGENT_ID so the in-container agent forwards them as
+    // X-Andy-* headers to andy-models — that's the prerequisite for the
+    // per-run usage query (#1948) and per-run cost slicing (#1949).
+    [Fact]
+    public async Task CreateContainer_WithRunAttribution_InjectsAndyRunTaskAgentEnvVars()
+    {
+        var (template, provider) = await SeedAsync();
+        var proxy = StubMintingToken("claude.jwt");
+        var service = MakeService(proxy);
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "headless-run",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            OwnerId = "user-1",
+            CodeAssistant = new CodeAssistantConfig { Tool = CodeAssistantType.ClaudeCode },
+            RunId = "run-123",
+            TaskId = "task-456",
+            AttributionAgentId = "agent-789",
+        }, CancellationToken.None);
+
+        var env = (await ReadEnqueuedJobAsync()).EnvironmentVariables;
+        env.Should().NotBeNull();
+        env!["ANDY_RUN_ID"].Should().Be("run-123");
+        env["ANDY_TASK_ID"].Should().Be("task-456");
+        env["ANDY_AGENT_ID"].Should().Be("agent-789");
+    }
+
+    [Fact]
+    public async Task CreateContainer_WithoutRunAttribution_OmitsAndyRunTaskAgentEnvVars()
+    {
+        var (template, provider) = await SeedAsync();
+        var proxy = StubMintingToken("claude.jwt");
+        var service = MakeService(proxy);
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "no-run-context",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            OwnerId = "user-1",
+            CodeAssistant = new CodeAssistantConfig { Tool = CodeAssistantType.ClaudeCode },
+        }, CancellationToken.None);
+
+        var env = (await ReadEnqueuedJobAsync()).EnvironmentVariables ?? new Dictionary<string, string>();
+        env.Should().NotContainKey("ANDY_RUN_ID");
+        env.Should().NotContainKey("ANDY_TASK_ID");
+        env.Should().NotContainKey("ANDY_AGENT_ID");
+    }
+
+    [Fact]
+    public async Task CreateContainer_RunAttribution_DoesNotOverrideCallerSuppliedEnvVar()
+    {
+        var (template, provider) = await SeedAsync();
+        var proxy = StubMintingToken("claude.jwt");
+        var service = MakeService(proxy);
+
+        await service.CreateContainerAsync(new CreateContainerRequest
+        {
+            Name = "explicit-run-env",
+            TemplateId = template.Id,
+            ProviderId = provider.Id,
+            OwnerId = "user-1",
+            CodeAssistant = new CodeAssistantConfig { Tool = CodeAssistantType.ClaudeCode },
+            RunId = "run-from-field",
+            EnvironmentVariables = new Dictionary<string, string> { ["ANDY_RUN_ID"] = "run-from-env" },
+        }, CancellationToken.None);
+
+        var env = (await ReadEnqueuedJobAsync()).EnvironmentVariables;
+        env!["ANDY_RUN_ID"].Should().Be("run-from-env",
+            "a caller-supplied env var must win over the request field — we never clobber an explicit value.");
+    }
+
     // -----------------------------------------------------------------
     // Helpers (mirror the proxy-token test file's setup)
     // -----------------------------------------------------------------


### PR DESCRIPTION
Minimal, separable touch for per-run token attribution — https://github.com/rivoli-ai/conductor/issues/1947 (TX F8.1).

## What
Carries the run/task/agent identity into the container so the in-container agent can attribute its andy-models LLM calls to a specific run.

- `CreateContainerRequest` gains nullable `RunId` / `TaskId` / `AttributionAgentId`.
- `ContainerOrchestrationService` injects them as `ANDY_RUN_ID` / `ANDY_TASK_ID` / `ANDY_AGENT_ID` env vars (never overriding a caller-supplied value, blank treated as unset). The in-container agent forwards these as `X-Andy-Run-Id` / `X-Andy-Task-Id` / `X-Andy-Agent-Id` on every andy-models proxy call — the prerequisite for andy-models PR #78 to stamp the ledger + gen_ai metrics.

## Scope
**No entity/schema change, no migration** — this is env input only. The upstream dispatcher (run executor) populates the request fields; that wiring is out of scope for this story. Cleanly separable from andy-models #78.

## Tests
`ContainerOrchestrationServicePerToolEnvTests`: inject / omit / no-override cases (3). Full `Andy.Containers.Api.Tests`: **1251 pass / 1 skip**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)