### PR TITLE
Make headless config runs-root config-driven, not IsEmbedded-gated

### DIFF
--- a/src/Andy.Containers.Api/Services/HeadlessConfigWriter.cs
+++ b/src/Andy.Containers.Api/Services/HeadlessConfigWriter.cs
@@ -1,25 +1,41 @@
 using Andy.Containers.Configurator;
-using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Configuration;
 
 namespace Andy.Containers.Api.Services;
 
 /// <summary>
-/// AP3 (rivoli-ai/andy-containers#105) writer. Uses
-/// <see cref="HostEnvironmentExtensions.IsEmbedded"/> to choose the on-disk
-/// root: hosted/Docker writes under <c>/var/run/andy/runs</c>, embedded
-/// (Conductor) writes under the OS temp dir so the unsandboxed Mac binary
-/// doesn't try to mkdir under <c>/var</c>.
+/// AP3 (rivoli-ai/andy-containers#105) writer. The on-disk runs-root is
+/// config-driven via the <c>ANDY_HEADLESS_RUNS_ROOT</c> environment variable
+/// (or <c>Containers:HeadlessRunsRoot</c> setting). When unset it defaults to
+/// a user-writable path under the OS temp dir so an unsandboxed host process
+/// (the Conductor daemon on macOS) never tries to <c>mkdir</c> under the
+/// root-owned <c>/var/run</c>. Hosted/Docker deployments point the env var at
+/// <c>/var/run/andy/runs</c> explicitly. This replaces the former
+/// <c>IsEmbedded()</c> branch — the "Embedded" hosting environment is being
+/// retired across the services (the daemon now runs them as host processes,
+/// not in-process), so runtime behaviour is selected by explicit config, not
+/// by an environment name.
 /// </summary>
 public sealed class HeadlessConfigWriter : IHeadlessConfigWriter
 {
-    private const string HostedRoot = "/var/run/andy/runs";
     private const string ConfigFileName = "config.json";
+    private const string RunsRootEnvVar = "ANDY_HEADLESS_RUNS_ROOT";
+    private const string RunsRootConfigKey = "Containers:HeadlessRunsRoot";
 
-    private readonly IHostEnvironment _environment;
+    private readonly string _runsRoot;
 
-    public HeadlessConfigWriter(IHostEnvironment environment)
+    public HeadlessConfigWriter(IConfiguration configuration)
     {
-        _environment = environment;
+        // Explicit config wins (env var or appsettings); otherwise default to
+        // a user-writable temp location that works for the host daemon and is
+        // shareable with the local container runtime.
+        var configured =
+            Environment.GetEnvironmentVariable(RunsRootEnvVar)
+            ?? configuration?[RunsRootConfigKey];
+
+        _runsRoot = string.IsNullOrWhiteSpace(configured)
+            ? Path.Combine(Path.GetTempPath(), "andy-containers", "runs")
+            : configured;
     }
 
     public async Task<string> WriteAsync(HeadlessRunConfig config, CancellationToken ct = default)
@@ -30,11 +46,7 @@ public sealed class HeadlessConfigWriter : IHeadlessConfigWriter
             throw new ArgumentException("HeadlessRunConfig.RunId must be set before writing.", nameof(config));
         }
 
-        var root = _environment.IsEmbedded()
-            ? Path.Combine(Path.GetTempPath(), "andy-containers", "runs")
-            : HostedRoot;
-
-        var runDir = Path.Combine(root, config.RunId.ToString());
+        var runDir = Path.Combine(_runsRoot, config.RunId.ToString());
         Directory.CreateDirectory(runDir);
 
         var path = Path.Combine(runDir, ConfigFileName);

--- a/tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigWriterTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigWriterTests.cs
@@ -2,32 +2,46 @@ using System.Text.Json;
 using Andy.Containers.Api.Services;
 using Andy.Containers.Configurator;
 using FluentAssertions;
-using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace Andy.Containers.Api.Tests.Configurator;
 
 // AP3 (rivoli-ai/andy-containers#105). Verifies the writer atomically
-// produces a snake_case JSON file under the embedded path. The hosted path
-// (/var/run/andy/runs) is not exercised here — it requires root on the
-// CI host and the path-selection branch is covered by HostEnvironment.
+// produces a snake_case JSON file under a config-driven runs-root.
+//
+// The path is now selected by explicit config (the `Containers:HeadlessRunsRoot`
+// setting / `ANDY_HEADLESS_RUNS_ROOT` env var), NOT by the retired "Embedded"
+// hosting environment (conductor: "remove embedded across the board" — the
+// daemon runs services as host processes, so the root-owned /var/run/andy
+// default broke the host daemon with an UnauthorizedAccessException). When
+// unset the writer defaults to a user-writable temp root.
 public class HeadlessConfigWriterTests : IDisposable
 {
     private readonly string _tempBase;
+    private readonly string _customRoot;
 
     public HeadlessConfigWriterTests()
     {
         _tempBase = Path.Combine(Path.GetTempPath(), "andy-containers", "runs");
+        _customRoot = Path.Combine(Path.GetTempPath(), "andy-containers-test-" + Guid.NewGuid().ToString("N"));
     }
 
     public void Dispose()
     {
-        // Tests above write under the OS temp dir. Best-effort cleanup of
-        // run subdirs created during this run; intentionally narrow so we
-        // never blow away unrelated state if Path.GetTempPath shifts.
-        if (!Directory.Exists(_tempBase)) return;
-        foreach (var dir in Directory.EnumerateDirectories(_tempBase))
+        // Best-effort cleanup of run subdirs created during this run;
+        // intentionally narrow so we never blow away unrelated state.
+        CleanupRunDirs(_tempBase);
+        if (Directory.Exists(_customRoot))
+        {
+            try { Directory.Delete(_customRoot, recursive: true); } catch { /* ignore */ }
+        }
+    }
+
+    private static void CleanupRunDirs(string root)
+    {
+        if (!Directory.Exists(root)) return;
+        foreach (var dir in Directory.EnumerateDirectories(root))
         {
             if (Guid.TryParse(Path.GetFileName(dir), out _))
             {
@@ -36,15 +50,29 @@ public class HeadlessConfigWriterTests : IDisposable
         }
     }
 
+    // Empty configuration → no env var, no setting → user-writable temp default.
+    private static IConfiguration EmptyConfig() =>
+        new ConfigurationBuilder().AddInMemoryCollection().Build();
+
+    private static IConfiguration ConfigWithRoot(string root) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Containers:HeadlessRunsRoot"] = root,
+            })
+            .Build();
+
     [Fact]
-    public async Task WriteAsync_Embedded_WritesSnakeCaseJsonUnderTempRoot()
+    public async Task WriteAsync_DefaultsToUserWritableTempRoot()
     {
-        var writer = new HeadlessConfigWriter(new FakeEnv(HostEnvironmentExtensions.EmbeddedEnvironmentName));
+        var writer = new HeadlessConfigWriter(EmptyConfig());
         var config = SampleConfig();
 
         var path = await writer.WriteAsync(config);
 
-        path.Should().StartWith(_tempBase);
+        path.Should().StartWith(_tempBase,
+            "with no configured runs-root the writer must default to the user-writable temp dir, " +
+            "never the root-owned /var/run/andy that breaks the host daemon");
         File.Exists(path).Should().BeTrue();
 
         var json = await File.ReadAllTextAsync(path);
@@ -59,9 +87,23 @@ public class HeadlessConfigWriterTests : IDisposable
     }
 
     [Fact]
+    public async Task WriteAsync_HonorsConfiguredRunsRoot()
+    {
+        var writer = new HeadlessConfigWriter(ConfigWithRoot(_customRoot));
+        var config = SampleConfig();
+
+        var path = await writer.WriteAsync(config);
+
+        path.Should().StartWith(_customRoot,
+            "an explicit Containers:HeadlessRunsRoot must be honored so hosted/Docker deployments " +
+            "can still target /var/run/andy/runs");
+        File.Exists(path).Should().BeTrue();
+    }
+
+    [Fact]
     public async Task WriteAsync_OverwritesExistingFile()
     {
-        var writer = new HeadlessConfigWriter(new FakeEnv(HostEnvironmentExtensions.EmbeddedEnvironmentName));
+        var writer = new HeadlessConfigWriter(EmptyConfig());
         var config = SampleConfig();
 
         var first = await writer.WriteAsync(config);
@@ -76,7 +118,7 @@ public class HeadlessConfigWriterTests : IDisposable
     [Fact]
     public async Task WriteAsync_LeavesNoTmpFileBehind()
     {
-        var writer = new HeadlessConfigWriter(new FakeEnv(HostEnvironmentExtensions.EmbeddedEnvironmentName));
+        var writer = new HeadlessConfigWriter(EmptyConfig());
         var config = SampleConfig();
 
         var path = await writer.WriteAsync(config);
@@ -88,7 +130,7 @@ public class HeadlessConfigWriterTests : IDisposable
     [Fact]
     public async Task WriteAsync_EmptyRunId_Throws()
     {
-        var writer = new HeadlessConfigWriter(new FakeEnv(HostEnvironmentExtensions.EmbeddedEnvironmentName));
+        var writer = new HeadlessConfigWriter(EmptyConfig());
         var config = SampleConfig() with { RunId = Guid.Empty };
 
         var act = async () => await writer.WriteAsync(config);
@@ -106,13 +148,4 @@ public class HeadlessConfigWriterTests : IDisposable
         Output = new HeadlessOutput { File = "/workspace/.andy-run/output.json", Stream = "stdout" },
         Limits = new HeadlessLimits { MaxIterations = 50, TimeoutSeconds = 300 },
     };
-
-    private sealed class FakeEnv : IHostEnvironment
-    {
-        public FakeEnv(string name) { EnvironmentName = name; }
-        public string EnvironmentName { get; set; }
-        public string ApplicationName { get; set; } = "test";
-        public string ContentRootPath { get; set; } = "/";
-        public IFileProvider ContentRootFileProvider { get; set; } = null!;
-    }
 }


### PR DESCRIPTION
## Problem
`HeadlessConfigWriter` selected its runs-root via `IHostEnvironment.IsEmbedded()`: hosted/Docker wrote under the root-owned `/var/run/andy/runs`. The Conductor daemon runs andy-containers as a **host process** (not the `Embedded` env), so it took the `/var/run/andy` branch and failed with `UnauthorizedAccessException` — runs persisted `Pending` and never dispatched to a container.

## Fix
Config-driven runs-root: `ANDY_HEADLESS_RUNS_ROOT` env / `Containers:HeadlessRunsRoot` setting, defaulting to a user-writable temp root. Hosted/Docker sets it to `/var/run/andy/runs`. Advances retiring the `Embedded` hosting environment (config-driven, not environment-name-driven).

## Tests
`HeadlessConfigWriterTests` updated for default-temp + configured-root paths. **5/5 passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)