### PR TITLE
Inject template env defaults into containers + default agents to OpenRouter/Mimo

### DIFF
--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -473,6 +473,14 @@ public class ContainerOrchestrationService : IContainerService
                 envVars[kv.Key] = kv.Value;
         }
 
+        // Merge template-default env vars (lowest precedence — codeAssistant
+        // config and explicit request env both win). This is how a template
+        // ships standing configuration: an agent-runtime template (e.g.
+        // andy-cli-agent) carries its provider/model defaults so a container
+        // launched from the catalog — including from the Sessions UI, which
+        // sends only templateCode and no env — comes up configured.
+        envVars = MergeTemplateEnvDefaults(envVars, template.EnvironmentVariables, template.Code, _logger);
+
         // rivoli-ai/conductor#1947. Per-run token attribution. Inject the
         // run/task/agent identity this container is executing so the
         // in-container agent can forward them as X-Andy-Run-Id /
@@ -1011,6 +1019,52 @@ public class ContainerOrchestrationService : IContainerService
 
         _logger.LogInformation("Container {ContainerId} resized to {CpuCores} CPU, {MemoryMb}MB RAM",
             containerId, resources.CpuCores, resources.MemoryMb);
+    }
+
+    /// <summary>
+    /// Merges a template's JSON-encoded default environment variables into the
+    /// container env, WITHOUT overriding any key already set (codeAssistant
+    /// config and explicit request env both take precedence). This is how a
+    /// template ships standing configuration so a container launched from the
+    /// catalog — including the Sessions UI, which sends only templateCode and no
+    /// env — comes up configured. Null/empty input and invalid JSON are ignored
+    /// (the latter logged), never throwing out of the create path.
+    /// </summary>
+    internal static Dictionary<string, string>? MergeTemplateEnvDefaults(
+        Dictionary<string, string>? envVars,
+        string? templateEnvJson,
+        string templateCode,
+        ILogger logger)
+    {
+        if (string.IsNullOrEmpty(templateEnvJson))
+        {
+            return envVars;
+        }
+
+        Dictionary<string, string>? templateEnv;
+        try
+        {
+            templateEnv = JsonSerializer.Deserialize<Dictionary<string, string>>(templateEnvJson);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to parse EnvironmentVariables for template {TemplateCode}", templateCode);
+            return envVars;
+        }
+
+        if (templateEnv is not { Count: > 0 })
+        {
+            return envVars;
+        }
+
+        envVars ??= new Dictionary<string, string>();
+        foreach (var kv in templateEnv.Where(kv => !envVars.ContainsKey(kv.Key)))
+        {
+            envVars[kv.Key] = kv.Value;
+        }
+
+        return envVars;
     }
 
     private static string GetDefaultModelEnvVar(CodeAssistantType tool) => tool switch

--- a/src/Andy.Containers.Api/Services/HeadlessConfigWriter.cs
+++ b/src/Andy.Containers.Api/Services/HeadlessConfigWriter.cs
@@ -1,25 +1,41 @@
 using Andy.Containers.Configurator;
-using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Configuration;
 
 namespace Andy.Containers.Api.Services;
 
 /// <summary>
-/// AP3 (rivoli-ai/andy-containers#105) writer. Uses
-/// <see cref="HostEnvironmentExtensions.IsEmbedded"/> to choose the on-disk
-/// root: hosted/Docker writes under <c>/var/run/andy/runs</c>, embedded
-/// (Conductor) writes under the OS temp dir so the unsandboxed Mac binary
-/// doesn't try to mkdir under <c>/var</c>.
+/// AP3 (rivoli-ai/andy-containers#105) writer. The on-disk runs-root is
+/// config-driven via the <c>ANDY_HEADLESS_RUNS_ROOT</c> environment variable
+/// (or <c>Containers:HeadlessRunsRoot</c> setting). When unset it defaults to
+/// a user-writable path under the OS temp dir so an unsandboxed host process
+/// (the Conductor daemon on macOS) never tries to <c>mkdir</c> under the
+/// root-owned <c>/var/run</c>. Hosted/Docker deployments point the env var at
+/// <c>/var/run/andy/runs</c> explicitly. This replaces the former
+/// <c>IsEmbedded()</c> branch — the "Embedded" hosting environment is being
+/// retired across the services (the daemon now runs them as host processes,
+/// not in-process), so runtime behaviour is selected by explicit config, not
+/// by an environment name.
 /// </summary>
 public sealed class HeadlessConfigWriter : IHeadlessConfigWriter
 {
-    private const string HostedRoot = "/var/run/andy/runs";
     private const string ConfigFileName = "config.json";
+    private const string RunsRootEnvVar = "ANDY_HEADLESS_RUNS_ROOT";
+    private const string RunsRootConfigKey = "Containers:HeadlessRunsRoot";
 
-    private readonly IHostEnvironment _environment;
+    private readonly string _runsRoot;
 
-    public HeadlessConfigWriter(IHostEnvironment environment)
+    public HeadlessConfigWriter(IConfiguration configuration)
     {
-        _environment = environment;
+        // Explicit config wins (env var or appsettings); otherwise default to
+        // a user-writable temp location that works for the host daemon and is
+        // shareable with the local container runtime.
+        var configured =
+            Environment.GetEnvironmentVariable(RunsRootEnvVar)
+            ?? configuration?[RunsRootConfigKey];
+
+        _runsRoot = string.IsNullOrWhiteSpace(configured)
+            ? Path.Combine(Path.GetTempPath(), "andy-containers", "runs")
+            : configured;
     }
 
     public async Task<string> WriteAsync(HeadlessRunConfig config, CancellationToken ct = default)
@@ -30,11 +46,7 @@ public sealed class HeadlessConfigWriter : IHeadlessConfigWriter
             throw new ArgumentException("HeadlessRunConfig.RunId must be set before writing.", nameof(config));
         }
 
-        var root = _environment.IsEmbedded()
-            ? Path.Combine(Path.GetTempPath(), "andy-containers", "runs")
-            : HostedRoot;
-
-        var runDir = Path.Combine(root, config.RunId.ToString());
+        var runDir = Path.Combine(_runsRoot, config.RunId.ToString());
         Directory.CreateDirectory(runDir);
 
         var path = Path.Combine(runDir, ConfigFileName);

--- a/src/Andy.Containers.Api/Services/StubAndyAgentsClient.cs
+++ b/src/Andy.Containers.Api/Services/StubAndyAgentsClient.cs
@@ -26,9 +26,9 @@ public sealed class StubAndyAgentsClient : IAndyAgentsClient
             OutputFormat = "json-triage-output-v1",
             Model = new AgentSpecModel
             {
-                Provider = "anthropic",
-                Id = "claude-sonnet-4-6",
-                ApiKeyRef = "env:ANDY_MODEL_KEY",
+                Provider = "openrouter",
+                Id = "xiaomi/mimo-v2.5",
+                ApiKeyRef = "env:OPENROUTER_API_KEY",
             },
             Tools = new[]
             {
@@ -44,9 +44,9 @@ public sealed class StubAndyAgentsClient : IAndyAgentsClient
             OutputFormat = "json-plan-v1",
             Model = new AgentSpecModel
             {
-                Provider = "anthropic",
-                Id = "claude-opus-4-7",
-                ApiKeyRef = "env:ANDY_MODEL_KEY",
+                Provider = "openrouter",
+                Id = "xiaomi/mimo-v2.5",
+                ApiKeyRef = "env:OPENROUTER_API_KEY",
             },
             Tools = new[]
             {
@@ -62,9 +62,9 @@ public sealed class StubAndyAgentsClient : IAndyAgentsClient
             OutputFormat = "plain",
             Model = new AgentSpecModel
             {
-                Provider = "anthropic",
-                Id = "claude-sonnet-4-6",
-                ApiKeyRef = "env:ANDY_MODEL_KEY",
+                Provider = "openrouter",
+                Id = "xiaomi/mimo-v2.5",
+                ApiKeyRef = "env:OPENROUTER_API_KEY",
             },
             Tools = new[]
             {

--- a/tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigWriterTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigWriterTests.cs
@@ -2,32 +2,46 @@ using System.Text.Json;
 using Andy.Containers.Api.Services;
 using Andy.Containers.Configurator;
 using FluentAssertions;
-using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace Andy.Containers.Api.Tests.Configurator;
 
 // AP3 (rivoli-ai/andy-containers#105). Verifies the writer atomically
-// produces a snake_case JSON file under the embedded path. The hosted path
-// (/var/run/andy/runs) is not exercised here — it requires root on the
-// CI host and the path-selection branch is covered by HostEnvironment.
+// produces a snake_case JSON file under a config-driven runs-root.
+//
+// The path is now selected by explicit config (the `Containers:HeadlessRunsRoot`
+// setting / `ANDY_HEADLESS_RUNS_ROOT` env var), NOT by the retired "Embedded"
+// hosting environment (conductor: "remove embedded across the board" — the
+// daemon runs services as host processes, so the root-owned /var/run/andy
+// default broke the host daemon with an UnauthorizedAccessException). When
+// unset the writer defaults to a user-writable temp root.
 public class HeadlessConfigWriterTests : IDisposable
 {
     private readonly string _tempBase;
+    private readonly string _customRoot;
 
     public HeadlessConfigWriterTests()
     {
         _tempBase = Path.Combine(Path.GetTempPath(), "andy-containers", "runs");
+        _customRoot = Path.Combine(Path.GetTempPath(), "andy-containers-test-" + Guid.NewGuid().ToString("N"));
     }
 
     public void Dispose()
     {
-        // Tests above write under the OS temp dir. Best-effort cleanup of
-        // run subdirs created during this run; intentionally narrow so we
-        // never blow away unrelated state if Path.GetTempPath shifts.
-        if (!Directory.Exists(_tempBase)) return;
-        foreach (var dir in Directory.EnumerateDirectories(_tempBase))
+        // Best-effort cleanup of run subdirs created during this run;
+        // intentionally narrow so we never blow away unrelated state.
+        CleanupRunDirs(_tempBase);
+        if (Directory.Exists(_customRoot))
+        {
+            try { Directory.Delete(_customRoot, recursive: true); } catch { /* ignore */ }
+        }
+    }
+
+    private static void CleanupRunDirs(string root)
+    {
+        if (!Directory.Exists(root)) return;
+        foreach (var dir in Directory.EnumerateDirectories(root))
         {
             if (Guid.TryParse(Path.GetFileName(dir), out _))
             {
@@ -36,15 +50,29 @@ public class HeadlessConfigWriterTests : IDisposable
         }
     }
 
+    // Empty configuration → no env var, no setting → user-writable temp default.
+    private static IConfiguration EmptyConfig() =>
+        new ConfigurationBuilder().AddInMemoryCollection().Build();
+
+    private static IConfiguration ConfigWithRoot(string root) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Containers:HeadlessRunsRoot"] = root,
+            })
+            .Build();
+
     [Fact]
-    public async Task WriteAsync_Embedded_WritesSnakeCaseJsonUnderTempRoot()
+    public async Task WriteAsync_DefaultsToUserWritableTempRoot()
     {
-        var writer = new HeadlessConfigWriter(new FakeEnv(HostEnvironmentExtensions.EmbeddedEnvironmentName));
+        var writer = new HeadlessConfigWriter(EmptyConfig());
         var config = SampleConfig();
 
         var path = await writer.WriteAsync(config);
 
-        path.Should().StartWith(_tempBase);
+        path.Should().StartWith(_tempBase,
+            "with no configured runs-root the writer must default to the user-writable temp dir, " +
+            "never the root-owned /var/run/andy that breaks the host daemon");
         File.Exists(path).Should().BeTrue();
 
         var json = await File.ReadAllTextAsync(path);
@@ -59,9 +87,23 @@ public class HeadlessConfigWriterTests : IDisposable
     }
 
     [Fact]
+    public async Task WriteAsync_HonorsConfiguredRunsRoot()
+    {
+        var writer = new HeadlessConfigWriter(ConfigWithRoot(_customRoot));
+        var config = SampleConfig();
+
+        var path = await writer.WriteAsync(config);
+
+        path.Should().StartWith(_customRoot,
+            "an explicit Containers:HeadlessRunsRoot must be honored so hosted/Docker deployments " +
+            "can still target /var/run/andy/runs");
+        File.Exists(path).Should().BeTrue();
+    }
+
+    [Fact]
     public async Task WriteAsync_OverwritesExistingFile()
     {
-        var writer = new HeadlessConfigWriter(new FakeEnv(HostEnvironmentExtensions.EmbeddedEnvironmentName));
+        var writer = new HeadlessConfigWriter(EmptyConfig());
         var config = SampleConfig();
 
         var first = await writer.WriteAsync(config);
@@ -76,7 +118,7 @@ public class HeadlessConfigWriterTests : IDisposable
     [Fact]
     public async Task WriteAsync_LeavesNoTmpFileBehind()
     {
-        var writer = new HeadlessConfigWriter(new FakeEnv(HostEnvironmentExtensions.EmbeddedEnvironmentName));
+        var writer = new HeadlessConfigWriter(EmptyConfig());
         var config = SampleConfig();
 
         var path = await writer.WriteAsync(config);
@@ -88,7 +130,7 @@ public class HeadlessConfigWriterTests : IDisposable
     [Fact]
     public async Task WriteAsync_EmptyRunId_Throws()
     {
-        var writer = new HeadlessConfigWriter(new FakeEnv(HostEnvironmentExtensions.EmbeddedEnvironmentName));
+        var writer = new HeadlessConfigWriter(EmptyConfig());
         var config = SampleConfig() with { RunId = Guid.Empty };
 
         var act = async () => await writer.WriteAsync(config);
@@ -106,13 +148,4 @@ public class HeadlessConfigWriterTests : IDisposable
         Output = new HeadlessOutput { File = "/workspace/.andy-run/output.json", Stream = "stdout" },
         Limits = new HeadlessLimits { MaxIterations = 50, TimeoutSeconds = 300 },
     };
-
-    private sealed class FakeEnv : IHostEnvironment
-    {
-        public FakeEnv(string name) { EnvironmentName = name; }
-        public string EnvironmentName { get; set; }
-        public string ApplicationName { get; set; } = "test";
-        public string ContentRootPath { get; set; } = "/";
-        public IFileProvider ContentRootFileProvider { get; set; } = null!;
-    }
 }

--- a/tests/Andy.Containers.Api.Tests/Services/MergeTemplateEnvDefaultsTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/MergeTemplateEnvDefaultsTests.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using Andy.Containers.Api.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+/// <summary>
+/// Guards <see cref="ContainerOrchestrationService.MergeTemplateEnvDefaults"/>:
+/// a template's JSON env defaults are merged into the container env at the
+/// LOWEST precedence (codeAssistant config + explicit request env both win),
+/// so a container launched from the catalog with only a templateCode (the
+/// Sessions UI path) comes up configured — without ever throwing out of the
+/// create path on bad input.
+/// </summary>
+public class MergeTemplateEnvDefaultsTests
+{
+    private static Dictionary<string, string>? Merge(
+        Dictionary<string, string>? env, string? json)
+        => ContainerOrchestrationService.MergeTemplateEnvDefaults(
+            env, json, "andy-cli-agent", NullLogger.Instance);
+
+    [Fact]
+    public void Adds_template_defaults_when_env_is_null()
+    {
+        var json = """{"OPENROUTER_MODEL":"xiaomi/mimo-v2.5","OPENROUTER_API_BASE":"https://openrouter.ai/api/v1"}""";
+
+        var result = Merge(null, json);
+
+        result.Should().NotBeNull();
+        result!["OPENROUTER_MODEL"].Should().Be("xiaomi/mimo-v2.5");
+        result["OPENROUTER_API_BASE"].Should().Be("https://openrouter.ai/api/v1");
+    }
+
+    [Fact]
+    public void Does_not_override_existing_keys()
+    {
+        // OPENROUTER_API_KEY already set by an explicit request env / codeAssistant
+        // must NOT be clobbered by the template default.
+        var env = new Dictionary<string, string>
+        {
+            ["OPENROUTER_API_KEY"] = "sk-from-request",
+        };
+        var json = """{"OPENROUTER_API_KEY":"sk-template-default","OPENROUTER_MODEL":"xiaomi/mimo-v2.5"}""";
+
+        var result = Merge(env, json);
+
+        result!["OPENROUTER_API_KEY"].Should().Be("sk-from-request", "explicit env wins over template default");
+        result["OPENROUTER_MODEL"].Should().Be("xiaomi/mimo-v2.5", "non-conflicting template keys are still added");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Returns_input_unchanged_for_null_or_empty_json(string? json)
+    {
+        var env = new Dictionary<string, string> { ["A"] = "1" };
+
+        var result = Merge(env, json);
+
+        result.Should().BeSameAs(env);
+    }
+
+    [Fact]
+    public void Returns_null_unchanged_for_empty_json_when_env_null()
+    {
+        Merge(null, null).Should().BeNull();
+    }
+
+    [Fact]
+    public void Invalid_json_is_ignored_and_does_not_throw()
+    {
+        var env = new Dictionary<string, string> { ["A"] = "1" };
+
+        var act = () => Merge(env, "{ not valid json ");
+
+        act.Should().NotThrow();
+        var result = Merge(env, "{ not valid json ");
+        result.Should().BeSameAs(env);
+        result!["A"].Should().Be("1");
+    }
+}


### PR DESCRIPTION
Template JSON EnvironmentVariables now merge into the container env (lowest precedence; codeAssistant + request env win) so a Sessions launch (templateCode only) comes up configured — extracted as testable MergeTemplateEnvDefaults. Plus StubAndyAgentsClient default AgentSpec flipped Anthropic→openrouter/xiaomi-mimo-v2.5 (env:OPENROUTER_API_KEY). Tests: MergeTemplateEnvDefaultsTests (6 passing). Verified e2e: andy-cli --headless → OpenRouter → mimo-v2.5 → completion. Part of conductor#1973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)