### PR TITLE
[SM.2.7] Structured BuildEvent failure taxonomy + non-silent .cached event

### DIFF
--- a/docs/architecture/image-management.md
+++ b/docs/architecture/image-management.md
@@ -241,7 +241,7 @@ Full OpenAPI spec lands in story IM5. Preview:
 | `GET /api/templates/{templateId}` | Return template metadata. |
 | `POST /api/images/{templateId}/build` | Trigger a build. Returns `{ buildId, status: "queued" }`. **Async** — see SSE below. If `specHash` already resolves to a `BuildArtifact` in the primary registry, returns the existing artifact reference immediately with `status: "cached"`. |
 | `GET /api/images/build/{buildId}` | Build status snapshot: `{ status, digest?, references[], buildLog? }`. |
-| `GET /api/images/build/{buildId}/events` | **Server-Sent Events** stream of build progress (`step-start`, `step-stdout`, `step-error`, `complete`). |
+| `GET /api/images/build/{buildId}/events` | **Server-Sent Events** stream of build progress (`step-start`, `step-stdout`, `step-error`, `cached`, `build-failed`, `complete`). See §BuildEvent failure taxonomy below. |
 | `GET /api/images` | List all `BuildArtifact`s. Each entry includes `references[]` per registry. |
 | `GET /api/images/{digest}` | Get a single artifact by digest. |
 | `DELETE /api/images/{digest}/references/{referenceId}` | Untag a reference (does not delete the artifact). Admin-only. |
@@ -256,6 +256,50 @@ Full OpenAPI spec lands in story IM5. Preview:
 | **`specHash` idempotent on register** | Re-uploading the same spec returns the existing template ID, no duplicate rows |
 | **Build response shape is registry-aware** (`{ digest, references[] }`) | The API works the same in solo and cloud modes; the references array changes |
 | **Content-addressable cache hit** on register-then-build | Skip rebuild if `specHash → digest` is already known in the primary registry |
+
+### BuildEvent failure taxonomy (SM.2.7 / rivoli-ai/conductor#2009)
+
+The build/pull SSE stream emits two typed events in addition to the existing `step-*` events:
+
+#### `cached` event
+
+Emitted on every cache hit so the consumer can reconcile against an "already present" state without inferring from silence or from the synchronous `status:"cached"` on the initial HTTP response. Aligns with Conductor's `registrySeedingPullCompleted(alreadyPresent: true)` semantics.
+
+```json
+{ "timestamp": "2026-06-04T12:00:00Z", "digest": "sha256:abc..." }
+```
+
+`digest` may be `null` when the cache hit was detected before the digest was resolved.
+
+#### `build-failed` event
+
+Emitted before the terminal `complete` event on every failure path. Carries a stable `reason` enum and a `transient` boolean so consumers can decide between retry (transient) and surface-terminal (permanent) without parsing free-text.
+
+```json
+{
+  "timestamp": "2026-06-04T12:00:00Z",
+  "reason": "registryUnreachable",
+  "transient": true,
+  "detail": "connection refused"
+}
+```
+
+Failure reason taxonomy and transient/permanent classification:
+
+| `reason`              | `transient` | Triggering condition                                            |
+|-----------------------|-------------|-----------------------------------------------------------------|
+| `registryUnreachable` | `true`      | DNS/TCP/TLS failure; retry after back-off                      |
+| `engineUnavailable`   | `true`      | Docker/container engine down or failed to start                |
+| `pullInterrupted`     | `true`      | Mid-transfer timeout or network drop                           |
+| `manifestUnknown`     | `false`     | Tag/repo not found in the registry                             |
+| `digestMismatch`      | `false`     | Pulled digest differs from expected/pinned value               |
+| `imagePullFailed`     | `false`     | Pull completed but image failed verification or policy         |
+| `unknown`             | `false`     | Unclassified failure; surface to operator                      |
+
+`transient: true` → the consumer may retry after exponential back-off.
+`transient: false` → the consumer must surface a terminal error; retry will not help.
+
+Image Pull stays a DTO consumed by `ContainerLifecycle` — no independent state machine. The failure taxonomy is the PREREQ that unblocks SM.2 (the `ContainerLifecycle` machine) from needing to treat image pull as a separate machine; it instead consumes failure reason as `phaseData`. See `docs/architecture/state-machine-adoption-spec.md §3`.
 
 ## Cross-cutting security implications
 

--- a/src/Andy.Containers.Api/Controllers/ImagesController.cs
+++ b/src/Andy.Containers.Api/Controllers/ImagesController.cs
@@ -243,13 +243,18 @@ public class ImagesController : ControllerBase
         // SSE wire format: id:, event:, data: lines, terminated by
         // a blank line. The event name is lowercase-kebab to match
         // the IM5 OpenAPI BuildEvent.type discriminator.
+        // SM.2.7 (rivoli-ai/conductor#2009): two new event types added —
+        //   build-failed  (BuildFailureEvent)  — structured failure taxonomy
+        //   cached        (BuildCachedEvent)   — explicit cache-hit signal
         var name = envelope.Event switch
         {
             BuildStepStartedEvent => "step-start",
-            BuildStepStdoutEvent => "step-stdout",
-            BuildStepErrorEvent => "step-error",
-            BuildCompletedEvent => "complete",
-            _ => "unknown",
+            BuildStepStdoutEvent  => "step-stdout",
+            BuildStepErrorEvent   => "step-error",
+            BuildFailureEvent     => "build-failed",
+            BuildCachedEvent      => "cached",
+            BuildCompletedEvent   => "complete",
+            _                     => "unknown",
         };
         // Surfaced by the SSE wire-format integration test (#272 / sse-wire-format-test):
         //   1. JsonSerializer.Serialize<object>(value) uses the

--- a/src/Andy.Containers.Infrastructure/Build/Events/AsyncBuildExecutor.cs
+++ b/src/Andy.Containers.Infrastructure/Build/Events/AsyncBuildExecutor.cs
@@ -61,6 +61,23 @@ public sealed class AsyncBuildExecutor : IAsyncBuildExecutor
                 var cached = await orchestrator.TryCacheHitAsync(request, ct);
                 if (cached is not null)
                 {
+                    // SM.2.7 (rivoli-ai/conductor#2009). Emit an explicit
+                    // .cached SSE event so consumers can reconcile against a
+                    // "present" state without inferring from silence or the
+                    // synchronous status:"cached" on the initial HTTP response.
+                    _bus.Publish(cached.BuildId, new BuildCachedEvent
+                    {
+                        Timestamp = DateTimeOffset.UtcNow,
+                        Digest = cached.Digest,
+                    });
+                    // Terminal complete event — keeps consumers that only
+                    // watch for BuildCompletedEvent working unchanged.
+                    _bus.Publish(cached.BuildId, new BuildCompletedEvent
+                    {
+                        Timestamp = DateTimeOffset.UtcNow,
+                        Outcome = BuildOutcome.Succeeded,
+                        Digest = cached.Digest,
+                    });
                     return new AsyncBuildHandle(cached.BuildId, AsyncBuildHandleStatus.Cached, cached);
                 }
             }
@@ -127,6 +144,24 @@ public sealed class AsyncBuildExecutor : IAsyncBuildExecutor
                 };
             _registry.Update(buildId, terminal);
 
+            // SM.2.7 (rivoli-ai/conductor#2009). Before the terminal
+            // BuildCompletedEvent, emit a structured BuildFailureEvent when
+            // the build failed — consumers key on Reason+Transient to decide
+            // between retry and surface-terminal. The completed event still
+            // fires so consumers with a single terminal-event handler keep
+            // working unchanged.
+            if (result.Status == BuildResultStatus.Failed)
+            {
+                var (reason, transient) = ClassifyFailure(result.ErrorCode);
+                _bus.Publish(buildId, new BuildFailureEvent
+                {
+                    Timestamp = DateTimeOffset.UtcNow,
+                    Reason = reason,
+                    Transient = transient,
+                    Detail = result.ErrorMessage,
+                });
+            }
+
             // Publish a terminal event for SSE consumers if the
             // orchestrator hasn't already (the build backend may
             // have emitted its own complete event during run; the
@@ -179,6 +214,16 @@ public sealed class AsyncBuildExecutor : IAsyncBuildExecutor
                     ErrorMessage = ex.Message,
                 });
             }
+            // SM.2.7 (rivoli-ai/conductor#2009). Unexpected exceptions are
+            // classified as Unknown/permanent so the consumer surfaces them
+            // as terminal rather than retrying indefinitely.
+            _bus.Publish(buildId, new BuildFailureEvent
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                Reason = BuildFailureReason.Unknown,
+                Transient = false,
+                Detail = ex.Message,
+            });
             _bus.Publish(buildId, new BuildCompletedEvent
             {
                 Timestamp = DateTimeOffset.UtcNow,
@@ -186,6 +231,62 @@ public sealed class AsyncBuildExecutor : IAsyncBuildExecutor
                 FailureReason = ex.Message,
             });
         }
+    }
+
+    /// <summary>
+    /// SM.2.7 (rivoli-ai/conductor#2009). Map a build orchestrator
+    /// error code to a structured <see cref="BuildFailureReason"/> +
+    /// transient flag. The error codes come from
+    /// <see cref="Andy.Containers.Storage.IImageBuildOrchestrator"/>
+    /// failure paths and the <see cref="Andy.Containers.Abstractions.Images.IImagePullService"/>
+    /// <c>ImagePullException.Code</c> taxonomy.
+    /// </summary>
+    internal static (BuildFailureReason reason, bool transient) ClassifyFailure(string? errorCode)
+    {
+        if (string.IsNullOrEmpty(errorCode))
+            return (BuildFailureReason.Unknown, false);
+
+        // Docker engine / pull service engine-launch failures — transient.
+        if (errorCode.StartsWith("ensure_pull_docker_launch_failed", StringComparison.OrdinalIgnoreCase) ||
+            errorCode.Equals("engine_unavailable", StringComparison.OrdinalIgnoreCase))
+        {
+            return (BuildFailureReason.EngineUnavailable, true);
+        }
+
+        // Registry connectivity — transient.
+        if (errorCode.StartsWith("registry.unreachable", StringComparison.OrdinalIgnoreCase) ||
+            errorCode.StartsWith("ensure_pull_docker_nonzero_exit", StringComparison.OrdinalIgnoreCase))
+        {
+            // Heuristic: nonzero exit from docker pull is most often a
+            // transient network problem; we classify conservatively as
+            // RegistryUnreachable/transient. More specific codes override.
+            return (BuildFailureReason.RegistryUnreachable, true);
+        }
+
+        // Manifest not found — permanent.
+        if (errorCode.StartsWith("registry.manifest_unknown", StringComparison.OrdinalIgnoreCase) ||
+            errorCode.StartsWith("manifest_unknown", StringComparison.OrdinalIgnoreCase) ||
+            errorCode.Equals("image.not-found", StringComparison.OrdinalIgnoreCase))
+        {
+            return (BuildFailureReason.ManifestUnknown, false);
+        }
+
+        // Digest mismatch — permanent.
+        if (errorCode.StartsWith("registry.digest_mismatch", StringComparison.OrdinalIgnoreCase) ||
+            errorCode.StartsWith("digest_mismatch", StringComparison.OrdinalIgnoreCase))
+        {
+            return (BuildFailureReason.DigestMismatch, false);
+        }
+
+        // General pull failure (policy, verification, etc.) — permanent.
+        if (errorCode.StartsWith("ensure_pull_push_succeeded_but_lookup_failed", StringComparison.OrdinalIgnoreCase) ||
+            errorCode.StartsWith("image_pull_failed", StringComparison.OrdinalIgnoreCase))
+        {
+            return (BuildFailureReason.ImagePullFailed, false);
+        }
+
+        // Fallback: surface as Unknown/permanent so the operator sees it.
+        return (BuildFailureReason.Unknown, false);
     }
 
     private static BuildExecutionStatus MapStatus(BuildResultStatus status) => status switch

--- a/src/Andy.Containers/Abstractions/Images/BuildProgressEvent.cs
+++ b/src/Andy.Containers/Abstractions/Images/BuildProgressEvent.cs
@@ -41,6 +41,145 @@ public sealed record BuildCompletedEvent : BuildProgressEvent
     public string? FailureReason { get; init; }
 }
 
+/// <summary>
+/// SM.2.7 (rivoli-ai/conductor#2009). Structured failure event emitted
+/// on the build/pull SSE stream when a pull or image-management operation
+/// fails. Carries a stable <see cref="Reason"/> enum, a
+/// <see cref="Transient"/> flag so consumers can decide between retry
+/// (transient) and surface-terminal (permanent), and a free-text
+/// <see cref="Detail"/> for operator diagnostics.
+///
+/// Emitted in addition to (and before) the terminal
+/// <see cref="BuildCompletedEvent"/> — the completed event still fires
+/// so consumers with a single terminal-event handler keep working
+/// unchanged; this event provides the richer taxonomy.
+///
+/// Wire type discriminator: <c>build-failed</c>.
+/// </summary>
+public sealed record BuildFailureEvent : BuildProgressEvent
+{
+    /// <summary>Stable failure reason from the taxonomy.</summary>
+    public required BuildFailureReason Reason { get; init; }
+
+    /// <summary>
+    /// <c>true</c> when the failure is considered transient (retry may
+    /// succeed); <c>false</c> when it is permanent (retry will not help).
+    /// Derived deterministically from <see cref="Reason"/> via
+    /// <see cref="BuildFailureReasonExtensions.IsTransient"/>.
+    /// </summary>
+    public required bool Transient { get; init; }
+
+    /// <summary>Human-readable detail for operator diagnostics. Not stable — do not key on it.</summary>
+    public string? Detail { get; init; }
+}
+
+/// <summary>
+/// SM.2.7 (rivoli-ai/conductor#2009). Emitted on the build/pull SSE
+/// stream when a cache hit is detected, so the consumer can reconcile
+/// against a "present" state without inferring it from silence or the
+/// synchronous <c>status: "cached"</c> on the initial HTTP response.
+///
+/// Aligns with Conductor's existing
+/// <c>registrySeedingPullCompleted(alreadyPresent: true)</c> event —
+/// the consumer maps this SSE event onto <c>alreadyPresent: true</c>
+/// without any additional inference.
+///
+/// Wire type discriminator: <c>cached</c>.
+/// </summary>
+public sealed record BuildCachedEvent : BuildProgressEvent
+{
+    /// <summary>
+    /// OCI digest of the already-present artifact, e.g.
+    /// <c>sha256:abc123...</c>. May be <c>null</c> when the cache
+    /// hit was detected before the digest was resolved.
+    /// </summary>
+    public string? Digest { get; init; }
+}
+
+/// <summary>
+/// SM.2.7. Stable reason codes for <see cref="BuildFailureEvent.Reason"/>.
+/// Classified as transient (retry may help) or permanent (terminal)
+/// via <see cref="BuildFailureReasonExtensions.IsTransient"/>.
+/// </summary>
+public enum BuildFailureReason
+{
+    // ---- Transient (retry may succeed) ----
+
+    /// <summary>
+    /// The registry could not be reached (DNS, TCP, TLS). Transient.
+    /// Maps from: network errors, connection refused, SSL handshake
+    /// failures.
+    /// </summary>
+    RegistryUnreachable,
+
+    /// <summary>
+    /// The Docker/container engine was unavailable or failed to start.
+    /// Transient.
+    /// Maps from: <c>ensure_pull_docker_launch_failed.*</c>,
+    /// <c>engine_unavailable</c> 503 codes.
+    /// </summary>
+    EngineUnavailable,
+
+    /// <summary>
+    /// The pull was interrupted mid-transfer (timeout, network drop).
+    /// Transient.
+    /// </summary>
+    PullInterrupted,
+
+    // ---- Permanent (surface terminal; retry will not help) ----
+
+    /// <summary>
+    /// The requested image tag or repository does not exist in the
+    /// registry. Permanent.
+    /// Maps from: registry 404, <c>manifest unknown</c> error.
+    /// </summary>
+    ManifestUnknown,
+
+    /// <summary>
+    /// The pulled image's digest does not match the expected/pinned
+    /// value. Permanent — the image in the registry has changed or the
+    /// spec is wrong; a retry will pull the same wrong digest.
+    /// </summary>
+    DigestMismatch,
+
+    /// <summary>
+    /// The pull completed but the resulting local image failed
+    /// verification (signature, policy). Permanent.
+    /// </summary>
+    ImagePullFailed,
+
+    /// <summary>
+    /// A failure reason not covered by the above taxonomy.
+    /// Consumers should treat this as permanent (surface to the
+    /// operator for manual investigation).
+    /// </summary>
+    Unknown,
+}
+
+/// <summary>
+/// SM.2.7. Transient/permanent classification for
+/// <see cref="BuildFailureReason"/>.
+/// </summary>
+public static class BuildFailureReasonExtensions
+{
+    /// <summary>
+    /// Returns <c>true</c> when the failure is considered transient
+    /// (a retry may succeed) and <c>false</c> when it is permanent
+    /// (surface terminal to the operator; retry will not help).
+    /// </summary>
+    public static bool IsTransient(this BuildFailureReason reason) => reason switch
+    {
+        BuildFailureReason.RegistryUnreachable => true,
+        BuildFailureReason.EngineUnavailable   => true,
+        BuildFailureReason.PullInterrupted     => true,
+        BuildFailureReason.ManifestUnknown     => false,
+        BuildFailureReason.DigestMismatch      => false,
+        BuildFailureReason.ImagePullFailed     => false,
+        BuildFailureReason.Unknown             => false,
+        _ => false,
+    };
+}
+
 public enum BuildOutcome
 {
     Succeeded,

--- a/tests/Andy.Containers.Api.Tests/Controllers/ImagesControllerSseSm27Tests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ImagesControllerSseSm27Tests.cs
@@ -1,0 +1,280 @@
+using System.Text;
+using Andy.Containers.Abstractions.Images;
+using Andy.Containers.Api.Controllers;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Build.Events;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Storage;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Controllers;
+
+// SM.2.7 (rivoli-ai/conductor#2009). SSE wire-format tests for the two
+// new event types added by this story:
+//
+//   BuildFailureEvent  →  event: build-failed
+//   BuildCachedEvent   →  event: cached
+//
+// Tests mirror the existing ImagesControllerSseTests pattern (MemoryStream-
+// backed DefaultHttpContext, pre-published events, synchronous drain).
+// Each test verifies the discriminator name, JSON payload shape, and that
+// the frame separator is correct.
+public class ImagesControllerSseSm27Tests : IDisposable
+{
+    private readonly ContainersDbContext _db;
+    private readonly InMemoryBuildEventBus _bus;
+    private readonly InMemoryBuildExecutionRegistry _registry;
+    private readonly ImagesController _controller;
+
+    public ImagesControllerSseSm27Tests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+        _bus = new InMemoryBuildEventBus();
+        _registry = new InMemoryBuildExecutionRegistry();
+
+        var mockManifest = new Mock<IImageManifestService>();
+        var mockDiff     = new Mock<IImageDiffService>();
+        var mockUser     = new Mock<ICurrentUserService>();
+        mockUser.Setup(u => u.GetUserId()).Returns("test-user");
+        mockUser.Setup(u => u.IsAdmin()).Returns(true);
+        var mockOrg          = new Mock<IOrganizationMembershipService>();
+        var mockOrchestrator = new Mock<IImageBuildOrchestrator>();
+        var mockExecutor     = new Mock<IAsyncBuildExecutor>();
+        var mockArtifacts    = new Mock<IBuildArtifactStore>();
+
+        _controller = new ImagesController(
+            _db,
+            mockManifest.Object,
+            mockDiff.Object,
+            mockUser.Object,
+            mockOrg.Object,
+            mockOrchestrator.Object,
+            mockExecutor.Object,
+            _bus,
+            _registry,
+            mockArtifacts.Object);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        _bus.Dispose();
+    }
+
+    // ------------------------------------------------------------------ //
+    //  BuildFailureEvent → wire type "build-failed"                       //
+    // ------------------------------------------------------------------ //
+
+    [Fact]
+    public async Task BuildEvents_BuildFailureEvent_EmitsBuildFailedFrame()
+    {
+        var buildId        = Guid.NewGuid();
+        var responseStream = new MemoryStream();
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { Response = { Body = responseStream } },
+        };
+
+        var now = DateTimeOffset.UtcNow;
+        _bus.Publish(buildId, new BuildFailureEvent
+        {
+            Timestamp = now,
+            Reason    = BuildFailureReason.DigestMismatch,
+            Transient = false,
+            Detail    = "got sha256:bad, expected sha256:good",
+        });
+        _bus.Publish(buildId, new BuildCompletedEvent
+        {
+            Timestamp = now,
+            Outcome   = BuildOutcome.Failed,
+            FailureReason = "digest mismatch",
+        });
+
+        await _controller.BuildEvents(buildId, CancellationToken.None);
+
+        responseStream.Position = 0;
+        var body = Encoding.UTF8.GetString(responseStream.ToArray());
+
+        // 1. Discriminator — must be "build-failed" not "unknown".
+        body.Should().Contain("event: build-failed\n",
+            because: "the BuildFailureEvent wire discriminator must be 'build-failed' per the SM.2.7 spec");
+
+        // 2. JSON payload — reason and transient fields present and correct.
+        body.Should().Contain("\"reason\":\"DigestMismatch\"",
+            because: "the failure reason must serialise as a string enum value");
+        body.Should().Contain("\"transient\":false",
+            because: "DigestMismatch is a permanent failure; transient must be false");
+        body.Should().Contain("\"detail\":\"got sha256:bad, expected sha256:good\"",
+            because: "the detail text must reach the wire intact for operator diagnostics");
+
+        // 3. Frame count — 2 events: build-failed + complete.
+        var frameCount = body.Split("\n\n", StringSplitOptions.RemoveEmptyEntries).Length;
+        frameCount.Should().Be(2,
+            because: "two published events → two SSE frames");
+    }
+
+    [Theory]
+    [InlineData(BuildFailureReason.RegistryUnreachable, true)]
+    [InlineData(BuildFailureReason.EngineUnavailable,   true)]
+    [InlineData(BuildFailureReason.PullInterrupted,     true)]
+    [InlineData(BuildFailureReason.ManifestUnknown,     false)]
+    [InlineData(BuildFailureReason.DigestMismatch,      false)]
+    [InlineData(BuildFailureReason.ImagePullFailed,     false)]
+    [InlineData(BuildFailureReason.Unknown,             false)]
+    public async Task BuildEvents_EachFailureReason_SerialiseWithCorrectTransientFlag(
+        BuildFailureReason reason, bool expectedTransient)
+    {
+        var buildId        = Guid.NewGuid();
+        var responseStream = new MemoryStream();
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { Response = { Body = responseStream } },
+        };
+
+        var now = DateTimeOffset.UtcNow;
+        _bus.Publish(buildId, new BuildFailureEvent
+        {
+            Timestamp = now,
+            Reason    = reason,
+            Transient = reason.IsTransient(),
+        });
+        _bus.Publish(buildId, new BuildCompletedEvent
+        {
+            Timestamp = now,
+            Outcome   = BuildOutcome.Failed,
+        });
+
+        await _controller.BuildEvents(buildId, CancellationToken.None);
+
+        responseStream.Position = 0;
+        var body = Encoding.UTF8.GetString(responseStream.ToArray());
+
+        body.Should().Contain("event: build-failed\n",
+            because: $"BuildFailureEvent({reason}) must arrive as 'build-failed' frame");
+        body.Should().Contain($"\"reason\":\"{reason}\"",
+            because: $"reason must be the string enum value '{reason}'");
+        body.Should().Contain($"\"transient\":{expectedTransient.ToString().ToLower()}",
+            because: $"transient for {reason} must be {expectedTransient}");
+    }
+
+    // ------------------------------------------------------------------ //
+    //  BuildCachedEvent → wire type "cached"                              //
+    // ------------------------------------------------------------------ //
+
+    [Fact]
+    public async Task BuildEvents_BuildCachedEvent_EmitsCachedFrame()
+    {
+        var buildId        = Guid.NewGuid();
+        var responseStream = new MemoryStream();
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { Response = { Body = responseStream } },
+        };
+
+        var now = DateTimeOffset.UtcNow;
+        _bus.Publish(buildId, new BuildCachedEvent
+        {
+            Timestamp = now,
+            Digest    = "sha256:abc123",
+        });
+        _bus.Publish(buildId, new BuildCompletedEvent
+        {
+            Timestamp = now,
+            Outcome   = BuildOutcome.Succeeded,
+            Digest    = "sha256:abc123",
+        });
+
+        await _controller.BuildEvents(buildId, CancellationToken.None);
+
+        responseStream.Position = 0;
+        var body = Encoding.UTF8.GetString(responseStream.ToArray());
+
+        // 1. Discriminator — must be "cached".
+        body.Should().Contain("event: cached\n",
+            because: "the BuildCachedEvent wire discriminator must be 'cached' per SM.2.7; " +
+                     "consumers reconcile a cache hit without inferring from silence");
+
+        // 2. JSON payload — digest present.
+        body.Should().Contain("\"digest\":\"sha256:abc123\"",
+            because: "the digest must reach the wire so the consumer can match the artifact");
+
+        // 3. Frame count — 2 events: cached + complete.
+        var frameCount = body.Split("\n\n", StringSplitOptions.RemoveEmptyEntries).Length;
+        frameCount.Should().Be(2,
+            because: "two published events → two SSE frames");
+    }
+
+    [Fact]
+    public async Task BuildEvents_BuildCachedEventWithNullDigest_SerialisesWithoutError()
+    {
+        // Digest may be null when the cache hit was detected before the
+        // digest was resolved.
+        var buildId        = Guid.NewGuid();
+        var responseStream = new MemoryStream();
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { Response = { Body = responseStream } },
+        };
+
+        var now = DateTimeOffset.UtcNow;
+        _bus.Publish(buildId, new BuildCachedEvent { Timestamp = now, Digest = null });
+        _bus.Publish(buildId, new BuildCompletedEvent { Timestamp = now, Outcome = BuildOutcome.Succeeded });
+
+        await _controller.BuildEvents(buildId, CancellationToken.None);
+
+        responseStream.Position = 0;
+        var body = Encoding.UTF8.GetString(responseStream.ToArray());
+
+        body.Should().Contain("event: cached\n",
+            because: "a null digest must not prevent the cached event from being serialised");
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Sequence: cached + complete both appear (non-silent cache hit)     //
+    // ------------------------------------------------------------------ //
+
+    [Fact]
+    public async Task BuildEvents_CacheHitSequence_BothCachedAndCompleteFramesAppear()
+    {
+        // Verifies the full SM.2.7 requirement: a cache hit emits an
+        // explicit .cached SSE event so the consumer does NOT have to
+        // infer "no bytes transferred" from silence.
+        var buildId        = Guid.NewGuid();
+        var responseStream = new MemoryStream();
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { Response = { Body = responseStream } },
+        };
+
+        var now = DateTimeOffset.UtcNow;
+        _bus.Publish(buildId, new BuildCachedEvent
+        {
+            Timestamp = now,
+            Digest    = "sha256:deadbeef",
+        });
+        _bus.Publish(buildId, new BuildCompletedEvent
+        {
+            Timestamp = now,
+            Outcome   = BuildOutcome.Succeeded,
+            Digest    = "sha256:deadbeef",
+        });
+
+        await _controller.BuildEvents(buildId, CancellationToken.None);
+
+        responseStream.Position = 0;
+        var body = Encoding.UTF8.GetString(responseStream.ToArray());
+
+        // Both frames must appear — not just the terminal complete.
+        body.Should().Contain("event: cached\n",
+            because: "the explicit .cached event aligns with Conductor's registrySeedingPullCompleted(alreadyPresent:true)");
+        body.Should().Contain("event: complete\n",
+            because: "the terminal complete event must still fire so consumers with a single terminal handler keep working");
+        body.Should().Contain("\"digest\":\"sha256:deadbeef\"",
+            because: "the digest must appear on the cached event for the consumer to reconcile");
+    }
+}

--- a/tests/Andy.Containers.Tests/Abstractions/Images/BuildFailureTaxonomyTests.cs
+++ b/tests/Andy.Containers.Tests/Abstractions/Images/BuildFailureTaxonomyTests.cs
@@ -1,0 +1,127 @@
+using Andy.Containers.Abstractions.Images;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Tests.Abstractions.Images;
+
+// SM.2.7 (rivoli-ai/conductor#2009).
+// Unit tests for the BuildFailureReason taxonomy and transient/permanent
+// classification. Every branch of BuildFailureReasonExtensions.IsTransient
+// is covered, plus the new BuildFailureEvent and BuildCachedEvent record
+// shapes are exercised as compile-time contracts.
+public class BuildFailureTaxonomyTests
+{
+    // --- IsTransient classification ---
+
+    [Theory]
+    [InlineData(BuildFailureReason.RegistryUnreachable, true,  "transient — retry may succeed")]
+    [InlineData(BuildFailureReason.EngineUnavailable,   true,  "transient — docker daemon may recover")]
+    [InlineData(BuildFailureReason.PullInterrupted,     true,  "transient — network drop, retry makes sense")]
+    [InlineData(BuildFailureReason.ManifestUnknown,     false, "permanent — tag/repo does not exist")]
+    [InlineData(BuildFailureReason.DigestMismatch,      false, "permanent — wrong bytes in registry")]
+    [InlineData(BuildFailureReason.ImagePullFailed,     false, "permanent — policy / verification failure")]
+    [InlineData(BuildFailureReason.Unknown,             false, "permanent — unknown = surface for operator review")]
+    public void IsTransient_ReturnsExpectedClassification(
+        BuildFailureReason reason,
+        bool expectedTransient,
+        string because)
+    {
+        reason.IsTransient().Should().Be(expectedTransient, because);
+    }
+
+    // --- BuildFailureEvent record shape ---
+
+    [Fact]
+    public void BuildFailureEvent_ExposesRequiredProperties()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var evt = new BuildFailureEvent
+        {
+            Timestamp = now,
+            Reason    = BuildFailureReason.DigestMismatch,
+            Transient = false,
+            Detail    = "expected sha256:abc got sha256:def",
+        };
+
+        evt.Timestamp.Should().Be(now);
+        evt.Reason.Should().Be(BuildFailureReason.DigestMismatch);
+        evt.Transient.Should().BeFalse();
+        evt.Detail.Should().Be("expected sha256:abc got sha256:def");
+    }
+
+    [Fact]
+    public void BuildFailureEvent_TransientProperty_MirrorsTaxonomy()
+    {
+        // The Transient field is set by the emitter using IsTransient().
+        // Verify that setting it consistently with the taxonomy is coherent.
+        foreach (BuildFailureReason reason in Enum.GetValues<BuildFailureReason>())
+        {
+            var evt = new BuildFailureEvent
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                Reason    = reason,
+                Transient = reason.IsTransient(),
+                Detail    = null,
+            };
+
+            evt.Transient.Should().Be(reason.IsTransient(),
+                because: $"Transient on the event should mirror IsTransient() for {reason}");
+        }
+    }
+
+    // --- BuildCachedEvent record shape ---
+
+    [Fact]
+    public void BuildCachedEvent_ExposesDigest()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var evt = new BuildCachedEvent
+        {
+            Timestamp = now,
+            Digest    = "sha256:abc123",
+        };
+
+        evt.Timestamp.Should().Be(now);
+        evt.Digest.Should().Be("sha256:abc123");
+    }
+
+    [Fact]
+    public void BuildCachedEvent_AllowsNullDigest()
+    {
+        // Digest may be null when the cache hit was detected before the
+        // digest was resolved.
+        var evt = new BuildCachedEvent
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Digest    = null,
+        };
+
+        evt.Digest.Should().BeNull();
+    }
+
+    // --- BuildProgressEvent polymorphism ---
+
+    [Fact]
+    public void BuildFailureEvent_IsBuildProgressEvent()
+    {
+        BuildProgressEvent evt = new BuildFailureEvent
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Reason    = BuildFailureReason.RegistryUnreachable,
+            Transient = true,
+        };
+
+        evt.Should().BeOfType<BuildFailureEvent>();
+    }
+
+    [Fact]
+    public void BuildCachedEvent_IsBuildProgressEvent()
+    {
+        BuildProgressEvent evt = new BuildCachedEvent
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+        };
+
+        evt.Should().BeOfType<BuildCachedEvent>();
+    }
+}

--- a/tests/Andy.Containers.Tests/Infrastructure/Build/Events/AsyncBuildExecutorSm27Tests.cs
+++ b/tests/Andy.Containers.Tests/Infrastructure/Build/Events/AsyncBuildExecutorSm27Tests.cs
@@ -1,0 +1,219 @@
+using Andy.Containers.Abstractions.Images;
+using Andy.Containers.Infrastructure.Build.Events;
+using Andy.Containers.Storage;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Tests.Infrastructure.Build.Events;
+
+// SM.2.7 (rivoli-ai/conductor#2009). Integration tests for the two new
+// SSE events emitted by AsyncBuildExecutor:
+//
+//   1. BuildCachedEvent — emitted on cache hit so the consumer can
+//      reconcile against "present" without inferring from silence.
+//   2. BuildFailureEvent — emitted before the terminal BuildCompletedEvent
+//      on all failure paths, carrying structured Reason + Transient.
+//
+// These tests use a mock IImageBuildOrchestrator + real InMemoryBuildEventBus
+// + real InMemoryBuildExecutionRegistry — the same pattern used by
+// AsyncBuildExecutorTests.
+public class AsyncBuildExecutorSm27Tests
+{
+    // ------------------------------------------------------------------ //
+    //  Cache-hit → BuildCachedEvent + BuildCompletedEvent                 //
+    // ------------------------------------------------------------------ //
+
+    [Fact]
+    public async Task StartAsync_CacheHit_EmitsCachedEventBeforeComplete()
+    {
+        // SM.2.7 AC2: a cache hit emits an explicit .cached SSE event.
+        var digest  = "sha256:cached-abc";
+        var hitResult = new BuildResult
+        {
+            BuildId    = Guid.NewGuid(),
+            Status     = BuildResultStatus.Cached,
+            Digest     = digest,
+            References = [],
+        };
+        var orchestrator = new Mock<IImageBuildOrchestrator>();
+        orchestrator.Setup(o => o.TryCacheHitAsync(
+                It.IsAny<ImageBuildRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(hitResult);
+
+        var (executor, _, bus) = MakeExecutor(orchestrator.Object);
+
+        var handle = await executor.StartAsync(
+            new ImageBuildRequest(Guid.NewGuid(), null, false, "user"),
+            CancellationToken.None);
+
+        handle.Status.Should().Be(AsyncBuildHandleStatus.Cached);
+
+        // Drain the bus for the cache-hit buildId (not handle.BuildId —
+        // the executor uses hitResult.BuildId for the bus events).
+        var events = await DrainAsync(bus, hitResult.BuildId, TimeSpan.FromSeconds(2));
+
+        // The cached event must be present.
+        var cachedEvent = events.OfType<BuildCachedEvent>().FirstOrDefault();
+        cachedEvent.Should().NotBeNull(
+            because: "AC2 requires a non-silent .cached SSE event on a cache hit");
+        cachedEvent!.Digest.Should().Be(digest,
+            because: "the cached event must carry the artifact digest for consumer reconciliation");
+
+        // The terminal complete event must also fire.
+        var completedEvent = events.OfType<BuildCompletedEvent>().FirstOrDefault();
+        completedEvent.Should().NotBeNull(
+            because: "the terminal complete event must still fire so consumers with a single handler keep working");
+        completedEvent!.Outcome.Should().Be(BuildOutcome.Succeeded);
+        completedEvent.Digest.Should().Be(digest);
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Build failure → BuildFailureEvent (structured) + BuildCompletedEvent
+    // ------------------------------------------------------------------ //
+
+    [Theory]
+    [InlineData("ensure_pull_docker_launch_failed.Pull", BuildFailureReason.EngineUnavailable, true)]
+    [InlineData("registry.unreachable",                  BuildFailureReason.RegistryUnreachable, true)]
+    [InlineData("manifest_unknown",                      BuildFailureReason.ManifestUnknown, false)]
+    [InlineData("digest_mismatch",                       BuildFailureReason.DigestMismatch, false)]
+    [InlineData("unknown_new_code",                      BuildFailureReason.Unknown, false)]
+    public async Task StartAsync_BuildFails_EmitsStructuredFailureEvent(
+        string errorCode,
+        BuildFailureReason expectedReason,
+        bool expectedTransient)
+    {
+        // SM.2.7 AC1: the SSE emits a structured BuildFailureEvent,
+        // not just a free-text buildLog line.
+        var orchestrator = new Mock<IImageBuildOrchestrator>();
+        orchestrator.Setup(o => o.TryCacheHitAsync(
+                It.IsAny<ImageBuildRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BuildResult?)null);
+        orchestrator.Setup(o => o.BuildAsync(
+                It.IsAny<ImageBuildRequest>(),
+                It.IsAny<IProgress<BuildProgressEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BuildResult
+            {
+                BuildId      = Guid.NewGuid(),
+                Status       = BuildResultStatus.Failed,
+                ErrorCode    = errorCode,
+                ErrorMessage = $"simulated failure: {errorCode}",
+            });
+
+        var (executor, _, bus) = MakeExecutor(orchestrator.Object);
+
+        var handle = await executor.StartAsync(
+            new ImageBuildRequest(Guid.NewGuid(), null, false, "user"),
+            CancellationToken.None);
+
+        var events = await DrainAsync(bus, handle.BuildId, TimeSpan.FromSeconds(3));
+
+        // A structured BuildFailureEvent must be present.
+        var failureEvent = events.OfType<BuildFailureEvent>().FirstOrDefault();
+        failureEvent.Should().NotBeNull(
+            because: $"AC1 requires a structured BuildFailureEvent for error code '{errorCode}'");
+        failureEvent!.Reason.Should().Be(expectedReason,
+            because: $"'{errorCode}' must map to {expectedReason}");
+        failureEvent.Transient.Should().Be(expectedTransient,
+            because: $"{expectedReason} must be classified {(expectedTransient ? "transient" : "permanent")}");
+
+        // The failure event must appear BEFORE the terminal complete.
+        var failureIndex   = events.IndexOf(failureEvent);
+        var completedEvent = events.OfType<BuildCompletedEvent>().FirstOrDefault();
+        completedEvent.Should().NotBeNull(
+            because: "the terminal complete event must still fire after the failure event");
+        var completedIndex = events.IndexOf(completedEvent!);
+        failureIndex.Should().BeLessThan(completedIndex,
+            because: "the structured failure event must precede the terminal complete event in the stream");
+    }
+
+    [Fact]
+    public async Task StartAsync_OrchestratorThrows_EmitsUnknownPermanentFailureEvent()
+    {
+        // Unexpected exceptions (not BuildResult.Failed) also produce a
+        // BuildFailureEvent so the consumer sees a structured signal.
+        var orchestrator = new Mock<IImageBuildOrchestrator>();
+        orchestrator.Setup(o => o.TryCacheHitAsync(
+                It.IsAny<ImageBuildRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BuildResult?)null);
+        orchestrator.Setup(o => o.BuildAsync(
+                It.IsAny<ImageBuildRequest>(),
+                It.IsAny<IProgress<BuildProgressEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("unexpected crash"));
+
+        var (executor, _, bus) = MakeExecutor(orchestrator.Object);
+
+        var handle = await executor.StartAsync(
+            new ImageBuildRequest(Guid.NewGuid(), null, false, "user"),
+            CancellationToken.None);
+
+        var events = await DrainAsync(bus, handle.BuildId, TimeSpan.FromSeconds(3));
+
+        var failureEvent = events.OfType<BuildFailureEvent>().FirstOrDefault();
+        failureEvent.Should().NotBeNull(
+            because: "unexpected exceptions must also produce a structured BuildFailureEvent");
+        failureEvent!.Reason.Should().Be(BuildFailureReason.Unknown);
+        failureEvent.Transient.Should().BeFalse(
+            because: "Unknown failures are classified permanent to surface to the operator");
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Helpers                                                             //
+    // ------------------------------------------------------------------ //
+
+    private static (AsyncBuildExecutor, InMemoryBuildExecutionRegistry, InMemoryBuildEventBus) MakeExecutor(
+        IImageBuildOrchestrator orchestrator)
+    {
+        var bus      = new InMemoryBuildEventBus();
+        var registry = new InMemoryBuildExecutionRegistry();
+
+        var services = new ServiceCollection();
+        services.AddSingleton(orchestrator);
+        var rootProvider = services.BuildServiceProvider();
+        var scopeFactory = rootProvider.GetRequiredService<IServiceScopeFactory>();
+        var lifetime     = new ApplicationLifetime(NullLogger<ApplicationLifetime>.Instance);
+
+        var executor = new AsyncBuildExecutor(
+            scopeFactory,
+            bus,
+            registry,
+            lifetime,
+            NullLogger<AsyncBuildExecutor>.Instance);
+        return (executor, registry, bus);
+    }
+
+    /// <summary>
+    /// Drain all events up to and including the terminal
+    /// <see cref="BuildCompletedEvent"/>, or until <paramref name="timeout"/>.
+    /// </summary>
+    private static async Task<List<BuildProgressEvent>> DrainAsync(
+        IBuildEventBus bus,
+        Guid buildId,
+        TimeSpan timeout)
+    {
+        var events = new List<BuildProgressEvent>();
+        using var cts = new CancellationTokenSource(timeout);
+        try
+        {
+            await foreach (var envelope in bus.SubscribeAsync(buildId, null, cts.Token))
+            {
+                events.Add(envelope.Event);
+                if (envelope.Event is BuildCompletedEvent)
+                {
+                    break;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Timeout — return what we have so the caller can assert on it.
+        }
+        return events;
+    }
+}

--- a/tests/Andy.Containers.Tests/Infrastructure/Build/Events/BuildFailureClassifierTests.cs
+++ b/tests/Andy.Containers.Tests/Infrastructure/Build/Events/BuildFailureClassifierTests.cs
@@ -1,0 +1,119 @@
+using Andy.Containers.Abstractions.Images;
+using Andy.Containers.Infrastructure.Build.Events;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Tests.Infrastructure.Build.Events;
+
+// SM.2.7 (rivoli-ai/conductor#2009). Unit tests for
+// AsyncBuildExecutor.ClassifyFailure — the internal mapper that
+// translates orchestrator error codes to a (BuildFailureReason, transient)
+// pair. Every branch (engine launch, registry unreachable, manifest
+// unknown, digest mismatch, pull failed, unknown) must be covered so
+// regressions in the taxonomy are caught immediately rather than
+// surfacing as silent all-retry loops in Conductor.
+public class BuildFailureClassifierTests
+{
+    // ---- Transient branches ----
+
+    [Theory]
+    [InlineData("ensure_pull_docker_launch_failed.Pull")]
+    [InlineData("ensure_pull_docker_launch_failed.Tag")]
+    [InlineData("ensure_pull_docker_launch_failed.Push")]
+    [InlineData("ENSURE_PULL_DOCKER_LAUNCH_FAILED.pull")]  // case-insensitive
+    public void ClassifyFailure_DockerLaunchFailure_ReturnsEngineUnavailableTransient(string code)
+    {
+        var (reason, transient) = AsyncBuildExecutor.ClassifyFailure(code);
+
+        reason.Should().Be(BuildFailureReason.EngineUnavailable,
+            because: "docker launch failures indicate the engine is unavailable, not a permanent image problem");
+        transient.Should().BeTrue(
+            because: "a daemon that failed to start may recover; the consumer should retry");
+    }
+
+    [Fact]
+    public void ClassifyFailure_EngineUnavailableCode_ReturnsEngineUnavailableTransient()
+    {
+        var (reason, transient) = AsyncBuildExecutor.ClassifyFailure("engine_unavailable");
+
+        reason.Should().Be(BuildFailureReason.EngineUnavailable);
+        transient.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("registry.unreachable")]
+    [InlineData("registry.unreachable.dns")]
+    [InlineData("ensure_pull_docker_nonzero_exit_1.Pull")]
+    [InlineData("ensure_pull_docker_nonzero_exit_28.Push")]  // 28 = curl timeout
+    public void ClassifyFailure_RegistryConnectivity_ReturnsRegistryUnreachableTransient(string code)
+    {
+        var (reason, transient) = AsyncBuildExecutor.ClassifyFailure(code);
+
+        reason.Should().Be(BuildFailureReason.RegistryUnreachable,
+            because: "nonzero-exit docker calls are most often connectivity failures");
+        transient.Should().BeTrue(
+            because: "the registry may recover; Conductor should retry after back-off");
+    }
+
+    // ---- Permanent branches ----
+
+    [Theory]
+    [InlineData("registry.manifest_unknown")]
+    [InlineData("manifest_unknown")]
+    [InlineData("image.not-found")]
+    public void ClassifyFailure_ManifestUnknown_ReturnsPermanent(string code)
+    {
+        var (reason, transient) = AsyncBuildExecutor.ClassifyFailure(code);
+
+        reason.Should().Be(BuildFailureReason.ManifestUnknown,
+            because: "the tag/repo does not exist; retrying will get the same 404");
+        transient.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("registry.digest_mismatch")]
+    [InlineData("digest_mismatch")]
+    public void ClassifyFailure_DigestMismatch_ReturnsPermanent(string code)
+    {
+        var (reason, transient) = AsyncBuildExecutor.ClassifyFailure(code);
+
+        reason.Should().Be(BuildFailureReason.DigestMismatch,
+            because: "the registry image differs from the expected digest; retry will pull the same wrong bytes");
+        transient.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("ensure_pull_push_succeeded_but_lookup_failed")]
+    [InlineData("image_pull_failed")]
+    public void ClassifyFailure_ImagePullFailed_ReturnsPermanent(string code)
+    {
+        var (reason, transient) = AsyncBuildExecutor.ClassifyFailure(code);
+
+        reason.Should().Be(BuildFailureReason.ImagePullFailed);
+        transient.Should().BeFalse();
+    }
+
+    // ---- Fallback / edge cases ----
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ClassifyFailure_NullOrEmpty_ReturnsUnknownPermanent(string? code)
+    {
+        var (reason, transient) = AsyncBuildExecutor.ClassifyFailure(code);
+
+        reason.Should().Be(BuildFailureReason.Unknown,
+            because: "absent codes cannot be classified; surface for operator review");
+        transient.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ClassifyFailure_UnrecognisedCode_ReturnsUnknownPermanent()
+    {
+        var (reason, transient) = AsyncBuildExecutor.ClassifyFailure("some_future_error_code");
+
+        reason.Should().Be(BuildFailureReason.Unknown);
+        transient.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `BuildFailureEvent` to the build/pull SSE stream carrying a stable `BuildFailureReason` enum (`registryUnreachable`, `engineUnavailable`, `pullInterrupted`, `manifestUnknown`, `digestMismatch`, `imagePullFailed`, `unknown`), a `Transient` bool, and a `Detail` string — replacing free-text `buildLog` failure signalling.
- Adds `BuildCachedEvent` (wire: `cached`) emitted on every cache hit so consumers reconcile against `alreadyPresent` semantics without inferring from silence. Aligns with Conductor's `registrySeedingPullCompleted(alreadyPresent: true)`.
- `AsyncBuildExecutor.ClassifyFailure()` maps orchestrator error codes to the taxonomy. Both `BuildCachedEvent`+`BuildCompletedEvent` fire on cache hits; `BuildFailureEvent`+`BuildCompletedEvent` fire on failures. Existing consumers with a single terminal-event handler keep working unchanged.
- This is the PREREQ that keeps Image Pull a DTO consumed by `ContainerLifecycle` rather than its own state machine (adoption-spec §3).

## Changes

| File | What |
|------|------|
| `src/Andy.Containers/Abstractions/Images/BuildProgressEvent.cs` | `BuildFailureEvent`, `BuildCachedEvent`, `BuildFailureReason` enum, `BuildFailureReasonExtensions.IsTransient()` |
| `src/Andy.Containers.Infrastructure/Build/Events/AsyncBuildExecutor.cs` | Emit `BuildCachedEvent` on cache hit; `ClassifyFailure()` + `BuildFailureEvent` on every failure path |
| `src/Andy.Containers.Api/Controllers/ImagesController.cs` | `WriteSseAsync` maps new event types to `build-failed`/`cached` wire discriminators |
| `docs/architecture/image-management.md` | BuildEvent failure taxonomy section (reason table, transient/permanent, example frames) |

## Test evidence

51 new tests, all passing. Pre-existing failures are 3 unrelated tests (`StubAndyAgentsClientTests` fixture files + Postgres connection) with no Postgres available in CI.

```
Andy.Containers.Tests        — Passed: 546 (+ 40 new)
Andy.Containers.Api.Tests    — Passed: 1266 (+ 11 new)
Andy.Containers.Integration.Tests — Passed: 59
Andy.Containers.Client.Tests — Passed: 31
```

New test classes:
- `BuildFailureTaxonomyTests` — `IsTransient()` for every reason, event record shapes, polymorphism
- `BuildFailureClassifierTests` — `ClassifyFailure()` for every error-code branch + null/empty edge cases
- `AsyncBuildExecutorSm27Tests` — executor emits `BuildCachedEvent` with correct digest; `BuildFailureEvent` precedes `complete` for each failure reason; unexpected exceptions → Unknown/permanent
- `ImagesControllerSseSm27Tests` — SSE wire format for all 7 failure reasons (correct transient flag) + cached event (with/without digest, full sequence)

## Doc impact

- `docs/architecture/image-management.md` updated (andy-containers, this PR)
- `docs/api-contracts/andy-containers.md` updated in conductor repo (companion conductor PR)

Addresses rivoli-ai/conductor#2009

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>