### PR TITLE
[Fix] NATS: don't provision overlapping stream in shared-broker daemon (tasks hung Running)

### DIFF
--- a/src/Andy.Containers.Infrastructure/Messaging/NatsOptions.cs
+++ b/src/Andy.Containers.Infrastructure/Messaging/NatsOptions.cs
@@ -12,4 +12,15 @@ public sealed class NatsOptions
     public string[] StreamSubjects { get; set; } = ["andy.>"];
     public TimeSpan MaxAge { get; set; } = TimeSpan.FromDays(7);
     public string DlqPrefix { get; set; } = "andy.containers.dlq";
+
+    /// When false, this service does NOT provision its JetStream stream on
+    /// boot and relies on a peer that already owns a stream covering its
+    /// subjects — the embedded/shared-broker daemon, where andy-tasks owns
+    /// ANDY_PROGRESS (andy.containers.events.run/container.>) + ANDY_DOMAIN.
+    /// Default true preserves standalone behaviour where this service owns
+    /// its stream. A scalar bool so it binds reliably from
+    /// `Messaging__Nats__ProvisionStream` (env array binding for
+    /// StreamSubjects is unreliable, so the embedded daemon flips this flag
+    /// rather than trying to override the subjects to match the peer).
+    public bool ProvisionStream { get; set; } = true;
 }

--- a/src/Andy.Containers.Infrastructure/Messaging/NatsStreamProvisioner.cs
+++ b/src/Andy.Containers.Infrastructure/Messaging/NatsStreamProvisioner.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using NATS.Client.JetStream;
 using NATS.Client.JetStream.Models;
 
 namespace Andy.Containers.Infrastructure.Messaging;
@@ -23,16 +24,55 @@ public sealed class NatsStreamProvisioner(
         await bus.ConnectAsync(ct);
 
         var opts = options.Value;
+
+        if (!opts.ProvisionStream)
+        {
+            // Embedded/shared-broker daemon: a peer (andy-tasks) owns the
+            // stream that covers our subjects. Don't provision — just stay
+            // connected and publish; the OutboxDispatcher retries any rows
+            // that race ahead of the peer's stream creation. Avoids the
+            // same-startup-wave race where this service would otherwise
+            // create a broad `andy.>` stream that blocks the peer's
+            // narrower ANDY_PROGRESS / ANDY_DOMAIN provisioning.
+            logger.LogInformation(
+                "NATS JetStream provisioning skipped (ProvisionStream=false); " +
+                "publishing to peer-owned streams.");
+            return;
+        }
+
         var config = new StreamConfig(opts.StreamName, opts.StreamSubjects)
         {
             MaxAge = opts.MaxAge
         };
 
-        await bus.JetStream.CreateOrUpdateStreamAsync(config, ct);
+        try
+        {
+            await bus.JetStream.CreateOrUpdateStreamAsync(config, ct);
 
-        logger.LogInformation(
-            "NATS JetStream stream {Stream} provisioned with subjects [{Subjects}]",
-            opts.StreamName, string.Join(", ", opts.StreamSubjects));
+            logger.LogInformation(
+                "NATS JetStream stream {Stream} provisioned with subjects [{Subjects}]",
+                opts.StreamName, string.Join(", ", opts.StreamSubjects));
+        }
+        catch (NatsJSApiException ex) when (
+            ex.Error.Code == 400 &&
+            (ex.Error.Description?.Contains("overlap", StringComparison.OrdinalIgnoreCase) ?? false))
+        {
+            // A PEER service (e.g. andy-tasks, which owns ANDY_PROGRESS +
+            // ANDY_DOMAIN) has already provisioned a stream whose subjects
+            // cover ours. JetStream forbids two streams with overlapping
+            // subjects, so our CreateOrUpdate is rejected — but the existing
+            // stream already captures everything we publish
+            // (`andy.containers.events.>`), so publishing still works. In a
+            // shared-broker (embedded daemon) deployment this is the EXPECTED
+            // steady state, not an error: swallow it so andy-containers does
+            // not crash-loop on startup. (Standalone deployments where this
+            // service owns its stream still create it on first boot.)
+            logger.LogInformation(
+                "NATS JetStream stream {Stream} not provisioned: its subjects [{Subjects}] " +
+                "overlap a peer-owned stream that already covers them — publishing to the " +
+                "existing stream. ({Detail})",
+                opts.StreamName, string.Join(", ", opts.StreamSubjects), ex.Error.Description);
+        }
     }
 
     public Task StopAsync(CancellationToken ct) => Task.CompletedTask;


### PR DESCRIPTION
## Summary
Root cause of every dispatched plan-execution task hanging `Running` forever in the embedded daemon.

andy-containers' messaging defaulted to **InMemory**, so its `andy.containers.events.run.*` outbox events never reached the shared NATS broker and the andy-tasks `ConductorExecutor`'s durable JetStream consumer waited forever. Flipping andy-containers to `Messaging:Provider=Nats` (conductor side) then exposed a second bug: its `NatsStreamProvisioner` tried to provision its default `"ANDY"` stream over `andy.>`, which **overlaps** the `ANDY_PROGRESS` (`andy.containers.events.run/container.>`) + `ANDY_DOMAIN` streams that andy-tasks owns. JetStream rejects overlapping subjects, so andy-containers crash-looped (`Hosting failed to start: subject "andy.>" overlaps with "andy.containers.events.run.>"`). Both services start in the same wave, so it was also a race — if andy-containers won, its broad stream blocked andy-tasks' narrower `ANDY_PROGRESS` and broke the executor's consumers.

## Changes (opt-in, backward compatible)
- **`NatsOptions.ProvisionStream`** (default `true`) — a **scalar bool** that binds reliably from `Messaging__Nats__ProvisionStream` (env array binding for `StreamSubjects` is unreliable, so the embedded daemon flips this instead of overriding subjects). When `false`, the provisioner stays connected but does **not** create a stream; publishes route to the peer-owned stream and the `OutboxDispatcher` retries rows that race ahead of the peer's stream creation.
- **Tolerant provisioner** — when it does provision, it now swallows the JetStream `400 "subjects overlap"` error (a peer already owns a covering stream). Standalone deployments (default `true`, no peer) still create their stream on first boot unchanged.

## Verification (live, embedded daemon)
With `Messaging__Nats__ProvisionStream=false` set by conductor: andy-containers boots clean (`NATS JetStream provisioning skipped (ProvisionStream=false); publishing to peer-owned streams`), run events land in `ANDY_PROGRESS`, and a dispatched plan-execution task progressed `Running → WaitingHuman` — the run-completion event reached the executor for the first time (previously hung `Running` indefinitely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)