### PR TITLE
[Fix] Stage headless config into container + wire in-container model access

### DIFF
--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -628,6 +628,67 @@ public class ContainerOrchestrationService : IContainerService
                 _logger.LogInformation(
                     "Injected shared ANDY_SERVICE_TOKEN (length={Length}) into container env (no per-container slugs required)",
                     serviceToken.Length);
+
+                // The headless andy-cli agent (plan execution) and any other
+                // OpenAI-SDK client read OPENAI_API_KEY + OPENAI_BASE_URL. The
+                // codeAssistant routing block above only runs for a configured
+                // assistant; an assistant-less headless run lands here, so
+                // point the OpenAI dialect at the andy-models proxy.
+                if (!string.IsNullOrWhiteSpace(containerFacingProxyUrl))
+                {
+                    // andy-models exposes the OpenAI-compatible chat surface at
+                    // `/models/v1/chat/completions` (the OpenAI SDK appends
+                    // `/chat/completions` to OPENAI_API_BASE). The `openai/v1`
+                    // dialect mount returns 405 for POST — use the plain `v1`.
+                    var openAiBaseUrl = CodeAssistantProxyRouting.BuildBaseUrl(
+                        containerFacingProxyUrl, "v1");
+                    // Set BOTH base-URL env names: the OpenAI SDK family uses
+                    // OPENAI_BASE_URL, but andy-cli's Andy.Llm provider (and
+                    // older clients like aider) read OPENAI_API_BASE.
+                    if (!envVars.ContainsKey("OPENAI_BASE_URL"))
+                    {
+                        envVars["OPENAI_BASE_URL"] = openAiBaseUrl;
+                    }
+                    if (!envVars.ContainsKey("OPENAI_API_BASE"))
+                    {
+                        envVars["OPENAI_API_BASE"] = openAiBaseUrl;
+                    }
+
+                    // The proxy validates aud=urn:andy-models-api; the shared
+                    // andy-containers M2M token (aud=urn:andy-containers-api) is
+                    // rejected 401. Mint a per-container proxy token ISSUED BY
+                    // andy-models (correct audience + denylist-revocable),
+                    // scoped to the default model slugs, and hand THAT to the
+                    // OpenAI client.
+                    if (_proxyTokenService is not null && !envVars.ContainsKey("OPENAI_API_KEY"))
+                    {
+                        var modelSlugs = _configuration.GetSection("Proxy:HeadlessModelSlugs").Get<string[]>();
+                        if (modelSlugs is null || modelSlugs.Length == 0)
+                        {
+                            modelSlugs = new[] { "deepseek-v4-flash" };
+                        }
+                        try
+                        {
+                            var modelToken = await _proxyTokenService.MintForContainerAsync(
+                                container.Id.ToString(), container.OwnerId, modelSlugs, ct);
+                            if (modelToken is not null)
+                            {
+                                envVars["OPENAI_API_KEY"] = modelToken.Jwt;
+                                container.ProxyServiceTokenId ??= modelToken.TokenId;
+                                _logger.LogInformation(
+                                    "Minted andy-models proxy token for headless OpenAI client (tokenId={TokenId}, slugs={Slugs}); OPENAI_BASE_URL={Url}",
+                                    modelToken.TokenId, string.Join(",", modelSlugs),
+                                    UrlRedactor.Redact(openAiBaseUrl));
+                            }
+                        }
+                        catch (ProxyTokenException ex)
+                        {
+                            _logger.LogWarning(ex,
+                                "Failed to mint andy-models proxy token for headless container {ContainerName}; OpenAI calls will 401.",
+                                container.Name);
+                        }
+                    }
+                }
             }
             catch (Exception tokenEx)
             {

--- a/src/Andy.Containers.Api/Services/GitCloneService.cs
+++ b/src/Andy.Containers.Api/Services/GitCloneService.cs
@@ -191,13 +191,25 @@ public class GitCloneService : IGitCloneService
             if (repo.Submodules)
                 cloneArgs.Add("--recurse-submodules");
 
-            // `--` ends git's option parsing so a URL starting with `-` cannot
-            // be re-interpreted as a flag.
+            // git refuses to clone into a non-empty directory, but the
+            // container pre-initialises the workspace (an empty git repo +
+            // run branch) BEFORE clone time, so `git clone <url> /workspace`
+            // fails with "destination path already exists and is not an empty
+            // directory". Clone into a throwaway temp dir, then MERGE the
+            // result (including its real .git) into the target, replacing the
+            // placeholder init. `--` ends git's option parsing so a URL
+            // starting with `-` cannot be re-interpreted as a flag.
+            var tmpDir = "/tmp/andy-clone-" + Guid.NewGuid().ToString("N");
             cloneArgs.Add("--");
             cloneArgs.Add(ShellQuote(cloneUrl));
-            cloneArgs.Add(ShellQuote(repo.TargetPath));
+            cloneArgs.Add(ShellQuote(tmpDir));
 
-            var command = string.Join(" ", cloneArgs);
+            var target = ShellQuote(repo.TargetPath);
+            var quotedTmp = ShellQuote(tmpDir);
+            var command =
+                $"rm -rf {quotedTmp} && {string.Join(" ", cloneArgs)} && "
+                + $"mkdir -p {target} && rm -rf {target}/.git && "
+                + $"cp -a {quotedTmp}/. {target}/ && rm -rf {quotedTmp}";
 
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             timeoutCts.CancelAfter(CloneTimeout);

--- a/src/Andy.Containers.Api/Services/HeadlessRunner.cs
+++ b/src/Andy.Containers.Api/Services/HeadlessRunner.cs
@@ -124,7 +124,40 @@ public sealed class HeadlessRunner : IHeadlessRunner
                 CancellationToken.None);
         }
 
-        var command = $"andy-cli run --headless --config {ShellEscape(configPath)}";
+        // The configurator writes the headless config to a HOST temp dir, but
+        // andy-cli runs INSIDE the container where that path doesn't exist.
+        // Read it here (it's required — the agent can't run without it) and
+        // stage it into the container as the FIRST step of the same exec, so
+        // there's a single command whose exit code is andy-cli's.
+        string configJson;
+        try
+        {
+            configJson = await File.ReadAllTextAsync(configPath, execToken);
+        }
+        catch (OperationCanceledException) when (execToken.IsCancellationRequested)
+        {
+            return await TerminateAsync(run, RunEventKind.Cancelled, RunStatus.Cancelled,
+                exitCode: null, durationSeconds: sw.Elapsed.TotalSeconds, error: "Cancelled before spawn",
+                CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            return await TerminateAsync(run, RunEventKind.Failed, RunStatus.Failed,
+                exitCode: null, durationSeconds: sw.Elapsed.TotalSeconds,
+                error: $"Headless config could not be read from host path '{configPath}': {ex.Message}",
+                CancellationToken.None);
+        }
+
+        // base64 sidesteps every shell-escaping hazard the raw JSON would carry;
+        // `base64 -d` is in the coreutils every andy-headless image ships.
+        var inContainerConfigPath = $"/tmp/andy-runs/{run.Id}/config.json";
+        var stageDir = $"/tmp/andy-runs/{run.Id}";
+        var configB64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(configJson));
+        var command =
+            $"mkdir -p {ShellEscape(stageDir)} && "
+            + $"printf %s {ShellEscape(configB64)} | base64 -d > {ShellEscape(inContainerConfigPath)} && "
+            + $"andy-cli run --headless --config {ShellEscape(inContainerConfigPath)}";
         var execTimeout = await ResolveExecTimeoutAsync(configPath, execToken);
 
         // F4.1 (#1934). Resolve the literal run-scoped token so the

--- a/src/Andy.Containers.Api/Services/StubAndyAgentsClient.cs
+++ b/src/Andy.Containers.Api/Services/StubAndyAgentsClient.cs
@@ -80,11 +80,14 @@ public sealed class StubAndyAgentsClient : IAndyAgentsClient
             return Task.FromResult<AgentSpec?>(null);
         }
 
-        // The coding role can patch files + use git; everyone else is read-only.
+        // The coding role gets the local `git` CLI for branch/diff work;
+        // file editing uses andy-cli's BUILT-IN tools (no external MCP server).
+        // Everyone else is read-only with no tools. (The previous fs.patch MCP
+        // tool pointed at a placeholder `mcp.internal` host that doesn't
+        // resolve, which crashed the in-container agent on startup.)
         var tools = key == "coding"
             ? new[]
             {
-                new AgentSpecTool { Name = "fs.patch", Transport = "mcp", Endpoint = "https://mcp.internal/tools/fs.patch" },
                 new AgentSpecTool { Name = "git", Transport = "cli", Binary = "git", Command = new[] { "git" } },
             }
             : Array.Empty<AgentSpecTool>();

--- a/tests/Andy.Containers.Api.Tests/Configurator/StubAndyAgentsClientTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Configurator/StubAndyAgentsClientTests.cs
@@ -38,12 +38,14 @@ public class StubAndyAgentsClientTests
     }
 
     [Fact]
-    public async Task GetAgentAsync_CodingRole_CanPatchAndUseGit()
+    public async Task GetAgentAsync_CodingRole_HasLocalGitOnly()
     {
         var spec = await _client.GetAgentAsync("coding", revision: null);
 
-        spec!.Tools.Should().Contain(t => t.Name == "fs.patch");
-        spec.Tools.Should().Contain(t => t.Name == "git");
+        // git is a local CLI tool; file editing uses andy-cli's built-ins.
+        // No external MCP tools (a placeholder endpoint would crash the agent).
+        spec!.Tools.Should().Contain(t => t.Name == "git" && t.Transport == "cli");
+        spec.Tools.Should().OnlyContain(t => t.Transport == "cli");
     }
 
     [Fact]

--- a/tests/Andy.Containers.Api.Tests/Services/GitCloneServiceTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/GitCloneServiceTests.cs
@@ -214,7 +214,7 @@ public class GitCloneServiceTests : IDisposable
             .ReturnsAsync("ghp_mytoken123");
 
         string? cloneCommand = null;
-        _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.StartsWith("git clone")), It.IsAny<CancellationToken>()))
+        _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("git clone")), It.IsAny<CancellationToken>()))
             .Callback<Guid, string, CancellationToken>((_, cmd, _) => cloneCommand = cmd)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
         _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("---FILES---")), It.IsAny<CancellationToken>()))
@@ -245,7 +245,7 @@ public class GitCloneServiceTests : IDisposable
             .ReturnsAsync("ghp_mytoken123");
 
         string? cloneCommand = null;
-        _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.StartsWith("git clone")), It.IsAny<CancellationToken>()))
+        _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("git clone")), It.IsAny<CancellationToken>()))
             .Callback<Guid, string, CancellationToken>((_, cmd, _) => cloneCommand = cmd)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
         _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("---FILES---")), It.IsAny<CancellationToken>()))
@@ -276,7 +276,7 @@ public class GitCloneServiceTests : IDisposable
             .ReturnsAsync((string?)null);
 
         string? cloneCommand = null;
-        _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.StartsWith("git clone")), It.IsAny<CancellationToken>()))
+        _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("git clone")), It.IsAny<CancellationToken>()))
             .Callback<Guid, string, CancellationToken>((_, cmd, _) => cloneCommand = cmd)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
         _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("---FILES---")), It.IsAny<CancellationToken>()))
@@ -302,7 +302,7 @@ public class GitCloneServiceTests : IDisposable
         await _db.SaveChangesAsync();
 
         string? cloneCommand = null;
-        _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.StartsWith("git clone")), It.IsAny<CancellationToken>()))
+        _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("git clone")), It.IsAny<CancellationToken>()))
             .Callback<Guid, string, CancellationToken>((_, cmd, _) => cloneCommand = cmd)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
         _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("---FILES---")), It.IsAny<CancellationToken>()))
@@ -328,7 +328,7 @@ public class GitCloneServiceTests : IDisposable
         await _db.SaveChangesAsync();
 
         string? cloneCommand = null;
-        _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.StartsWith("git clone")), It.IsAny<CancellationToken>()))
+        _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("git clone")), It.IsAny<CancellationToken>()))
             .Callback<Guid, string, CancellationToken>((_, cmd, _) => cloneCommand = cmd)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
         _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("---FILES---")), It.IsAny<CancellationToken>()))
@@ -354,7 +354,7 @@ public class GitCloneServiceTests : IDisposable
         await _db.SaveChangesAsync();
 
         string? cloneCommand = null;
-        _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.StartsWith("git clone")), It.IsAny<CancellationToken>()))
+        _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("git clone")), It.IsAny<CancellationToken>()))
             .Callback<Guid, string, CancellationToken>((_, cmd, _) => cloneCommand = cmd)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
         _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("---FILES---")), It.IsAny<CancellationToken>()))
@@ -381,7 +381,7 @@ public class GitCloneServiceTests : IDisposable
         await _db.SaveChangesAsync();
 
         string? cloneCommand = null;
-        _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.StartsWith("git clone")), It.IsAny<CancellationToken>()))
+        _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("git clone")), It.IsAny<CancellationToken>()))
             .Callback<Guid, string, CancellationToken>((_, cmd, _) => cloneCommand = cmd)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
         _mockContainerService.Setup(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("---FILES---")), It.IsAny<CancellationToken>()))
@@ -389,7 +389,11 @@ public class GitCloneServiceTests : IDisposable
 
         await _service.CloneRepositoryAsync(container.Id, repo.Id);
 
-        cloneCommand.Should().StartWith("git clone ");
+        // git can't clone into the pre-initialised /workspace, so the command
+        // clones into a temp dir and merges the result into the target.
+        cloneCommand.Should().Contain("git clone ");
+        cloneCommand.Should().Contain("/tmp/andy-clone-");
+        cloneCommand.Should().Contain("cp -a");
         cloneCommand.Should().NotContain("--depth");
         cloneCommand.Should().NotContain("--branch");
         cloneCommand.Should().NotContain("--recurse-submodules");
@@ -416,7 +420,7 @@ public class GitCloneServiceTests : IDisposable
         await _service.CloneRepositoriesAsync(container.Id);
 
         // 2 clone commands + 2 metadata collection commands
-        _mockContainerService.Verify(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.StartsWith("git clone")), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        _mockContainerService.Verify(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("git clone")), It.IsAny<CancellationToken>()), Times.Exactly(2));
 
         var repos = await _db.ContainerGitRepositories.Where(r => r.ContainerId == container.Id).ToListAsync();
         repos.Should().OnlyContain(r => r.CloneStatus == GitCloneStatus.Cloned);
@@ -444,7 +448,7 @@ public class GitCloneServiceTests : IDisposable
         await _service.CloneRepositoriesAsync(container.Id);
 
         // Only the Pending repo should be cloned (1 clone + 1 metadata)
-        _mockContainerService.Verify(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.StartsWith("git clone")), It.IsAny<CancellationToken>()), Times.Once);
+        _mockContainerService.Verify(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("git clone")), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -474,7 +478,7 @@ public class GitCloneServiceTests : IDisposable
         await _service.CloneRepositoriesAsync(container.Id);
 
         // Both repos should have been attempted
-        _mockContainerService.Verify(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.StartsWith("git clone")), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        _mockContainerService.Verify(s => s.ExecAsync(container.Id, It.Is<string>(cmd => cmd.Contains("git clone")), It.IsAny<CancellationToken>()), Times.Exactly(2));
 
         var repos = await _db.ContainerGitRepositories.Where(r => r.ContainerId == container.Id).ToListAsync();
         // One should have failed, one should have succeeded

--- a/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
@@ -26,8 +26,15 @@ public class HeadlessRunnerTests : IDisposable
     private readonly Mock<ITokenIssuer> _tokens = new();
     private readonly HeadlessRunner _runner;
 
+    // The runner now stages the on-disk headless config INTO the container
+    // before spawning andy-cli (it reads the host file + writes it via exec),
+    // so the config path must point at a real, readable file.
+    private readonly string _configPath;
+
     public HeadlessRunnerTests()
     {
+        _configPath = Path.Combine(Path.GetTempPath(), $"headless-config-{Guid.NewGuid():N}.json");
+        File.WriteAllText(_configPath, "{}");
         _db = InMemoryDbHelper.CreateContext();
         // AP10 (#112): runner now revokes the run-scoped token on every
         // terminal path. Default to a no-op revoke; AP10-specific tests
@@ -40,7 +47,11 @@ public class HeadlessRunnerTests : IDisposable
             NullLogger<HeadlessRunner>.Instance);
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose()
+    {
+        _db.Dispose();
+        try { File.Delete(_configPath); } catch { /* best-effort temp cleanup */ }
+    }
 
     [Fact]
     public async Task StartAsync_ExitZero_TransitionsToSucceeded_WritesFinishedEvent()
@@ -48,7 +59,7 @@ public class HeadlessRunnerTests : IDisposable
         var run = SeedRun();
         SetupExec(run.ContainerId!.Value, exitCode: 0, stdOut: "ok");
 
-        var outcome = await _runner.StartAsync(run, "/tmp/x/config.json");
+        var outcome = await _runner.StartAsync(run, _configPath);
 
         outcome.Kind.Should().Be(RunEventKind.Finished);
         outcome.Status.Should().Be(RunStatus.Succeeded);
@@ -82,7 +93,7 @@ public class HeadlessRunnerTests : IDisposable
         var run = SeedRun();
         SetupExec(run.ContainerId!.Value, exitCode: exitCode, stdErr: "boom");
 
-        var outcome = await _runner.StartAsync(run, "/tmp/x/config.json");
+        var outcome = await _runner.StartAsync(run, _configPath);
 
         outcome.Kind.Should().Be(kind);
         outcome.Status.Should().Be(status);
@@ -106,7 +117,7 @@ public class HeadlessRunnerTests : IDisposable
                 It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("docker daemon unreachable"));
 
-        var outcome = await _runner.StartAsync(run, "/tmp/x/config.json");
+        var outcome = await _runner.StartAsync(run, _configPath);
 
         outcome.Kind.Should().Be(RunEventKind.Failed);
         outcome.Status.Should().Be(RunStatus.Failed);
@@ -133,7 +144,7 @@ public class HeadlessRunnerTests : IDisposable
                 It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new OperationCanceledException("exec timeout"));
 
-        var outcome = await _runner.StartAsync(run, "/tmp/x/config.json", CancellationToken.None);
+        var outcome = await _runner.StartAsync(run, _configPath, CancellationToken.None);
 
         outcome.Kind.Should().Be(RunEventKind.Timeout);
         outcome.Status.Should().Be(RunStatus.Timeout);
@@ -153,7 +164,7 @@ public class HeadlessRunnerTests : IDisposable
                 It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new OperationCanceledException(cts.Token));
 
-        var outcome = await _runner.StartAsync(run, "/tmp/x/config.json", cts.Token);
+        var outcome = await _runner.StartAsync(run, _configPath, cts.Token);
 
         outcome.Kind.Should().Be(RunEventKind.Cancelled);
         outcome.Status.Should().Be(RunStatus.Cancelled);
@@ -179,7 +190,7 @@ public class HeadlessRunnerTests : IDisposable
                 throw new InvalidOperationException("delay should have thrown");
             });
 
-        var startTask = _runner.StartAsync(run, "/tmp/x/config.json");
+        var startTask = _runner.StartAsync(run, _configPath);
 
         // Wait for ExecAsync to be in flight before signalling — the
         // runner's registration only exists between the SaveChanges of
@@ -213,7 +224,7 @@ public class HeadlessRunnerTests : IDisposable
         var run = SeedRun();
         SetupExec(run.ContainerId!.Value, exitCode: 0);
 
-        await _runner.StartAsync(run, "/tmp/x/config.json");
+        await _runner.StartAsync(run, _configPath);
 
         _cancellation.TryCancel(run.Id).Should().BeFalse(
             "registration must be removed after the runner terminates");
@@ -224,7 +235,7 @@ public class HeadlessRunnerTests : IDisposable
     {
         var run = SeedRunWithoutContainer();
 
-        var outcome = await _runner.StartAsync(run, "/tmp/x/config.json");
+        var outcome = await _runner.StartAsync(run, _configPath);
 
         outcome.Kind.Should().Be(RunEventKind.Failed);
         outcome.Status.Should().Be(RunStatus.Failed);
@@ -253,7 +264,7 @@ public class HeadlessRunnerTests : IDisposable
         var run = SeedRun();
         SetupExec(run.ContainerId!.Value, exitCode);
 
-        await _runner.StartAsync(run, "/tmp/x/config.json");
+        await _runner.StartAsync(run, _configPath);
 
         _tokens.Verify(t => t.RevokeAsync(run.Id, It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -266,7 +277,7 @@ public class HeadlessRunnerTests : IDisposable
         // doesn't outlive the run row.
         var run = SeedRunWithoutContainer();
 
-        await _runner.StartAsync(run, "/tmp/x/config.json");
+        await _runner.StartAsync(run, _configPath);
 
         _tokens.Verify(t => t.RevokeAsync(run.Id, It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -281,18 +292,20 @@ public class HeadlessRunnerTests : IDisposable
             .Setup(t => t.RevokeAsync(run.Id, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("issuer down"));
 
-        var outcome = await _runner.StartAsync(run, "/tmp/x/config.json");
+        var outcome = await _runner.StartAsync(run, _configPath);
 
         outcome.Status.Should().Be(RunStatus.Succeeded,
             "issuer failure must be logged, not propagated as a run failure");
     }
 
     [Fact]
-    public async Task StartAsync_ConfigPathIsShellEscaped()
+    public async Task StartAsync_StagesConfigIntoContainer_AndShellEscapesInContainerPath()
     {
-        // A config path with a single quote in it would break a naive
-        // command interpolation. Verify the runner emits a properly
-        // single-quote-escaped argument so /bin/sh -c can parse it.
+        // andy-cli runs INSIDE the container where the host config path doesn't
+        // exist, so the runner stages the config there (base64-decoded into a
+        // fixed in-container path) as the first step of the same exec, then
+        // points andy-cli at that path — single-quote-wrapped so /bin/sh -c
+        // parses it.
         var run = SeedRun();
         string? captured = null;
         _containers
@@ -301,11 +314,13 @@ public class HeadlessRunnerTests : IDisposable
             .Callback<Guid, string, TimeSpan, CancellationToken>((_, cmd, _, _) => captured = cmd)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
 
-        await _runner.StartAsync(run, "/tmp/o'malley/config.json");
+        await _runner.StartAsync(run, _configPath);
 
         captured.Should().NotBeNull();
-        captured.Should().Contain("andy-cli run --headless --config");
-        captured.Should().Contain("'/tmp/o'\\''malley/config.json'");
+        // Stage step: base64-decode the config into the in-container path.
+        captured.Should().Contain($"base64 -d > '/tmp/andy-runs/{run.Id}/config.json'");
+        // Run step: andy-cli against the single-quote-escaped in-container path.
+        captured.Should().Contain($"andy-cli run --headless --config '/tmp/andy-runs/{run.Id}/config.json'");
     }
 
     [Fact]
@@ -334,25 +349,29 @@ public class HeadlessRunnerTests : IDisposable
     }
 
     [Fact]
-    public async Task StartAsync_ConfigUnreadable_FallsBackToFifteenMinuteDefault()
+    public async Task StartAsync_ConfigUnreadable_FailsRunWithoutSpawningAndyCli()
     {
-        // A missing/malformed config file must not crash the runner — fall
-        // back to the legacy 15-min ceiling so a misconfigured run still
-        // terminates instead of hanging on the inner CTS that AQ3 also
-        // refuses to set up.
+        // The headless config is staged INTO the container (andy-cli reads it
+        // there), so a config that can't be read on the host is a hard failure
+        // — the agent must never start without its config. (Previously the
+        // runner fell back to a default timeout and spawned anyway; that masked
+        // a misconfigured run as a hung one.)
         var run = SeedRun();
         var missingPath = Path.Combine(Path.GetTempPath(), $"never-existed-{Guid.NewGuid():N}.json");
 
-        TimeSpan? capturedTimeout = null;
+        string? spawnCommand = null;
         _containers
             .Setup(c => c.ExecAsync(
                 It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, string, TimeSpan, CancellationToken>((_, _, t, _) => capturedTimeout = t)
+            .Callback<Guid, string, TimeSpan, CancellationToken>((_, cmd, _, _) => spawnCommand = cmd)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
 
-        await _runner.StartAsync(run, missingPath);
+        var outcome = await _runner.StartAsync(run, missingPath);
 
-        capturedTimeout.Should().Be(TimeSpan.FromMinutes(15));
+        outcome.Kind.Should().Be(RunEventKind.Failed);
+        outcome.Status.Should().Be(RunStatus.Failed);
+        outcome.Error.Should().Contain("config could not be read");
+        spawnCommand.Should().BeNull("andy-cli must not spawn when its config is unreadable");
     }
 
     [Fact]
@@ -383,7 +402,7 @@ public class HeadlessRunnerTests : IDisposable
         var run = SeedRun(correlationId: correlation);
         SetupExec(run.ContainerId!.Value, exitCode: 0);
 
-        await _runner.StartAsync(run, "/tmp/x/config.json");
+        await _runner.StartAsync(run, _configPath);
 
         var entry = await _db.OutboxEntries.SingleAsync();
         entry.CorrelationId.Should().Be(correlation,
@@ -417,7 +436,7 @@ public class HeadlessRunnerTests : IDisposable
             NullLogger<HeadlessRunner>.Instance, collector.Object);
         SetupExec(run.ContainerId.Value, exitCode: 0);
 
-        await runner.StartAsync(run, "/tmp/x/config.json");
+        await runner.StartAsync(run, _configPath);
 
         var persisted = await _db.Runs.FindAsync(run.Id);
         persisted!.OutputArtifacts.Should().HaveCount(2);
@@ -454,7 +473,7 @@ public class HeadlessRunnerTests : IDisposable
             NullLogger<HeadlessRunner>.Instance, collector.Object);
         SetupExec(run.ContainerId.Value, exitCode: 0);
 
-        var outcome = await runner.StartAsync(run, "/tmp/x/config.json");
+        var outcome = await runner.StartAsync(run, _configPath);
 
         outcome.Status.Should().Be(RunStatus.Succeeded,
             "collector failures must not corrupt the run outcome");
@@ -480,7 +499,7 @@ public class HeadlessRunnerTests : IDisposable
 
         // Default _runner (constructed in the class ctor) has no
         // collector. Exercise it directly.
-        await _runner.StartAsync(run, "/tmp/x/config.json");
+        await _runner.StartAsync(run, _configPath);
 
         var entry = await _db.OutboxEntries.SingleAsync();
         using var doc = JsonDocument.Parse(entry.PayloadJson);
@@ -502,7 +521,7 @@ public class HeadlessRunnerTests : IDisposable
             _containers.Object, _db, _cancellation, _tokens.Object,
             NullLogger<HeadlessRunner>.Instance, collector.Object);
 
-        await runner.StartAsync(run, "/tmp/x/config.json");
+        await runner.StartAsync(run, _configPath);
 
         collector.Verify(
             c => c.CollectAsync(It.IsAny<Container>(), It.IsAny<CancellationToken>()),


### PR DESCRIPTION
## Summary
The four "last mile" fixes between *run container provisioned* and *andy-cli actually runs the model and edits files* in headless plan execution.

1. **HeadlessRunner — config staging.** The configurator writes the headless config to a HOST temp dir, but andy-cli runs *inside* the container where that path doesn't exist (`Config file not found: /var/folders/.../config.json`). Read the config on the host and base64-stage it into the container (`/tmp/andy-runs/{runId}/config.json`) as the first step of the same exec, so a single command's exit code is andy-cli's.
2. **GitCloneService — clone into pre-initialised workspace.** The container pre-initialises `/workspace` (empty git repo + run branch) before clone time, so `git clone <url> /workspace` failed with *"destination path already exists and is not empty"*. Clone into a throwaway temp dir, then merge the result (real `.git` included) into the target.
3. **StubAndyAgentsClient — drop broken MCP tool.** The coding role's `fs.patch` MCP tool pointed at a placeholder `mcp.internal` host that doesn't resolve and crashed the in-container agent on startup. File editing uses andy-cli's built-in tools; the coding role keeps the local `git` CLI.
4. **ContainerOrchestrationService — in-container model access.** An assistant-less headless run never set OpenAI client env. Point `OPENAI_BASE_URL`/`OPENAI_API_BASE` at the andy-models proxy (plain `v1` mount) and mint a per-container proxy token (`aud=urn:andy-models-api`, scoped to `Proxy:HeadlessModelSlugs`, default `deepseek-v4-flash`) as `OPENAI_API_KEY`, since the shared andy-containers M2M token (`aud=urn:andy-containers-api`) is rejected 401.

## Tests
70 passing across `HeadlessRunner` / `GitCloneService` / `StubAndyAgentsClient`, including new `StartAsync_StagesConfigIntoContainer_AndShellEscapesInContainerPath` and `GetAgentAsync_CodingRole_HasLocalGitOnly`.

## Risk / context
This is the final container-side layer of the real multi-task plan-execution demo (andy-rbac#84, andy-tasks#362, andy-models#79, andy-containers#342/#343 already merged). Not yet observed end-to-end in a live container — that's the next verification step after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)