### PR TITLE
[Fix] RunEventStream cursor query untranslatable on SQLite — run events never completed upstream

### DIFF
--- a/src/Andy.Containers.Api/Services/RunEventStream.cs
+++ b/src/Andy.Containers.Api/Services/RunEventStream.cs
@@ -45,19 +45,24 @@ public static class RunEventStream
         while (!ct.IsCancellationRequested)
         {
             // Fetch any new outbox rows for this run, ordered by creation.
-            // Cursor on CreatedAt + bounded batch + client-side ordering
-            // matches OutboxDispatcher's SQLite-friendly pattern (provider
-            // can't translate DateTimeOffset ORDER BY).
-            var query = db.OutboxEntries
+            // SQLite's EF provider can't translate DateTimeOffset operations:
+            // NEITHER the cursor comparison (`CreatedAt > x`) NOR ORDER BY.
+            // The subject-prefix filter IS translatable (→ LIKE), so scope
+            // server-side by prefix, then apply the cursor + ordering + batch
+            // bound CLIENT-side. A single run's outbox event count is small,
+            // so the client-eval is bounded. (Doing the cursor `Where` in the
+            // query throws "could not be translated" once cursor is set, which
+            // silently dropped every post-cursor event — including the
+            // terminal Succeeded/Failed — so the run never completed upstream.)
+            var rows = await db.OutboxEntries
                 .AsNoTracking()
-                .Where(e => e.Subject.StartsWith(subjectPrefix));
-            if (cursor is not null)
-            {
-                query = query.Where(e => e.CreatedAt > cursor.Value);
-            }
+                .Where(e => e.Subject.StartsWith(subjectPrefix))
+                .ToListAsync(ct);
 
-            var batch = (await query.Take(BatchSize).ToListAsync(ct))
+            var batch = rows
+                .Where(e => cursor is null || e.CreatedAt > cursor.Value)
                 .OrderBy(e => e.CreatedAt)
+                .Take(BatchSize)
                 .ToList();
 
             foreach (var entry in batch)

--- a/tests/Andy.Containers.Api.Tests/Services/RunEventStreamTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/RunEventStreamTests.cs
@@ -5,6 +5,7 @@ using Andy.Containers.Infrastructure.Messaging;
 using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Xunit;
 
 namespace Andy.Containers.Api.Tests.Services;
@@ -44,6 +45,53 @@ public class RunEventStreamTests : IDisposable
         collected[0].Subject.Should().Be($"andy.containers.events.run.{run.Id}.finished");
         collected[0].ExitCode.Should().Be(0);
         collected[0].DurationSeconds.Should().Be(1.5);
+    }
+
+    [Fact]
+    public async Task TerminalRun_OnRealSqlite_YieldsEventAndStopsWithoutTranslationError()
+    {
+        // Regression: the cursor advance (`CreatedAt > cursor`) is a
+        // DateTimeOffset comparison the SQLite EF provider CANNOT translate.
+        // After the first poll delivers the terminal event and sets the
+        // cursor, the drain poll re-runs the query WITH that cursor and the
+        // buggy code threw InvalidOperationException ("could not be
+        // translated") — which aborted the run.events stream so the terminal
+        // Succeeded/Failed event never reached the upstream executor and the
+        // task hung "Running" forever. The InMemory provider masks this (it
+        // evaluates any CLR predicate), so — like
+        // OutboxDispatcherTests.DrainOnceAsync_DoesNotCrashUnderSqlite — this
+        // runs RunEventStream against a REAL SQLite database.
+        using var connection = new Microsoft.Data.Sqlite.SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<ContainersDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        using var db = new ContainersDbContext(options);
+        await db.Database.EnsureCreatedAsync();
+
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "stream-test",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            Status = RunStatus.Succeeded,
+        };
+        db.Runs.Add(run);
+        db.AppendAgentRunEvent(run, RunEventKind.Finished, exitCode: 0, durationSeconds: 1.5);
+        await db.SaveChangesAsync();
+
+        var collected = new List<RunEventDto>();
+        await foreach (var evt in RunEventStream.AsyncEnumerate(db, run.Id, FastPoll))
+        {
+            collected.Add(evt);
+        }
+
+        collected.Should().ContainSingle();
+        collected[0].Subject.Should().Be($"andy.containers.events.run.{run.Id}.finished");
+        collected[0].ExitCode.Should().Be(0);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
`RunEventStream.AsyncEnumerate` built its cursor filter `.Where(e => e.CreatedAt > cursor.Value)` inside the `IQueryable`. `CreatedAt` is a `DateTimeOffset`, which the **SQLite EF provider cannot translate** (the same limitation the file's own comment already notes for `DateTimeOffset` ORDER BY).

After the first poll delivered the terminal event and set the cursor, the **drain poll** re-ran the query *with* the cursor and threw `InvalidOperationException` ("could not be translated"). That aborted the `GET /api/runs/{id}/events` stream, so the terminal `Succeeded`/`Failed` event **never reached the upstream andy-tasks `PlanExecutor`** — the task hung `Running` forever even though the container run had already exited 0.

Discovered while driving real multi-task plan execution end-to-end: a research-agent run `Succeeded` (exit 0) in andy-containers but its task stayed `Running` in andy-tasks. Root cause was this lost run-completion event.

## Fix
Keep the translatable subject-prefix filter server-side (→ `LIKE`), then apply the cursor + ordering + batch bound **client-side**. A single run's outbox event volume is small, so the client-eval is bounded.

## Tests
The existing `RunEventStreamTests` used the EF **InMemory** provider, which evaluates any CLR predicate and so masked the bug. Added `TerminalRun_OnRealSqlite_YieldsEventAndStopsWithoutTranslationError` against a **real SQLite** DB (mirroring `OutboxDispatcherTests.DrainOnceAsync_DoesNotCrashUnderSqlite`):
- **Fails** on the old code with the exact `could not be translated` error.
- **Passes** on the fix.
- All 6 RunEventStream tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)