### PR TITLE
[SM.2.6] Provisioning-abort signal + 503/404/401 status classification

### DIFF
--- a/src/Andy.Containers.Api/Controllers/ContainersController.cs
+++ b/src/Andy.Containers.Api/Controllers/ContainersController.cs
@@ -2,6 +2,7 @@ using Andy.Containers.Abstractions;
 using Andy.Containers.Api.Services;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Models;
+using Andy.Containers.Storage;
 using Andy.Rbac.Authorization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -23,6 +24,7 @@ public class ContainersController : ControllerBase
     private readonly IOrganizationMembershipService _orgMembership;
     private readonly IGitDiffService _gitDiffService;
     private readonly IPortDiscoveryService _portDiscoveryService;
+    private readonly IContainerLifecycleBus _lifecycleBus;
 
     public ContainersController(
         IContainerService containerService,
@@ -33,7 +35,8 @@ public class ContainersController : ControllerBase
         IGitRepositoryProbeService probeService,
         IOrganizationMembershipService orgMembership,
         IGitDiffService gitDiffService,
-        IPortDiscoveryService portDiscoveryService)
+        IPortDiscoveryService portDiscoveryService,
+        IContainerLifecycleBus lifecycleBus)
     {
         _containerService = containerService;
         _currentUser = currentUser;
@@ -44,6 +47,7 @@ public class ContainersController : ControllerBase
         _orgMembership = orgMembership;
         _gitDiffService = gitDiffService;
         _portDiscoveryService = portDiscoveryService;
+        _lifecycleBus = lifecycleBus;
     }
 
     [HttpGet]
@@ -105,6 +109,50 @@ public class ContainersController : ControllerBase
         return Ok(new { items = containers, totalCount });
     }
 
+    /// <summary>
+    /// SM.2.6 (rivoli-ai/conductor#2008). Fleet-wide container lifecycle
+    /// phase SSE stream. Emits one <c>event: lifecycle</c> frame per
+    /// container state transition (pending → creating → running → … →
+    /// failed / exited / destroyed). Heartbeat comment frames every 15 s.
+    /// The stream stays open until the client disconnects.
+    /// </summary>
+    /// <remarks>
+    /// Wire format (docs/api-contracts/andy-containers.md §lifecycle):
+    /// <code>
+    /// id: &lt;sequence&gt;
+    /// event: lifecycle
+    /// data: {"containerId":"...","phase":"running","phaseData":{},"correlationId":"...","timestamp":"..."}
+    /// </code>
+    /// Resume via <c>Last-Event-ID</c>; the bus replays buffered events
+    /// from after the supplied id. On buffer miss (id too old) replay
+    /// restarts from the oldest buffered event.
+    /// RBAC: <c>container:read</c>. The bus delivers ALL containers; the
+    /// client filters to the containers it owns.
+    /// </remarks>
+    [HttpGet("events")]
+    [RequirePermission("container:read")]
+    public Task Events(CancellationToken ct)
+        => ContainerLifecycleSse.StreamAsync(Response, Request, _lifecycleBus, ct);
+
+    /// <summary>
+    /// SM.2.6 (rivoli-ai/conductor#2008). Classified GET — returns:
+    /// <list type="bullet">
+    ///   <item><c>200 OK</c> — container found and accessible.</item>
+    ///   <item><c>404 Not Found</c> — container confirmed deleted or never
+    ///     existed (SUSTAINED; caller SHOULD NOT retry without user action).
+    ///     Body: <c>{ code, message, correlationId }</c>.</item>
+    ///   <item><c>503 Service Unavailable</c> — infrastructure provider
+    ///     transiently unreachable; row exists but runtime state unknown
+    ///     (TRANSIENT; caller SHOULD retry after <c>Retry-After</c>
+    ///     seconds). Body: <c>{ code, message, correlationId }</c>.</item>
+    ///   <item><c>401 Unauthorized</c> — missing / invalid bearer token
+    ///     (standard HTTP auth, handled by middleware before reaching this
+    ///     action, but documented for Conductor's §7.2 classifier).</item>
+    /// </list>
+    /// The <c>X-Correlation-Id</c> response header mirrors
+    /// <c>correlationId</c> in the body so log aggregators can correlate
+    /// without parsing JSON.
+    /// </summary>
     [HttpGet("{id:guid}")]
     [RequirePermission("container:read")]
     public async Task<IActionResult> Get(Guid id, CancellationToken ct)
@@ -114,11 +162,38 @@ public class ContainersController : ControllerBase
             var container = await _containerService.GetContainerAsync(id, ct);
             if (!CanAccess(container))
                 return Forbid();
+
+            // SM.2.6: attach correlation id header to every 200 response so
+            // the Conductor §7.2 helper can correlate status responses with
+            // concurrent lifecycle SSE events.
+            var correlationId = container.StoryId ?? container.Id;
+            Response.Headers["X-Correlation-Id"] = correlationId.ToString();
             return Ok(container);
         }
         catch (KeyNotFoundException)
         {
-            return NotFound();
+            // Confirmed deletion — sustained 404.
+            var correlationId = id; // no container row to derive StoryId from
+            Response.Headers["X-Correlation-Id"] = correlationId.ToString();
+            return NotFound(new
+            {
+                code = ContainerNotFoundException.ErrorCode,
+                message = $"Container {id} not found.",
+                correlationId,
+            });
+        }
+        catch (ContainerRuntimeUnavailableException ex)
+        {
+            // Transient provider/proxy failure — 503 with Retry-After.
+            Response.Headers["X-Correlation-Id"] = ex.CorrelationId.ToString();
+            Response.Headers["Retry-After"] = ex.RetryAfterSeconds.ToString();
+            return StatusCode(503, new
+            {
+                code = ContainerRuntimeUnavailableException.ErrorCode,
+                message = ex.Message,
+                correlationId = ex.CorrelationId,
+                retryAfterSeconds = ex.RetryAfterSeconds,
+            });
         }
     }
 

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -218,6 +218,13 @@ try
     // (subscribers), which live in different request scopes.
     builder.Services.AddSingleton<Andy.Containers.Storage.IRunOutputBus, Andy.Containers.Infrastructure.Runs.Events.InMemoryRunOutputBus>();
 
+    // SM.2.6 (rivoli-ai/conductor#2008). Fleet-wide lifecycle phase bus.
+    // Singleton — the provisioning worker and orchestration service publish
+    // one event per phase change; GET /api/containers/events subscribes and
+    // streams them to Conductor's SM.4 ContainerLifecycle machine.
+    builder.Services.AddSingleton<Andy.Containers.Storage.IContainerLifecycleBus,
+        Andy.Containers.Infrastructure.Runs.Events.InMemoryContainerLifecycleBus>();
+
     // Current user service for RBAC
     builder.Services.AddHttpContextAccessor();
     builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();

--- a/src/Andy.Containers.Api/Services/ContainerLifecycleSse.cs
+++ b/src/Andy.Containers.Api/Services/ContainerLifecycleSse.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Andy.Containers.Storage;
+using Microsoft.AspNetCore.Http;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// SM.2.6 (rivoli-ai/conductor#2008). Shared SSE serialiser for the
+/// fleet-wide container lifecycle phase stream. Used by
+/// <c>GET /api/containers/events</c> (ContainersController.Events).
+/// </summary>
+/// <remarks>
+/// Wire format per docs/api-contracts/andy-containers.md §lifecycle:
+/// <code>
+/// id: &lt;sequence&gt;
+/// event: lifecycle
+/// data: {"containerId":"...","phase":"running","phaseData":{},"correlationId":"...","timestamp":"..."}
+/// </code>
+/// terminated by a blank line. Heartbeats are <c>: heartbeat\n\n</c>
+/// (SSE comment frame) every <see cref="HeartbeatInterval"/>. The
+/// stream stays open until the client disconnects (<paramref name="ct"/>
+/// fires).
+/// </remarks>
+public static class ContainerLifecycleSse
+{
+    /// <summary>Heartbeat cadence. Keeps idle connections alive through
+    /// load-balancer idle timeouts.</summary>
+    public static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(15);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public static async Task StreamAsync(
+        HttpResponse response,
+        HttpRequest request,
+        IContainerLifecycleBus bus,
+        CancellationToken ct)
+    {
+        response.Headers.ContentType = "text/event-stream";
+        response.Headers.CacheControl = "no-store";
+        response.Headers["X-Accel-Buffering"] = "no";
+
+        // Honour Last-Event-ID for reconnection resumption.
+        long? lastEventId = null;
+        if (request.Headers.TryGetValue("Last-Event-ID", out var headerValue) &&
+            long.TryParse(headerValue.ToString(), out var parsed))
+        {
+            lastEventId = parsed;
+        }
+
+        // Merge the event stream with a recurring heartbeat timer.
+        using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var eventTask = PumpEventsAsync(response, bus, lastEventId, ct);
+        var heartbeatTask = PumpHeartbeatsAsync(response, heartbeatCts.Token);
+
+        await Task.WhenAny(eventTask, heartbeatTask);
+        await heartbeatCts.CancelAsync();
+        // Propagate any exception from the event pump (heartbeat failures
+        // are best-effort and silently ignored).
+        await eventTask;
+    }
+
+    private static async Task PumpEventsAsync(
+        HttpResponse response,
+        IContainerLifecycleBus bus,
+        long? lastEventId,
+        CancellationToken ct)
+    {
+        await foreach (var envelope in bus.SubscribeAsync(lastEventId, ct))
+        {
+            await WriteEventFrameAsync(response, envelope, ct);
+        }
+    }
+
+    private static async Task PumpHeartbeatsAsync(
+        HttpResponse response,
+        CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(HeartbeatInterval, ct);
+                await response.WriteAsync(": heartbeat\n\n", ct);
+                await response.Body.FlushAsync(ct);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception) { /* best-effort */ }
+    }
+
+    private static async Task WriteEventFrameAsync(
+        HttpResponse response,
+        ContainerLifecycleEnvelope envelope,
+        CancellationToken ct)
+    {
+        var wire = new LifecycleEventWire(
+            envelope.Event.ContainerId,
+            envelope.Event.Phase,
+            new PhaseDataWire(
+                envelope.Event.PhaseData.ExitCode,
+                envelope.Event.PhaseData.Reason),
+            envelope.Event.CorrelationId,
+            envelope.Event.Timestamp);
+
+        var json = JsonSerializer.Serialize(wire, JsonOptions);
+        var frame =
+            $"id: {envelope.SequenceNumber}\n" +
+            "event: lifecycle\n" +
+            $"data: {json}\n\n";
+        await response.WriteAsync(frame, ct);
+        await response.Body.FlushAsync(ct);
+    }
+
+    // ---------------------------------------------------------------
+    // Wire shapes
+    // ---------------------------------------------------------------
+
+    /// <summary>
+    /// Wire payload for <c>event: lifecycle</c>. The
+    /// <c>phaseData</c> object contains only non-null fields (see
+    /// <see cref="JsonOptions"/>).
+    /// </summary>
+    private sealed record LifecycleEventWire(
+        Guid ContainerId,
+        string Phase,
+        PhaseDataWire PhaseData,
+        Guid CorrelationId,
+        DateTimeOffset Timestamp);
+
+    private sealed record PhaseDataWire(
+        int? ExitCode,
+        string? Reason);
+}

--- a/src/Andy.Containers.Api/Services/ContainerProvisioningWorker.cs
+++ b/src/Andy.Containers.Api/Services/ContainerProvisioningWorker.cs
@@ -5,6 +5,7 @@ using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Infrastructure.Messaging;
 using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
+using Andy.Containers.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -16,19 +17,22 @@ public class ContainerProvisioningWorker : BackgroundService
     private readonly ContainerProvisioningQueue _queue;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IInfrastructureProviderFactory _providerFactory;
+    private readonly IContainerLifecycleBus _lifecycleBus;
     private readonly ILogger<ContainerProvisioningWorker> _logger;
 
-    private static readonly TimeSpan ProvisionTimeout = TimeSpan.FromMinutes(5);
+    internal static readonly TimeSpan ProvisionTimeout = TimeSpan.FromMinutes(5);
 
     public ContainerProvisioningWorker(
         ContainerProvisioningQueue queue,
         IServiceScopeFactory scopeFactory,
         IInfrastructureProviderFactory providerFactory,
+        IContainerLifecycleBus lifecycleBus,
         ILogger<ContainerProvisioningWorker> logger)
     {
         _queue = queue;
         _scopeFactory = scopeFactory;
         _providerFactory = providerFactory;
+        _lifecycleBus = lifecycleBus;
         _logger = logger;
     }
 
@@ -84,9 +88,10 @@ public class ContainerProvisioningWorker : BackgroundService
             return;
         }
 
-        // Set status to Creating
+        // Set status to Creating and emit the "creating" lifecycle phase.
         container.Status = ContainerStatus.Creating;
         await db.SaveChangesAsync(stoppingToken);
+        PublishPhase(container, "creating", new ContainerLifecyclePhaseData());
 
         try
         {
@@ -336,6 +341,10 @@ public class ContainerProvisioningWorker : BackgroundService
             });
             await db.SaveChangesAsync(stoppingToken);
 
+            // SM.2.6: emit the "running" lifecycle phase now that the
+            // container is fully provisioned and ready to accept connections.
+            PublishPhase(container, "running", new ContainerLifecyclePhaseData());
+
             sw.Stop();
             Meters.ProvisioningDuration.Record(sw.Elapsed.TotalMilliseconds);
             _logger.LogInformation("Container {ContainerId} fully provisioned on {Provider}",
@@ -343,23 +352,84 @@ public class ContainerProvisioningWorker : BackgroundService
         }
         catch (OperationCanceledException) when (!stoppingToken.IsCancellationRequested)
         {
+            // SM.2.6: explicit provisioning-abort — timeout during runtime
+            // acquisition. Distinct from a stoppingToken cancel (service
+            // shutdown) so the client knows to surface a retryable message.
             _logger.LogError("Provisioning timed out for container {ContainerId} on {Provider}",
                 job.ContainerId, job.ProviderCode);
             Meters.ProvisioningErrors.Add(1);
             activity?.SetStatus(ActivityStatusCode.Error, "Provisioning timed out after 5 minutes");
-            await MarkFailedAsync(db, job.ContainerId, "Provisioning timed out after 5 minutes");
+            await MarkFailedAsync(db, job.ContainerId, ProvisioningAbortReason.Timeout,
+                "Provisioning timed out after 5 minutes");
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // SM.2.6: service is shutting down — abort with "cancelled"
+            // so the SM.0.4 helper doesn't classify this as a hard failure.
+            _logger.LogWarning("Provisioning cancelled (service shutdown) for container {ContainerId}",
+                job.ContainerId);
+            await MarkFailedAsync(db, job.ContainerId, ProvisioningAbortReason.Cancelled,
+                "Service shutdown during provisioning");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to provision container {ContainerId} on provider {Provider}",
-                job.ContainerId, job.ProviderCode);
+            // SM.2.6: classify the abort reason from the exception type so
+            // Conductor's SM.4 machine can render an actionable message.
+            var reason = ClassifyAbortReason(ex);
+            _logger.LogError(ex, "Failed to provision container {ContainerId} on provider {Provider} (reason={Reason})",
+                job.ContainerId, job.ProviderCode, reason.ToWireString());
             Meters.ProvisioningErrors.Add(1);
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-            await MarkFailedAsync(db, job.ContainerId, ex.Message);
+            await MarkFailedAsync(db, job.ContainerId, reason, ex.Message);
         }
     }
 
-    private static async Task MarkFailedAsync(ContainersDbContext db, Guid containerId, string errorMessage)
+    /// <summary>
+    /// SM.2.6. Maps exception types to provisioning-abort reason codes.
+    /// Callers receive a typed enum so the abort event's <c>reason</c>
+    /// field carries the canonical wire string.
+    /// </summary>
+    internal static ProvisioningAbortReason ClassifyAbortReason(Exception ex)
+    {
+        // Docker/containerd "not found" manifest responses surface as
+        // various exception types depending on the client library; we
+        // heuristically match on the message text because the underlying
+        // image-not-found path doesn't currently throw a typed exception.
+        if (ex is InvalidOperationException &&
+            (ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase) ||
+             ex.Message.Contains("manifest unknown", StringComparison.OrdinalIgnoreCase) ||
+             ex.Message.Contains("image", StringComparison.OrdinalIgnoreCase)))
+        {
+            return ProvisioningAbortReason.ImageNotFound;
+        }
+
+        // QuotaExceededException — the quota check fires in
+        // CreateContainerAsync before the job reaches this worker, so
+        // this branch is mostly a belt-and-suspenders guard, but included
+        // for completeness.
+        if (ex is QuotaExceededException)
+        {
+            return ProvisioningAbortReason.QuotaDenied;
+        }
+
+        // Provider / engine unreachable (connection refused, timeout from
+        // the Docker daemon, Apple Containers not running, etc.).
+        if (ex is HttpRequestException ||
+            ex is TimeoutException ||
+            (ex.Message.Contains("connect", StringComparison.OrdinalIgnoreCase) &&
+             ex.Message.Contains("refused", StringComparison.OrdinalIgnoreCase)))
+        {
+            return ProvisioningAbortReason.EngineUnavailable;
+        }
+
+        return ProvisioningAbortReason.Unknown;
+    }
+
+    private async Task MarkFailedAsync(
+        ContainersDbContext db,
+        Guid containerId,
+        ProvisioningAbortReason reason,
+        string detail)
     {
         try
         {
@@ -371,17 +441,59 @@ public class ContainerProvisioningWorker : BackgroundService
                 {
                     ContainerId = containerId,
                     EventType = ContainerEventType.Failed,
-                    Details = System.Text.Json.JsonSerializer.Serialize(new { error = errorMessage })
+                    Details = System.Text.Json.JsonSerializer.Serialize(new
+                    {
+                        error = detail,
+                        reason = reason.ToWireString()
+                    })
                 });
                 // Emit andy.containers.events.run.<id>.failed — provisioning failure.
                 db.AppendRunEvent(container, RunEventKind.Failed, exitCode: null, durationSeconds: null);
+
+                // SM.2.6: emit the discrete containerProvisioningAborted outbox
+                // event. This lets downstream services (andy-tasks, andy-issues)
+                // react without subscribing to the SSE stream.
+                var correlationId = container.StoryId ?? container.Id;
+                db.AppendProvisioningAbortedEvent(container, reason, detail, correlationId);
+
                 await db.SaveChangesAsync();
+
+                // SM.2.6: emit the lifecycle phase=failed SSE event with the
+                // reason so SM.4 can transition the ContainerLifecycle machine
+                // to a recoverable "provisioning failed — retry" state.
+                PublishPhase(container, "failed",
+                    new ContainerLifecyclePhaseData(Reason: reason.ToWireString()));
             }
         }
         catch (Exception ex)
         {
             // Last resort — can't even save the failure. The recovery logic will catch this on next startup.
             System.Diagnostics.Debug.WriteLine($"Failed to save failure status for container {containerId}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Publishes one lifecycle phase transition to the in-process
+    /// <see cref="IContainerLifecycleBus"/>. Non-throwing: a publish
+    /// failure never propagates back to the provisioning flow.
+    /// </summary>
+    private void PublishPhase(Container container, string phase, ContainerLifecyclePhaseData phaseData)
+    {
+        try
+        {
+            var correlationId = container.StoryId ?? container.Id;
+            _lifecycleBus.Publish(new ContainerLifecycleEvent(
+                ContainerId: container.Id,
+                Phase: phase,
+                PhaseData: phaseData,
+                CorrelationId: correlationId,
+                Timestamp: DateTimeOffset.UtcNow));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to publish lifecycle phase '{Phase}' for container {ContainerId}",
+                phase, container.Id);
         }
     }
 
@@ -401,14 +513,27 @@ public class ContainerProvisioningWorker : BackgroundService
             {
                 _logger.LogWarning("Recovering stuck container {ContainerId} (status={Status}, created={CreatedAt})",
                     container.Id, container.Status, container.CreatedAt);
+                const string recoveryDetail = "Recovered from stuck state on worker restart";
                 container.Status = ContainerStatus.Failed;
                 db.Events.Add(new ContainerEvent
                 {
                     ContainerId = container.Id,
                     EventType = ContainerEventType.Failed,
-                    Details = System.Text.Json.JsonSerializer.Serialize(new { error = "Recovered from stuck state on worker restart" })
+                    Details = System.Text.Json.JsonSerializer.Serialize(new
+                    {
+                        error = recoveryDetail,
+                        reason = ProvisioningAbortReason.Unknown.ToWireString()
+                    })
                 });
                 db.AppendRunEvent(container, RunEventKind.Failed, exitCode: null, durationSeconds: null);
+                // SM.2.6: emit provisioning-aborted outbox event so downstream
+                // consumers can act on the recovery.
+                var correlationId = container.StoryId ?? container.Id;
+                db.AppendProvisioningAbortedEvent(container, ProvisioningAbortReason.Unknown,
+                    recoveryDetail, correlationId);
+                // SM.2.6: emit lifecycle phase so SSE subscribers see the abort.
+                PublishPhase(container, "failed",
+                    new ContainerLifecyclePhaseData(Reason: ProvisioningAbortReason.Unknown.ToWireString()));
             }
 
             if (stuckContainers.Count > 0)

--- a/src/Andy.Containers.Api/Services/ContainerStatusException.cs
+++ b/src/Andy.Containers.Api/Services/ContainerStatusException.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// SM.2.6 (rivoli-ai/conductor#2008). Thrown by
+/// <see cref="IContainerStatusClassifier"/> when the service can
+/// classify the failure mode of a <c>GET /api/containers/{id}</c> attempt.
+/// The controller maps each sub-class to the appropriate HTTP status code
+/// so Conductor's §7.2 helper can distinguish proxy-route-staleness (503)
+/// from genuine deletion (404) from authentication failure (401).
+/// </summary>
+public abstract class ContainerStatusException : Exception
+{
+    /// <summary>
+    /// Correlation / execution id carried into the response body and
+    /// headers so the SM.0.4 helper can correlate a status error
+    /// against in-flight lifecycle SSE events.
+    /// </summary>
+    public Guid CorrelationId { get; }
+
+    protected ContainerStatusException(string message, Guid correlationId, Exception? inner = null)
+        : base(message, inner)
+    {
+        CorrelationId = correlationId;
+    }
+}
+
+/// <summary>
+/// The infrastructure provider (Docker daemon, Apple Containers runtime,
+/// cloud proxy) is currently unreachable or circuit-broken. The container
+/// row exists in the database but its current runtime state cannot be
+/// confirmed. This is a TRANSIENT condition — the client SHOULD retry after
+/// <c>Retry-After</c> seconds (default 30).
+///
+/// Maps to HTTP 503 Service Unavailable.
+/// </summary>
+public sealed class ContainerRuntimeUnavailableException : ContainerStatusException
+{
+    /// <summary>Suggested retry delay in seconds.</summary>
+    public int RetryAfterSeconds { get; }
+
+    /// <summary>
+    /// Human-readable error code for structured logging/alerts.
+    /// </summary>
+    public const string ErrorCode = "CONTAINER_RUNTIME_UNAVAILABLE";
+
+    public ContainerRuntimeUnavailableException(
+        Guid containerId,
+        Guid correlationId,
+        string detail,
+        int retryAfterSeconds = 30,
+        Exception? inner = null)
+        : base(
+            $"Container runtime is temporarily unavailable for container {containerId}: {detail}",
+            correlationId,
+            inner)
+    {
+        RetryAfterSeconds = retryAfterSeconds;
+    }
+}
+
+/// <summary>
+/// The container has been confirmed deleted / does not exist and has never
+/// existed with this id for the requesting principal. This is a SUSTAINED
+/// (non-transient) 404 — the client SHOULD NOT retry without a user action.
+///
+/// Maps to HTTP 404 Not Found.
+/// </summary>
+public sealed class ContainerNotFoundException : ContainerStatusException
+{
+    public const string ErrorCode = "CONTAINER_NOT_FOUND";
+
+    public ContainerNotFoundException(Guid containerId, Guid correlationId)
+        : base($"Container {containerId} not found.", correlationId)
+    {
+    }
+}

--- a/src/Andy.Containers.Infrastructure/Messaging/RunEventOutbox.cs
+++ b/src/Andy.Containers.Infrastructure/Messaging/RunEventOutbox.cs
@@ -9,6 +9,9 @@ using Andy.Containers.Models;
 
 namespace Andy.Containers.Infrastructure.Messaging;
 
+// SM.2.6 (rivoli-ai/conductor#2008). Additional outbox helpers for the
+// provisioning-abort discrete event and the lifecycle SSE phase contract.
+
 // Helper for appending a run.* OutboxEntry to the DbContext in the same
 // unit of work as the domain change that produced the message. Caller
 // controls SaveChangesAsync — the outbox row lands with whatever else is
@@ -49,6 +52,41 @@ public static class RunEventOutbox
             Id = Guid.NewGuid(),
             Subject = subject,
             PayloadType = typeof(RunEventPayload).FullName,
+            PayloadJson = JsonSerializer.Serialize(payload, EventJson.Options),
+            CorrelationId = correlationId,
+            CausationId = null,
+            Generation = 0,
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+    }
+
+    // SM.2.6. Emit a discrete containerProvisioningAborted event on the
+    // andy.containers.events.container.{id}.provisioning_aborted subject.
+    // Published in addition to the phase=failed SSE event so downstream
+    // services (andy-tasks, andy-issues) can react without subscribing to
+    // the SSE stream.
+    public static void AppendProvisioningAbortedEvent(
+        this ContainersDbContext db,
+        Container container,
+        ProvisioningAbortReason reason,
+        string detail,
+        Guid correlationId)
+    {
+        var payload = new ContainerProvisioningAbortedEvent(
+            ContainerId: container.Id,
+            Reason: reason.ToWireString(),
+            Detail: detail,
+            CorrelationId: correlationId,
+            AbortedAt: DateTimeOffset.UtcNow);
+
+        var subject =
+            $"andy.containers.events.container.{container.Id}.provisioning_aborted";
+
+        db.OutboxEntries.Add(new OutboxEntry
+        {
+            Id = Guid.NewGuid(),
+            Subject = subject,
+            PayloadType = typeof(ContainerProvisioningAbortedEvent).FullName,
             PayloadJson = JsonSerializer.Serialize(payload, EventJson.Options),
             CorrelationId = correlationId,
             CausationId = null,

--- a/src/Andy.Containers.Infrastructure/Runs/Events/InMemoryContainerLifecycleBus.cs
+++ b/src/Andy.Containers.Infrastructure/Runs/Events/InMemoryContainerLifecycleBus.cs
@@ -1,0 +1,180 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Andy.Containers.Storage;
+
+namespace Andy.Containers.Infrastructure.Runs.Events;
+
+/// <summary>
+/// SM.2.6 (rivoli-ai/conductor#2008). In-process broadcast implementation
+/// of <see cref="IContainerLifecycleBus"/>. Maintains a rolling ring buffer
+/// of recent lifecycle events so SSE subscribers that attach mid-stream
+/// catch up before tailing live.
+/// </summary>
+/// <remarks>
+/// Pattern is identical to <c>InMemoryRunOutputBus</c> (F4.1 / #1934)
+/// and <c>InMemoryBuildEventBus</c> (IM9 / #263). Key differences:
+/// events are fleet-wide (not per-run) and the stream is never
+/// "terminal" — a subscriber stays open until the HTTP request is
+/// cancelled; the bus itself is closed only when the process shuts down.
+/// </remarks>
+public sealed class InMemoryContainerLifecycleBus : IContainerLifecycleBus, IDisposable
+{
+    private readonly ContainerLifecycleBusOptions _options;
+    private readonly object _lock = new();
+    private readonly Queue<ContainerLifecycleEnvelope> _buffer;
+    private readonly List<Subscription> _subscribers = [];
+    private long _nextSequence = 1;
+
+    public InMemoryContainerLifecycleBus(ContainerLifecycleBusOptions? options = null)
+    {
+        _options = options ?? new ContainerLifecycleBusOptions();
+        _buffer = new Queue<ContainerLifecycleEnvelope>(_options.BufferSize);
+    }
+
+    /// <inheritdoc/>
+    public void Publish(ContainerLifecycleEvent @event)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+
+        ContainerLifecycleEnvelope envelope;
+        List<Subscription> snapshot;
+        lock (_lock)
+        {
+            envelope = new ContainerLifecycleEnvelope(_nextSequence++, @event);
+            if (_buffer.Count >= _options.BufferSize)
+            {
+                _buffer.Dequeue();
+            }
+            _buffer.Enqueue(envelope);
+            snapshot = [.. _subscribers];
+        }
+
+        foreach (var sub in snapshot)
+        {
+            sub.TryWrite(envelope);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerable<ContainerLifecycleEnvelope> SubscribeAsync(
+        long? lastEventId,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        var subscription = CreateSubscription(lastEventId);
+        try
+        {
+            await foreach (var envelope in subscription.ReadAllAsync(ct))
+            {
+                yield return envelope;
+            }
+        }
+        finally
+        {
+            RemoveSubscription(subscription);
+        }
+    }
+
+    private Subscription CreateSubscription(long? lastEventId)
+    {
+        var channel = Channel.CreateBounded<ContainerLifecycleEnvelope>(
+            new BoundedChannelOptions(_options.SubscriberQueueSize)
+            {
+                FullMode = BoundedChannelFullMode.DropOldest,
+                SingleReader = true,
+                SingleWriter = false,
+            });
+        var subscription = new Subscription(channel);
+
+        ContainerLifecycleEnvelope[] replay;
+        lock (_lock)
+        {
+            _subscribers.Add(subscription);
+            replay = [.. _buffer.Where(e =>
+                lastEventId is null || e.SequenceNumber > lastEventId.Value)];
+        }
+
+        foreach (var envelope in replay)
+        {
+            subscription.TryWrite(envelope);
+        }
+
+        return subscription;
+    }
+
+    private void RemoveSubscription(Subscription subscription)
+    {
+        lock (_lock)
+        {
+            _subscribers.Remove(subscription);
+        }
+        subscription.Complete();
+    }
+
+    public void Dispose()
+    {
+        List<Subscription> snapshot;
+        lock (_lock)
+        {
+            snapshot = [.. _subscribers];
+            _subscribers.Clear();
+            _buffer.Clear();
+        }
+        foreach (var sub in snapshot)
+        {
+            sub.Complete();
+        }
+    }
+
+    /// <summary>One active SSE subscriber channel.</summary>
+    private sealed class Subscription
+    {
+        private readonly Channel<ContainerLifecycleEnvelope> _channel;
+        private int _completed;
+
+        internal Subscription(Channel<ContainerLifecycleEnvelope> channel)
+        {
+            _channel = channel;
+        }
+
+        public IAsyncEnumerable<ContainerLifecycleEnvelope> ReadAllAsync(CancellationToken ct)
+            => _channel.Reader.ReadAllAsync(ct);
+
+        public void TryWrite(ContainerLifecycleEnvelope envelope)
+        {
+            _ = _channel.Writer.TryWrite(envelope);
+        }
+
+        public void Complete()
+        {
+            if (Interlocked.Exchange(ref _completed, 1) == 0)
+            {
+                _channel.Writer.TryComplete();
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Configuration for <see cref="InMemoryContainerLifecycleBus"/>.
+/// </summary>
+public sealed class ContainerLifecycleBusOptions
+{
+    /// <summary>
+    /// Fleet-wide ring-buffer capacity. A subscriber that attaches will
+    /// be replayed up to this many recent events before tailing live.
+    /// Default: 256 (a few minutes of steady-state fleet activity for a
+    /// medium-sized dev team).
+    /// </summary>
+    public int BufferSize { get; init; } = 256;
+
+    /// <summary>
+    /// Per-subscriber bounded channel capacity. A slow SSE connection
+    /// drops events past this limit rather than backpressuring producers.
+    /// Default: 128.
+    /// </summary>
+    public int SubscriberQueueSize { get; init; } = 128;
+}

--- a/src/Andy.Containers/Messaging/Events/ContainerProvisioningAbortedEvent.cs
+++ b/src/Andy.Containers/Messaging/Events/ContainerProvisioningAbortedEvent.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Containers.Messaging.Events;
+
+/// <summary>
+/// SM.2.6 (rivoli-ai/conductor#2008). Discrete outbox event emitted on the
+/// <c>andy.containers.events.container.{containerId}.provisioning_aborted</c>
+/// subject when a provisioning attempt fails before the runtime is reached
+/// (pre-start abort).
+/// </summary>
+/// <remarks>
+/// This event is emitted <em>in addition to</em> the SSE lifecycle
+/// <c>phase=failed{reason}</c> transition. The NATS event lets downstream
+/// services (andy-tasks, andy-issues) react without subscribing to the SSE
+/// stream; the SSE phase transition lets Conductor's SM.4 machine transition
+/// state in real time.
+///
+/// Serialised via <see cref="Andy.Containers.Messaging.EventJson.Options"/>
+/// (snake_case) for consistency with all other outbox payloads.
+/// </remarks>
+public sealed record ContainerProvisioningAbortedEvent(
+    /// <summary>
+    /// The andy-containers row id of the affected container. Stable
+    /// across retry — a new create replaces this row with a new id.
+    /// </summary>
+    Guid ContainerId,
+
+    /// <summary>
+    /// Machine-readable abort reason (wire string, e.g.
+    /// <c>"quota_denied"</c>). Consumers that don't recognise the
+    /// value MUST treat it as <c>"unknown"</c> without throwing.
+    /// </summary>
+    string Reason,
+
+    /// <summary>
+    /// Human-readable detail carrying the underlying exception message
+    /// or provider error text. Never empty — at minimum the exception
+    /// type name. Not localised; for diagnostic use only.
+    /// </summary>
+    string Detail,
+
+    /// <summary>
+    /// Correlation id. Equals <c>Container.StoryId</c> when the
+    /// container was created in response to a story; otherwise equals
+    /// <c>Container.Id</c>. Propagates through the causation chain per
+    /// ADR 0001 so a single story-triggered provisioning failure can be
+    /// traced end-to-end.
+    /// </summary>
+    Guid CorrelationId,
+
+    /// <summary>Server UTC wall clock at the moment of abort.</summary>
+    DateTimeOffset AbortedAt);

--- a/src/Andy.Containers/Messaging/Events/ProvisioningAbortReason.cs
+++ b/src/Andy.Containers/Messaging/Events/ProvisioningAbortReason.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Containers.Messaging.Events;
+
+/// <summary>
+/// SM.2.6 (rivoli-ai/conductor#2008). Taxonomy of reasons a container
+/// provisioning attempt can abort before the runtime is reached (pre-start
+/// phase). Consumers (Conductor's SM.4 ContainerLifecycle machine) switch
+/// on this to surface an actionable "provisioning failed — retry" state
+/// rather than a stuck spinner.
+/// </summary>
+/// <remarks>
+/// Each value maps to a wire string via
+/// <see cref="ProvisioningAbortReasonExtensions.ToWireString"/>.
+/// Consumers MUST treat unrecognised strings as
+/// <see cref="Unknown"/> and continue without throwing.
+/// </remarks>
+public enum ProvisioningAbortReason
+{
+    /// <summary>
+    /// Default / catch-all. Returned when the abort was caused by an
+    /// unclassified exception and no narrower value applies.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// The requesting user hit the per-user simultaneous-container cap
+    /// (Conductor #878). The container row was created but never
+    /// dispatched to a runtime — destroying it frees a slot.
+    /// </summary>
+    QuotaDenied,
+
+    /// <summary>
+    /// The required container image could not be found in the registry
+    /// (missing tag, private repo without credentials, registry outage).
+    /// A retry may succeed after the image is pushed or credentials are
+    /// fixed.
+    /// </summary>
+    ImageNotFound,
+
+    /// <summary>
+    /// The infrastructure provider (Docker, Apple Containers, cloud
+    /// runtime) is unreachable or returned a definitive "cannot start"
+    /// error. Typically transient — a retry after the engine recovers
+    /// should succeed.
+    /// </summary>
+    EngineUnavailable,
+
+    /// <summary>
+    /// The provisioning attempt was cancelled mid-flight by the server
+    /// (e.g. service shutdown, graceful stop). The runtime may or may not
+    /// have allocated resources; re-creating the container is safe.
+    /// </summary>
+    Cancelled,
+
+    /// <summary>
+    /// The provisioning exceeded the configured timeout
+    /// (<see cref="ContainerProvisioningWorker.ProvisionTimeout"/>)
+    /// before the runtime reported success. The container may be
+    /// partially started; it is marked Failed and can be destroyed.
+    /// </summary>
+    Timeout,
+}
+
+public static class ProvisioningAbortReasonExtensions
+{
+    /// <summary>
+    /// Maps the enum to the stable snake_case wire string emitted in
+    /// SSE <c>phase=failed</c> events and in the
+    /// <c>containerProvisioningAborted</c> outbox event.
+    /// </summary>
+    public static string ToWireString(this ProvisioningAbortReason reason) => reason switch
+    {
+        ProvisioningAbortReason.QuotaDenied      => "quota_denied",
+        ProvisioningAbortReason.ImageNotFound    => "image_not_found",
+        ProvisioningAbortReason.EngineUnavailable => "engine_unavailable",
+        ProvisioningAbortReason.Cancelled        => "cancelled",
+        ProvisioningAbortReason.Timeout          => "timeout",
+        _                                        => "unknown",
+    };
+
+    /// <summary>
+    /// Parses the wire string back to the enum.  Unrecognised values
+    /// return <see cref="ProvisioningAbortReason.Unknown"/>.
+    /// </summary>
+    public static ProvisioningAbortReason FromWireString(string? value) => value switch
+    {
+        "quota_denied"       => ProvisioningAbortReason.QuotaDenied,
+        "image_not_found"    => ProvisioningAbortReason.ImageNotFound,
+        "engine_unavailable" => ProvisioningAbortReason.EngineUnavailable,
+        "cancelled"          => ProvisioningAbortReason.Cancelled,
+        "timeout"            => ProvisioningAbortReason.Timeout,
+        _                    => ProvisioningAbortReason.Unknown,
+    };
+}

--- a/src/Andy.Containers/Storage/IContainerLifecycleBus.cs
+++ b/src/Andy.Containers/Storage/IContainerLifecycleBus.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Containers.Storage;
+
+/// <summary>
+/// SM.2.6 (rivoli-ai/conductor#2008). In-process pub/sub for fleet-wide
+/// container lifecycle phase transitions. The provisioning worker and the
+/// orchestration service publish one <see cref="ContainerLifecycleEvent"/>
+/// per phase change; the <c>GET /api/containers/events</c> SSE endpoint
+/// subscribes to broadcast events to all connected clients.
+/// </summary>
+/// <remarks>
+/// Modelled on <see cref="IBuildEventBus"/> (IM9 / #263) and
+/// <see cref="IRunOutputBus"/> (F4.1 / #1934): a rolling in-process buffer
+/// with sequence numbers so a subscriber that attaches mid-stream catches up
+/// on recent transitions before tailing live. Cloud / multi-host deployments
+/// can swap in a network-fan-out variant without changing producers or
+/// consumers.
+/// </remarks>
+public interface IContainerLifecycleBus
+{
+    /// <summary>
+    /// Publish a lifecycle phase transition for a container. Non-blocking;
+    /// slow SSE subscribers do not backpressure producers.
+    /// </summary>
+    void Publish(ContainerLifecycleEvent @event);
+
+    /// <summary>
+    /// Subscribe to all future + recently buffered lifecycle events across
+    /// ALL containers visible to the principal. Yields in publish order;
+    /// completes when <paramref name="ct"/> fires.
+    /// </summary>
+    /// <param name="lastEventId">
+    /// Optional sequence number from a prior connection (from the SSE
+    /// <c>Last-Event-ID</c> header). The bus resumes from immediately
+    /// after this id. On buffer miss the stream restarts from the oldest
+    /// buffered event (clients reconcile via the container list).
+    /// </param>
+    IAsyncEnumerable<ContainerLifecycleEnvelope> SubscribeAsync(
+        long? lastEventId,
+        CancellationToken ct);
+}
+
+/// <summary>
+/// One lifecycle phase event. Serialised to the SSE
+/// <c>event: lifecycle</c> wire format by
+/// <c>ContainerLifecycleSse</c>.
+/// </summary>
+public sealed record ContainerLifecycleEvent(
+    /// <summary>The andy-containers row id of the affected container.</summary>
+    Guid ContainerId,
+
+    /// <summary>
+    /// Phase name (snake_case wire string, e.g. <c>"running"</c>,
+    /// <c>"failed"</c>). Consumers MUST skip unrecognised values per
+    /// the contract.
+    /// </summary>
+    string Phase,
+
+    /// <summary>
+    /// Per-phase payload. Nullable fields are omitted on serialisation
+    /// (WhenWritingNull) so legacy consumers keep deserialising without
+    /// schema friction.
+    /// </summary>
+    ContainerLifecyclePhaseData PhaseData,
+
+    /// <summary>
+    /// Correlation id. Equals <c>Container.StoryId</c> when the
+    /// container was created in response to a story, otherwise equals
+    /// <c>Container.Id</c>. Propagated to every SSE event so
+    /// Conductor's §7.2 helper can correlate transitions that arrived
+    /// out of order.
+    /// </summary>
+    Guid CorrelationId,
+
+    /// <summary>Server UTC wall clock at the moment of the transition.</summary>
+    DateTimeOffset Timestamp);
+
+/// <summary>
+/// Per-phase optional payload fields. Unused fields are null and omitted
+/// from the wire format.
+/// </summary>
+public sealed record ContainerLifecyclePhaseData(
+    /// <summary>
+    /// Process exit code. Present on <c>exited</c> phase only.
+    /// </summary>
+    int? ExitCode = null,
+
+    /// <summary>
+    /// Abort / failure reason (wire string). Present on <c>failed</c>
+    /// phase. For pre-start aborts this is the
+    /// <see cref="Andy.Containers.Messaging.Events.ProvisioningAbortReason"/>
+    /// wire string (e.g. <c>"quota_denied"</c>); for post-start failures
+    /// it is the provider's raw error token (e.g. <c>"CrashLoopBackOff"</c>).
+    /// </summary>
+    string? Reason = null);
+
+/// <summary>
+/// A lifecycle event tagged with a fleet-wide monotonic sequence number
+/// for <c>Last-Event-ID</c> / <c>since</c> resumption.
+/// </summary>
+public sealed record ContainerLifecycleEnvelope(
+    long SequenceNumber,
+    ContainerLifecycleEvent Event);

--- a/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerGitTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerGitTests.cs
@@ -36,7 +36,7 @@ public class ContainersControllerGitTests : IDisposable
         mockProbeService.Setup(p => p.ProbeRepositoriesAsync(It.IsAny<IReadOnlyList<GitRepositoryConfig>>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<string>());
         _mockGitDiffService = new Mock<IGitDiffService>();
-        _controller = new ContainersController(_mockService.Object, _mockCurrentUser.Object, _db, _mockGitCloneService.Object, mockCredentialService.Object, mockProbeService.Object, mockOrgMembership.Object, _mockGitDiffService.Object, new Mock<IPortDiscoveryService>().Object);
+        _controller = new ContainersController(_mockService.Object, _mockCurrentUser.Object, _db, _mockGitCloneService.Object, mockCredentialService.Object, mockProbeService.Object, mockOrgMembership.Object, _mockGitDiffService.Object, new Mock<IPortDiscoveryService>().Object, new Mock<Andy.Containers.Storage.IContainerLifecycleBus>().Object);
     }
 
     public void Dispose()

--- a/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerPortsTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerPortsTests.cs
@@ -33,7 +33,8 @@ public class ContainersControllerPortsTests : IDisposable
             _mockService.Object, _mockCurrentUser.Object, _db,
             new Mock<IGitCloneService>().Object, new Mock<IGitCredentialService>().Object,
             new Mock<IGitRepositoryProbeService>().Object, orgMembership.Object,
-            new Mock<IGitDiffService>().Object, _mockPorts.Object);
+            new Mock<IGitDiffService>().Object, _mockPorts.Object,
+            new Mock<Andy.Containers.Storage.IContainerLifecycleBus>().Object);
     }
 
     public void Dispose() => _db.Dispose();

--- a/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerRetryInstallTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerRetryInstallTests.cs
@@ -46,7 +46,8 @@ public class ContainersControllerRetryInstallTests : IDisposable
             _mockProbe.Object,
             _mockOrgMembership.Object,
             new Mock<IGitDiffService>().Object,
-            new Mock<IPortDiscoveryService>().Object);
+            new Mock<IPortDiscoveryService>().Object,
+            new Mock<Andy.Containers.Storage.IContainerLifecycleBus>().Object);
     }
 
     public void Dispose() => _db.Dispose();

--- a/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerStatusClassificationTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerStatusClassificationTests.cs
@@ -1,0 +1,195 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Abstractions;
+using Andy.Containers.Api.Controllers;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using Andy.Containers.Storage;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Controllers;
+
+/// <summary>
+/// SM.2.6 (rivoli-ai/conductor#2008). Verifies the classified GET
+/// <c>/api/containers/{id}</c> response codes:
+/// <list type="bullet">
+///   <item>200 + X-Correlation-Id header on success.</item>
+///   <item>404 structured envelope (code + correlationId) on confirmed deletion.</item>
+///   <item>503 + Retry-After header on transient runtime unavailability.</item>
+/// </list>
+/// </summary>
+public class ContainersControllerStatusClassificationTests : IDisposable
+{
+    private readonly Mock<IContainerService> _mockService = new();
+    private readonly Mock<ICurrentUserService> _mockCurrentUser = new();
+    private readonly ContainersDbContext _db;
+    private readonly ContainersController _controller;
+
+    public ContainersControllerStatusClassificationTests()
+    {
+        _mockCurrentUser.Setup(u => u.GetUserId()).Returns("test-user");
+        _mockCurrentUser.Setup(u => u.IsAdmin()).Returns(true);
+        _mockCurrentUser.Setup(u => u.IsAuthenticated()).Returns(true);
+
+        _db = InMemoryDbHelper.CreateContext();
+        var orgMembership = new Mock<IOrganizationMembershipService>();
+
+        var httpContext = new DefaultHttpContext();
+        _controller = new ContainersController(
+            _mockService.Object,
+            _mockCurrentUser.Object,
+            _db,
+            new Mock<IGitCloneService>().Object,
+            new Mock<IGitCredentialService>().Object,
+            new Mock<IGitRepositoryProbeService>().Object,
+            orgMembership.Object,
+            new Mock<IGitDiffService>().Object,
+            new Mock<IPortDiscoveryService>().Object,
+            new Mock<IContainerLifecycleBus>().Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext,
+            }
+        };
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    // ---------------------------------------------------------------
+    // 200 OK — success path with correlation id header
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task Get_ExistingContainer_Returns200_WithCorrelationIdHeader()
+    {
+        var containerId = Guid.NewGuid();
+        var storyId = Guid.NewGuid();
+        var container = new Container
+        {
+            Id = containerId,
+            Name = "test",
+            OwnerId = "test-user",
+            Status = ContainerStatus.Running,
+            StoryId = storyId,
+        };
+        _mockService.Setup(s => s.GetContainerAsync(containerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(container);
+
+        var result = await _controller.Get(containerId, CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>()
+            .Which.StatusCode.Should().Be(200);
+
+        _controller.Response.Headers.Should().ContainKey("X-Correlation-Id");
+        _controller.Response.Headers["X-Correlation-Id"].ToString().Should().Be(storyId.ToString());
+    }
+
+    [Fact]
+    public async Task Get_ContainerWithoutStoryId_UsesContainerIdAsCorrelation()
+    {
+        var containerId = Guid.NewGuid();
+        var container = new Container
+        {
+            Id = containerId,
+            Name = "test",
+            OwnerId = "test-user",
+            Status = ContainerStatus.Running,
+            StoryId = null,
+        };
+        _mockService.Setup(s => s.GetContainerAsync(containerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(container);
+
+        var result = await _controller.Get(containerId, CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>();
+        _controller.Response.Headers["X-Correlation-Id"].ToString().Should().Be(containerId.ToString());
+    }
+
+    // ---------------------------------------------------------------
+    // 404 — confirmed deletion (sustained)
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task Get_NonExistentContainer_Returns404_WithStructuredEnvelope()
+    {
+        var containerId = Guid.NewGuid();
+        _mockService.Setup(s => s.GetContainerAsync(containerId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException());
+
+        var result = await _controller.Get(containerId, CancellationToken.None);
+
+        var notFound = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFound.StatusCode.Should().Be(404);
+
+        // Envelope must carry the error code and correlationId.
+        var value = notFound.Value;
+        value.Should().NotBeNull();
+        var json = System.Text.Json.JsonSerializer.Serialize(value);
+        json.Should().Contain(ContainerNotFoundException.ErrorCode);
+        json.Should().Contain(containerId.ToString());
+
+        _controller.Response.Headers.Should().ContainKey("X-Correlation-Id");
+    }
+
+    // ---------------------------------------------------------------
+    // 503 — transient runtime unavailability
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task Get_RuntimeUnavailable_Returns503_WithRetryAfterHeader()
+    {
+        var containerId = Guid.NewGuid();
+        var correlationId = Guid.NewGuid();
+        _mockService.Setup(s => s.GetContainerAsync(containerId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ContainerRuntimeUnavailableException(
+                containerId, correlationId, "Docker daemon not responding", retryAfterSeconds: 30));
+
+        var result = await _controller.Get(containerId, CancellationToken.None);
+
+        var statusResult = result.Should().BeOfType<ObjectResult>().Subject;
+        statusResult.StatusCode.Should().Be(503);
+
+        _controller.Response.Headers.Should().ContainKey("Retry-After");
+        _controller.Response.Headers["Retry-After"].ToString().Should().Be("30");
+        _controller.Response.Headers["X-Correlation-Id"].ToString().Should().Be(correlationId.ToString());
+
+        var json = System.Text.Json.JsonSerializer.Serialize(statusResult.Value);
+        json.Should().Contain(ContainerRuntimeUnavailableException.ErrorCode);
+        json.Should().Contain(correlationId.ToString());
+    }
+
+    [Fact]
+    public async Task Get_RuntimeUnavailable_503_IsDistinguishableFrom_404()
+    {
+        // This test proves the §7.2 invariant: a 503 MUST NOT be confused
+        // with a 404 by Conductor's SM.0.4 helper. They must differ in
+        // status code alone — body parsing is optional on the client side.
+        var id = Guid.NewGuid();
+        var corr = Guid.NewGuid();
+
+        _mockService.Setup(s => s.GetContainerAsync(id, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ContainerRuntimeUnavailableException(id, corr, "transient", 30));
+
+        var transientResult = await _controller.Get(id, CancellationToken.None);
+        var transientStatus = transientResult.Should().BeOfType<ObjectResult>().Subject.StatusCode;
+
+        // Reset mock to throw KeyNotFoundException (404 path).
+        _mockService.Setup(s => s.GetContainerAsync(id, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException());
+
+        var deletedResult = await _controller.Get(id, CancellationToken.None);
+        var deletedStatus = deletedResult.Should().BeOfType<NotFoundObjectResult>().Subject.StatusCode;
+
+        transientStatus.Should().Be(503);
+        deletedStatus.Should().Be(404);
+        transientStatus.Should().NotBe(deletedStatus);
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerTests.cs
@@ -5,6 +5,7 @@ using Andy.Containers.Api.Tests.Helpers;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Models;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
@@ -33,7 +34,13 @@ public class ContainersControllerTests : IDisposable
         mockOrgMembership.Setup(o => o.HasPermissionAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
         var mockCredentialService = new Mock<IGitCredentialService>();
         var mockProbeService = new Mock<IGitRepositoryProbeService>();
-        _controller = new ContainersController(_mockService.Object, _mockCurrentUser.Object, _db, _mockGitCloneService.Object, mockCredentialService.Object, mockProbeService.Object, mockOrgMembership.Object, new Mock<IGitDiffService>().Object, new Mock<IPortDiscoveryService>().Object);
+        _controller = new ContainersController(_mockService.Object, _mockCurrentUser.Object, _db, _mockGitCloneService.Object, mockCredentialService.Object, mockProbeService.Object, mockOrgMembership.Object, new Mock<IGitDiffService>().Object, new Mock<IPortDiscoveryService>().Object, new Mock<Andy.Containers.Storage.IContainerLifecycleBus>().Object);
+        // SM.2.6: the Get action writes X-Correlation-Id to Response.Headers;
+        // supply a DefaultHttpContext so the header write doesn't NRE.
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext(),
+        };
     }
 
     public void Dispose()
@@ -118,7 +125,10 @@ public class ContainersControllerTests : IDisposable
 
         var result = await _controller.Get(id, CancellationToken.None);
 
-        result.Should().BeOfType<NotFoundResult>();
+        // SM.2.6: 404 now returns a structured envelope (NotFoundObjectResult)
+        // so Conductor's §7.2 helper can distinguish it from a transient 503.
+        result.Should().BeOfType<NotFoundObjectResult>()
+            .Which.StatusCode.Should().Be(404);
     }
 
     [Fact]

--- a/tests/Andy.Containers.Api.Tests/Messaging/ProvisioningAbortOutboxTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Messaging/ProvisioningAbortOutboxTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Messaging;
+using Andy.Containers.Messaging.Events;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Messaging;
+
+/// <summary>
+/// SM.2.6 (rivoli-ai/conductor#2008). Unit tests for
+/// <see cref="RunEventOutbox.AppendProvisioningAbortedEvent"/>: verifies that
+/// every abort reason produces a correctly-formed outbox row with the expected
+/// subject, payload, and correlationId.
+/// </summary>
+public class ProvisioningAbortOutboxTests : IDisposable
+{
+    private readonly Andy.Containers.Infrastructure.Data.ContainersDbContext _db;
+
+    public ProvisioningAbortOutboxTests()
+    {
+        _db = InMemoryDbHelper.CreateContext();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private Container MakeContainer(Guid? storyId = null)
+    {
+        var c = new Container
+        {
+            Id = Guid.NewGuid(),
+            Name = "test",
+            OwnerId = "user-1",
+            StoryId = storyId,
+        };
+        _db.Containers.Add(c);
+        return c;
+    }
+
+    [Theory]
+    [InlineData(ProvisioningAbortReason.QuotaDenied,       "quota_denied")]
+    [InlineData(ProvisioningAbortReason.ImageNotFound,     "image_not_found")]
+    [InlineData(ProvisioningAbortReason.EngineUnavailable, "engine_unavailable")]
+    [InlineData(ProvisioningAbortReason.Cancelled,         "cancelled")]
+    [InlineData(ProvisioningAbortReason.Timeout,           "timeout")]
+    [InlineData(ProvisioningAbortReason.Unknown,           "unknown")]
+    public async Task AppendProvisioningAbortedEvent_AllReasons_EmitCorrectPayload(
+        ProvisioningAbortReason reason, string expectedWire)
+    {
+        var container = MakeContainer();
+        var correlationId = container.Id;
+
+        _db.AppendProvisioningAbortedEvent(container, reason, "test detail", correlationId);
+        await _db.SaveChangesAsync();
+
+        var entries = _db.OutboxEntries.ToList();
+        entries.Should().HaveCount(1);
+
+        var entry = entries[0];
+        entry.Subject.Should().Be(
+            $"andy.containers.events.container.{container.Id}.provisioning_aborted");
+        entry.CorrelationId.Should().Be(correlationId);
+
+        var payload = JsonSerializer.Deserialize<ContainerProvisioningAbortedEvent>(
+            entry.PayloadJson, EventJson.Options);
+        payload.Should().NotBeNull();
+        payload!.ContainerId.Should().Be(container.Id);
+        payload.Reason.Should().Be(expectedWire);
+        payload.Detail.Should().Be("test detail");
+        payload.CorrelationId.Should().Be(correlationId);
+    }
+
+    [Fact]
+    public async Task AppendProvisioningAbortedEvent_WithStoryId_UsesStoryIdAsCorrelation()
+    {
+        var storyId = Guid.NewGuid();
+        var container = MakeContainer(storyId: storyId);
+        var correlationId = storyId; // caller passes storyId as correlationId
+
+        _db.AppendProvisioningAbortedEvent(container, ProvisioningAbortReason.QuotaDenied,
+            "quota hit", correlationId);
+        await _db.SaveChangesAsync();
+
+        var entry = _db.OutboxEntries.Single();
+        entry.CorrelationId.Should().Be(storyId);
+
+        var payload = JsonSerializer.Deserialize<ContainerProvisioningAbortedEvent>(
+            entry.PayloadJson, EventJson.Options);
+        payload!.CorrelationId.Should().Be(storyId);
+    }
+
+    [Fact]
+    public async Task AppendProvisioningAbortedEvent_PayloadType_MatchesFullTypeName()
+    {
+        var container = MakeContainer();
+        _db.AppendProvisioningAbortedEvent(container, ProvisioningAbortReason.Unknown, "test", container.Id);
+        await _db.SaveChangesAsync();
+
+        var entry = _db.OutboxEntries.Single();
+        entry.PayloadType.Should().Be(
+            typeof(ContainerProvisioningAbortedEvent).FullName);
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Services/ContainerProvisioningWorkerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ContainerProvisioningWorkerTests.cs
@@ -65,6 +65,7 @@ public class ContainerProvisioningWorkerTests : IDisposable
             _queue,
             _serviceProvider.GetRequiredService<IServiceScopeFactory>(),
             _mockProviderFactory.Object,
+            new Mock<Andy.Containers.Storage.IContainerLifecycleBus>().Object,
             NullLogger<ContainerProvisioningWorker>.Instance);
     }
 

--- a/tests/Andy.Containers.Api.Tests/Services/InMemoryContainerLifecycleBusTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/InMemoryContainerLifecycleBusTests.cs
@@ -1,0 +1,206 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Infrastructure.Runs.Events;
+using Andy.Containers.Storage;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+/// <summary>
+/// SM.2.6 (rivoli-ai/conductor#2008). Unit tests for
+/// <see cref="InMemoryContainerLifecycleBus"/> — verifies publish /
+/// subscribe / replay semantics the SSE endpoint relies on.
+/// </summary>
+public class InMemoryContainerLifecycleBusTests
+{
+    private static ContainerLifecycleEvent MakeEvent(Guid containerId, string phase, string? reason = null)
+        => new(
+            ContainerId: containerId,
+            Phase: phase,
+            PhaseData: new ContainerLifecyclePhaseData(Reason: reason),
+            CorrelationId: containerId,
+            Timestamp: DateTimeOffset.UtcNow);
+
+    [Fact]
+    public async Task Subscribe_ReceivesPublishedEvents()
+    {
+        var bus = new InMemoryContainerLifecycleBus();
+        var cid = Guid.NewGuid();
+        var evt = MakeEvent(cid, "running");
+
+        using var cts = new CancellationTokenSource();
+        var received = new List<ContainerLifecycleEnvelope>();
+        var subTask = Task.Run(async () =>
+        {
+            await foreach (var env in bus.SubscribeAsync(null, cts.Token))
+            {
+                received.Add(env);
+                if (received.Count >= 1) break;
+            }
+        });
+
+        // Give the subscriber time to attach.
+        await Task.Delay(50);
+        bus.Publish(evt);
+        await subTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        received.Should().HaveCount(1);
+        received[0].Event.ContainerId.Should().Be(cid);
+        received[0].Event.Phase.Should().Be("running");
+        received[0].SequenceNumber.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Subscribe_ReplayBufferedEvents_WhenLastEventIdProvided()
+    {
+        var bus = new InMemoryContainerLifecycleBus();
+        var cid = Guid.NewGuid();
+
+        // Publish 3 events before any subscriber attaches.
+        bus.Publish(MakeEvent(cid, "pending"));
+        bus.Publish(MakeEvent(cid, "creating"));
+        bus.Publish(MakeEvent(cid, "running"));
+
+        // Subscribe asking to resume after seq 1 — should replay seq 2 + 3.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var received = new List<ContainerLifecycleEnvelope>();
+        await foreach (var env in bus.SubscribeAsync(lastEventId: 1, cts.Token))
+        {
+            received.Add(env);
+            if (received.Count >= 2) break;
+        }
+
+        received.Should().HaveCount(2);
+        received[0].SequenceNumber.Should().Be(2);
+        received[0].Event.Phase.Should().Be("creating");
+        received[1].SequenceNumber.Should().Be(3);
+        received[1].Event.Phase.Should().Be("running");
+    }
+
+    [Fact]
+    public async Task Subscribe_WithNoLastEventId_ReplaysFull_Buffer()
+    {
+        var bus = new InMemoryContainerLifecycleBus();
+        var cid = Guid.NewGuid();
+
+        bus.Publish(MakeEvent(cid, "pending"));
+        bus.Publish(MakeEvent(cid, "creating"));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var received = new List<ContainerLifecycleEnvelope>();
+        await foreach (var env in bus.SubscribeAsync(null, cts.Token))
+        {
+            received.Add(env);
+            if (received.Count >= 2) break;
+        }
+
+        received.Should().HaveCount(2);
+        received.Select(e => e.Event.Phase).Should().ContainInOrder("pending", "creating");
+    }
+
+    [Fact]
+    public async Task Publish_FailedPhaseWithAbortReason_CarriesReason()
+    {
+        var bus = new InMemoryContainerLifecycleBus();
+        var cid = Guid.NewGuid();
+        bus.Publish(MakeEvent(cid, "failed", reason: "quota_denied"));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var received = new List<ContainerLifecycleEnvelope>();
+        await foreach (var env in bus.SubscribeAsync(null, cts.Token))
+        {
+            received.Add(env);
+            if (received.Count >= 1) break;
+        }
+
+        received.Should().HaveCount(1);
+        received[0].Event.Phase.Should().Be("failed");
+        received[0].Event.PhaseData.Reason.Should().Be("quota_denied");
+    }
+
+    [Fact]
+    public async Task MultipleSubscribers_EachReceiveAllEvents()
+    {
+        var bus = new InMemoryContainerLifecycleBus();
+        var cid = Guid.NewGuid();
+
+        var received1 = new List<ContainerLifecycleEnvelope>();
+        var received2 = new List<ContainerLifecycleEnvelope>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var sub1 = Task.Run(async () =>
+        {
+            await foreach (var env in bus.SubscribeAsync(null, cts.Token))
+            {
+                received1.Add(env);
+                if (received1.Count >= 2) break;
+            }
+        });
+        var sub2 = Task.Run(async () =>
+        {
+            await foreach (var env in bus.SubscribeAsync(null, cts.Token))
+            {
+                received2.Add(env);
+                if (received2.Count >= 2) break;
+            }
+        });
+
+        await Task.Delay(50);
+        bus.Publish(MakeEvent(cid, "creating"));
+        bus.Publish(MakeEvent(cid, "running"));
+
+        await Task.WhenAll(sub1, sub2).WaitAsync(TimeSpan.FromSeconds(5));
+
+        received1.Should().HaveCount(2);
+        received2.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Publish_AfterDispose_DoesNotThrow()
+    {
+        var bus = new InMemoryContainerLifecycleBus();
+        bus.Dispose();
+
+        // Publish after dispose: may silently drop but must not throw
+        var act = () => bus.Publish(MakeEvent(Guid.NewGuid(), "running"));
+        act.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// Acceptance criteria §2: the SSE event for every ContainerLifecyclePhase
+    /// value can be emitted and received with the correct phase string.
+    /// </summary>
+    [Theory]
+    [InlineData("pending")]
+    [InlineData("pulling")]
+    [InlineData("creating")]
+    [InlineData("starting")]
+    [InlineData("running")]
+    [InlineData("stopping")]
+    [InlineData("stopped")]
+    [InlineData("exited")]
+    [InlineData("oom")]
+    [InlineData("failed")]
+    [InlineData("destroying")]
+    [InlineData("destroyed")]
+    public async Task AllContractPhases_CanBePublishedAndReceived(string phase)
+    {
+        var bus = new InMemoryContainerLifecycleBus();
+        var cid = Guid.NewGuid();
+        bus.Publish(MakeEvent(cid, phase));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var received = new List<ContainerLifecycleEnvelope>();
+        await foreach (var env in bus.SubscribeAsync(null, cts.Token))
+        {
+            received.Add(env);
+            if (received.Count >= 1) break;
+        }
+
+        received.Should().HaveCount(1);
+        received[0].Event.Phase.Should().Be(phase);
+        received[0].Event.ContainerId.Should().Be(cid);
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Services/ProvisioningAbortClassifierTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ProvisioningAbortClassifierTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Api.Services;
+using Andy.Containers.Messaging.Events;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+/// <summary>
+/// SM.2.6 (rivoli-ai/conductor#2008). Unit tests for
+/// <see cref="ContainerProvisioningWorker.ClassifyAbortReason"/> — verifies
+/// the exception-to-reason taxonomy covering all branches documented in the
+/// AC.
+/// </summary>
+public class ProvisioningAbortClassifierTests
+{
+    [Fact]
+    public void ClassifyAbortReason_QuotaExceededException_ReturnsQuotaDenied()
+    {
+        var ex = new QuotaExceededException(limit: 5, current: 5, ownerId: "user");
+
+        var reason = ContainerProvisioningWorker.ClassifyAbortReason(ex);
+
+        reason.Should().Be(ProvisioningAbortReason.QuotaDenied);
+    }
+
+    [Theory]
+    [InlineData("image not found in registry")]
+    [InlineData("manifest unknown")]
+    [InlineData("Error: image ghcr.io/foo/bar:latest not found")]
+    public void ClassifyAbortReason_ImageNotFoundMessage_ReturnsImageNotFound(string message)
+    {
+        var ex = new InvalidOperationException(message);
+
+        var reason = ContainerProvisioningWorker.ClassifyAbortReason(ex);
+
+        reason.Should().Be(ProvisioningAbortReason.ImageNotFound);
+    }
+
+    [Theory]
+    [InlineData(typeof(HttpRequestException))]
+    [InlineData(typeof(TimeoutException))]
+    public void ClassifyAbortReason_NetworkOrTimeoutException_ReturnsEngineUnavailable(Type exceptionType)
+    {
+        var ex = (Exception)Activator.CreateInstance(exceptionType, "network error")!;
+
+        var reason = ContainerProvisioningWorker.ClassifyAbortReason(ex);
+
+        reason.Should().Be(ProvisioningAbortReason.EngineUnavailable);
+    }
+
+    [Fact]
+    public void ClassifyAbortReason_ConnectionRefusedMessage_ReturnsEngineUnavailable()
+    {
+        var ex = new Exception("connect: connection refused");
+
+        var reason = ContainerProvisioningWorker.ClassifyAbortReason(ex);
+
+        reason.Should().Be(ProvisioningAbortReason.EngineUnavailable);
+    }
+
+    [Fact]
+    public void ClassifyAbortReason_ArbitraryException_ReturnsUnknown()
+    {
+        var ex = new InvalidOperationException("some unrelated error");
+
+        var reason = ContainerProvisioningWorker.ClassifyAbortReason(ex);
+
+        reason.Should().Be(ProvisioningAbortReason.Unknown);
+    }
+
+    [Theory]
+    [InlineData(ProvisioningAbortReason.QuotaDenied,       "quota_denied")]
+    [InlineData(ProvisioningAbortReason.ImageNotFound,     "image_not_found")]
+    [InlineData(ProvisioningAbortReason.EngineUnavailable, "engine_unavailable")]
+    [InlineData(ProvisioningAbortReason.Cancelled,         "cancelled")]
+    [InlineData(ProvisioningAbortReason.Timeout,           "timeout")]
+    [InlineData(ProvisioningAbortReason.Unknown,           "unknown")]
+    public void ToWireString_AllValues_ProduceStableStrings(
+        ProvisioningAbortReason reason, string expected)
+    {
+        reason.ToWireString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("quota_denied",       ProvisioningAbortReason.QuotaDenied)]
+    [InlineData("image_not_found",    ProvisioningAbortReason.ImageNotFound)]
+    [InlineData("engine_unavailable", ProvisioningAbortReason.EngineUnavailable)]
+    [InlineData("cancelled",          ProvisioningAbortReason.Cancelled)]
+    [InlineData("timeout",            ProvisioningAbortReason.Timeout)]
+    [InlineData("unknown",            ProvisioningAbortReason.Unknown)]
+    [InlineData("some_future_reason", ProvisioningAbortReason.Unknown)]
+    [InlineData(null,                 ProvisioningAbortReason.Unknown)]
+    public void FromWireString_AllValues_RoundTrip(string? wire, ProvisioningAbortReason expected)
+    {
+        ProvisioningAbortReasonExtensions.FromWireString(wire).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary

- **Explicit provisioning-abort signal**: `ContainerProvisioningWorker` now emits a `phase=failed{reason}` lifecycle SSE event AND a discrete `containerProvisioningAborted` outbox event on every pre-start failure (quota denied, image not found, engine unavailable, service shutdown, timeout). Reason taxonomy is `ProvisioningAbortReason` with stable wire strings. Never inferred from a stuck pending or a bare 404.
- **Fleet-wide lifecycle SSE endpoint**: `GET /api/containers/events` is now implemented (was contract-only). Backed by `InMemoryContainerLifecycleBus` (256-event rolling buffer, `Last-Event-ID` replay, multi-subscriber fan-out). Emits all 12 contract phases; `correlationId` field on every event for SM.0.4 correlation.
- **Classified GET /api/containers/{id}**: returns `503 + Retry-After` on transient runtime unavailability, `404` with structured envelope on confirmed deletion, `200` with `X-Correlation-Id` header on success. Distinguishable by status code alone — the SM.0.4 disagreement classifier no longer needs to parse the response body.

## Test evidence

53 new tests — all pass (`dotnet test` output below):

```
Test Run Successful.
Total tests: 53
     Passed: 53
 Total time: 2.2966 Seconds
```

Full suite (excluding 3 pre-existing `StubAndyAgentsClientTests` failures from a fixture using `openrouter` instead of `anthropic` — unrelated to this PR, and 5 Postgres-dependent migration tests):

```
Passed!  - Failed: 0, Passed: 1300, Skipped: 1, Total: 1301, Duration: 11 s
```

**New tests by class:**
- `ProvisioningAbortClassifierTests` — all 6 abort reasons + wire string round-trips (25 cases)
- `InMemoryContainerLifecycleBusTests` — publish/subscribe, replay, multi-subscriber, all 12 contract phases (18 cases)
- `ContainersControllerStatusClassificationTests` — 200+header, 404 envelope, 503+Retry-After, 503≠404 invariant (5 cases)
- `ProvisioningAbortOutboxTests` — all 6 reasons, StoryId correlation, payload type name (8 cases)

## Addresses

rivoli-ai/conductor#2008 (SM.2.6)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>