### PR TITLE
[Feat] Make the coding agent capable — shell edit tool + task objective in prompt

### DIFF
--- a/src/Andy.Containers.Api/Controllers/RunsController.cs
+++ b/src/Andy.Containers.Api/Controllers/RunsController.cs
@@ -94,6 +94,9 @@ public class RunsController : ControllerBase
                 },
             PolicyId = request.PolicyId,
             CorrelationId = request.CorrelationId ?? Guid.NewGuid(),
+            // Transient (NotMapped): consumed by the configurator at create-time
+            // to bake the task into the headless agent's system prompt.
+            Objective = request.Objective,
             Status = RunStatus.Pending,
             CreatedAt = now,
             UpdatedAt = now,

--- a/src/Andy.Containers.Api/Services/StubAndyAgentsClient.cs
+++ b/src/Andy.Containers.Api/Services/StubAndyAgentsClient.cs
@@ -35,7 +35,13 @@ public sealed class StubAndyAgentsClient : IAndyAgentsClient
     {
         Provider = "openai",
         Id = "deepseek-v4-flash",
-        ApiKeyRef = "env:ANDY_SERVICE_TOKEN",
+        // The in-container OpenAI-dialect client reads its bearer from
+        // OPENAI_API_KEY — andy-containers injects a per-container proxy token
+        // there (aud=urn:andy-models-api) alongside OPENAI_BASE_URL pointed at
+        // the andy-models proxy. (The shared ANDY_SERVICE_TOKEN is
+        // aud=urn:andy-containers-api and the proxy rejects it 401, so the key
+        // ref must name OPENAI_API_KEY, not ANDY_SERVICE_TOKEN.)
+        ApiKeyRef = "env:OPENAI_API_KEY",
     };
 
     // Per-role presentation. Keyed by the andy-agents slug the planner emits;
@@ -49,7 +55,7 @@ public sealed class StubAndyAgentsClient : IAndyAgentsClient
                 "json-plan-v1", new[] { "draft-only" }, 120, 900),
             ["research"] = ("You are the research agent. Gather the context the plan needs and summarise it.",
                 "plain", new[] { "read-only" }, 120, 900),
-            ["coding"] = ("You are the coding agent. Implement the assigned TaskNode against the delegation contract, editing files in /workspace and leaving the change on a branch for human review.",
+            ["coding"] = ("You are the coding agent working inside a sandboxed container. Your repository is checked out at /workspace (the current working directory). Implement the task described below by EDITING FILES — do not ask the user for clarification; you already have everything you need, so act. Use the `shell` tool to inspect and modify files: pass a single bash command string as the args element, e.g. `cat README.md`, `ls`, or a heredoc/printf/sed to write changes (the command runs as `bash -c \"<your string>\"` in /workspace). Use `git` for diff/branch/commit. Make the minimal change that satisfies the task, verify it by reading the file back, then stop. Keep your edits on the working tree for human review.",
                 "plain", new[] { "write-branch", "sandboxed" }, 400, 3600),
             ["review"] = ("You are the review agent. Inspect the diff produced by the coding task for safety and correctness; do not modify files.",
                 "plain", new[] { "read-only" }, 200, 1800),
@@ -80,14 +86,29 @@ public sealed class StubAndyAgentsClient : IAndyAgentsClient
             return Task.FromResult<AgentSpec?>(null);
         }
 
-        // The coding role gets the local `git` CLI for branch/diff work;
-        // file editing uses andy-cli's BUILT-IN tools (no external MCP server).
-        // Everyone else is read-only with no tools. (The previous fs.patch MCP
-        // tool pointed at a placeholder `mcp.internal` host that doesn't
-        // resolve, which crashed the in-container agent on startup.)
+        // The coding role gets a `shell` tool (the agent's actual file-editing
+        // capability) plus the local `git` CLI for branch/diff work. Everyone
+        // else is read-only with no tools.
+        //
+        // andy-cli headless registers NO built-in file tools — the agent's
+        // entire tool surface is exactly what's declared here (HeadlessToolHost
+        // only wires `cli`/`mcp` transports). So a coding agent with only `git`
+        // literally cannot write files; it needs an exec capability. `shell`
+        // maps to `bash -c <script>` via CliSubprocessTool (the LLM supplies the
+        // script as a single `args` element), which is how andy-cli edits files
+        // in the sandboxed container. (The earlier fs.patch MCP tool pointed at
+        // a placeholder `mcp.internal` host that didn't resolve and crashed the
+        // agent on startup; a shell tool needs no external server.)
         var tools = key == "coding"
             ? new[]
             {
+                new AgentSpecTool
+                {
+                    Name = "shell",
+                    Transport = "cli",
+                    Binary = "bash",
+                    Command = new[] { "bash", "-c" },
+                },
                 new AgentSpecTool { Name = "git", Transport = "cli", Binary = "git", Command = new[] { "git" } },
             }
             : Array.Empty<AgentSpecTool>();

--- a/src/Andy.Containers/Configurator/HeadlessConfigBuilder.cs
+++ b/src/Andy.Containers/Configurator/HeadlessConfigBuilder.cs
@@ -51,6 +51,15 @@ public sealed class HeadlessConfigBuilder : IHeadlessConfigBuilder
 
         var tools = agent.Tools.Select(MapTool).ToList();
 
+        // andy-cli uses Agent.Instructions as the SYSTEM PROMPT and hands the
+        // agent a fixed "Begin." kickoff — so the concrete task objective MUST
+        // be baked into the instructions or the model has nothing to act on
+        // (it asks for clarification and edits nothing). The AgentSpec carries
+        // only the generic role prompt; the per-run objective lives on the
+        // Run (forwarded from the andy-tasks TaskNode's delegation contract).
+        // Compose: role instructions + the concrete task.
+        var instructions = ComposeInstructions(agent.Instructions, run.Objective);
+
         return new HeadlessRunConfig
         {
             SchemaVersion = 1,
@@ -59,7 +68,7 @@ public sealed class HeadlessConfigBuilder : IHeadlessConfigBuilder
             {
                 Slug = agent.Slug,
                 Revision = agent.Revision,
-                Instructions = agent.Instructions,
+                Instructions = instructions,
                 OutputFormat = agent.OutputFormat,
             },
             Model = new HeadlessModel
@@ -191,6 +200,22 @@ public sealed class HeadlessConfigBuilder : IHeadlessConfigBuilder
         // Re-join from the validated segments so the stager works against
         // a canonical, collapsed relative path.
         return string.Join('/', segments);
+    }
+
+    // Compose the agent's generic role prompt with the concrete per-run task
+    // objective into a single system prompt. When no objective is supplied
+    // (e.g. a read-only role, or a caller that didn't forward one) the role
+    // instructions stand alone — preserving the prior behaviour.
+    internal static string ComposeInstructions(string roleInstructions, string? objective)
+    {
+        if (string.IsNullOrWhiteSpace(objective))
+        {
+            return roleInstructions;
+        }
+
+        return roleInstructions
+            + "\n\n## Task\n"
+            + objective.Trim();
     }
 
     private static HeadlessTool MapTool(AgentSpecTool tool)

--- a/src/Andy.Containers/Models/Run.cs
+++ b/src/Andy.Containers/Models/Run.cs
@@ -79,6 +79,23 @@ public class Run
     public IReadOnlyList<RunInput>? Inputs { get; set; }
 
     /// <summary>
+    /// The concrete task objective for this run — the andy-tasks TaskNode's
+    /// delegation-contract objective, forwarded on the create request. The
+    /// configurator bakes it into the headless agent's system prompt
+    /// (<c>HeadlessConfigBuilder.ComposeInstructions</c>) so the in-container
+    /// agent acts on the actual task rather than the generic role prompt.
+    /// <para>
+    /// Not persisted (<c>[NotMapped]</c>): it's consumed at create-time, when
+    /// the configurator builds the headless config from the in-memory run, so
+    /// no schema change is needed. (A configurator RETRY that re-loads the run
+    /// from the DB would not see it — persisting it is a follow-up if retry
+    /// fidelity is required.)
+    /// </para>
+    /// </summary>
+    [System.ComponentModel.DataAnnotations.Schema.NotMapped]
+    public string? Objective { get; set; }
+
+    /// <summary>
     /// Transition the run to <paramref name="next"/> according to AP1's state-machine
     /// invariants. Throws <see cref="InvalidOperationException"/> for illegal
     /// transitions so callers cannot silently corrupt history.

--- a/src/Andy.Containers/Models/RunDtos.cs
+++ b/src/Andy.Containers/Models/RunDtos.cs
@@ -30,6 +30,15 @@ public class CreateRunRequest
     /// controller mints a fresh root id so every Run still has a chain anchor.
     /// </summary>
     public Guid? CorrelationId { get; set; }
+
+    /// <summary>
+    /// The concrete task objective (the andy-tasks TaskNode's
+    /// delegation-contract objective). The configurator bakes it into the
+    /// headless agent's system prompt so the in-container agent acts on the
+    /// actual task, not just its generic role prompt. Optional — omitted for
+    /// runs with no task context (the agent then sees only the role prompt).
+    /// </summary>
+    public string? Objective { get; set; }
 }
 
 public class WorkspaceRefRequest

--- a/tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigBuilderTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigBuilderTests.cs
@@ -57,6 +57,39 @@ public class HeadlessConfigBuilderTests
     }
 
     [Fact]
+    public void Build_WithObjective_BakesTaskIntoSystemPrompt()
+    {
+        // andy-cli uses Agent.Instructions as the system prompt + a fixed
+        // "Begin." kickoff, so the concrete task must be inside the
+        // instructions or the agent has nothing to act on. The per-run
+        // objective (forwarded from the andy-tasks delegation contract) must
+        // be appended to the agent's generic role prompt.
+        var run = SeedRun();
+        run.Objective = "Add a Quick Start section to README.md.";
+        var spec = TriageAgent();
+
+        var config = _builder.Build(run, spec);
+
+        config.Agent.Instructions.Should().Contain(spec.Instructions,
+            "the generic role prompt is preserved");
+        config.Agent.Instructions.Should().Contain("Add a Quick Start section to README.md.",
+            "the concrete task objective must be baked into the system prompt");
+    }
+
+    [Fact]
+    public void Build_WithoutObjective_LeavesRoleInstructionsUnchanged()
+    {
+        // A run with no objective (read-only role, or a caller that didn't
+        // forward one) keeps exactly the role prompt — no trailing scaffolding.
+        var run = SeedRun(); // Objective null
+        var spec = TriageAgent();
+
+        var config = _builder.Build(run, spec);
+
+        config.Agent.Instructions.Should().Be(spec.Instructions);
+    }
+
+    [Fact]
     public void Build_EmptyInstructions_Throws()
     {
         var run = SeedRun();

--- a/tests/Andy.Containers.Api.Tests/Configurator/StubAndyAgentsClientTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Configurator/StubAndyAgentsClientTests.cs
@@ -34,17 +34,25 @@ public class StubAndyAgentsClientTests
         // allow-list would reject.
         spec.Model.Provider.Should().Be("openai");
         spec.Model.Id.Should().Be("deepseek-v4-flash");
-        spec.Model.ApiKeyRef.Should().Be("env:ANDY_SERVICE_TOKEN");
+        // The OpenAI-dialect client reads its bearer from OPENAI_API_KEY (the
+        // per-container aud=urn:andy-models-api proxy token), NOT the shared
+        // ANDY_SERVICE_TOKEN (aud=urn:andy-containers-api, rejected 401).
+        spec.Model.ApiKeyRef.Should().Be("env:OPENAI_API_KEY");
     }
 
     [Fact]
-    public async Task GetAgentAsync_CodingRole_HasLocalGitOnly()
+    public async Task GetAgentAsync_CodingRole_HasShellAndGitTools()
     {
         var spec = await _client.GetAgentAsync("coding", revision: null);
 
-        // git is a local CLI tool; file editing uses andy-cli's built-ins.
-        // No external MCP tools (a placeholder endpoint would crash the agent).
-        spec!.Tools.Should().Contain(t => t.Name == "git" && t.Transport == "cli");
+        // The coding agent's actual file-editing capability is the `shell`
+        // tool (bash -c via CliSubprocessTool) — andy-cli headless registers NO
+        // built-in file tools, so without an exec tool the agent cannot write
+        // files. `git` is kept for branch/diff/commit. All local CLI; no
+        // external MCP (a placeholder endpoint would crash the agent).
+        spec!.Tools.Should().Contain(t => t.Name == "shell" && t.Transport == "cli"
+            && t.Binary == "bash");
+        spec.Tools.Should().Contain(t => t.Name == "git" && t.Transport == "cli");
         spec.Tools.Should().OnlyContain(t => t.Transport == "cli");
     }
 


### PR DESCRIPTION
## Summary
With the human-verification gate now passable (andy-auth#114), the coding task dispatches and andy-cli runs — but **edits nothing**. Three gaps in the agent's headless config, all fixed here:

1. **No file-edit tool.** andy-cli headless registers **no** built-in tools (`HeadlessToolHost` wires only `cli`/`mcp` transports), so a coding agent with just `git` literally cannot write files. Add a **`shell`** CLI tool (`bash -c <script>` via `CliSubprocessTool`) — the agent's actual edit capability in the sandboxed container; keep `git` for branch/diff.
2. **Generic prompt, no task.** andy-cli uses `Agent.Instructions` as the **system prompt** + a fixed `"Begin."` kickoff, so the concrete objective must be *in* the instructions or the model asks for clarification and edits nothing (observed: *"As the research agent… please provide the plan's objective"*). The per-run objective now rides `CreateRunRequest.Objective` → `Run.Objective` (`[NotMapped]`, consumed at create-time from the in-memory run — no schema change) and `HeadlessConfigBuilder.ComposeInstructions` bakes it into the prompt. **Requires andy-tasks companion PR** to forward it.
3. **Wrong model token ref.** `ProxyModel.ApiKeyRef` was `env:ANDY_SERVICE_TOKEN` (aud=`urn:andy-containers-api`, rejected 401 by the andy-models proxy); now `env:OPENAI_API_KEY` (the per-container aud=`urn:andy-models-api` token #344 injects).

Coding-role instructions also made directive (use `shell`, don't ask, minimal change, verify by reading back).

## Tests
- `StubAndyAgentsClientTests` — coding has shell+git; `ApiKeyRef == env:OPENAI_API_KEY`.
- `HeadlessConfigBuilderTests` +2 — objective baked into the system prompt; absent objective leaves the role prompt unchanged.
- 45 configurator tests green incl. the golden-file (unaffected — objective null there).

Companion: andy-tasks PR (forwards `DelegationContract.Objective` on the run request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)