### PR TITLE
[AX.1] andy-containers: resolve agent from andy-agents (replace stub)

### DIFF
--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -388,10 +388,69 @@ try
     builder.Services.AddContainersMessaging(builder.Configuration);
 
     // AP3 (rivoli-ai/andy-containers#105). Configurator pipeline:
-    // andy-agents lookup (stubbed until Epic W lands) → headless-config
-    // builder → on-disk writer. RunsController invokes the facade after
-    // persisting a Pending Run. AP6 picks the file up to spawn andy-cli.
-    builder.Services.AddSingleton<IAndyAgentsClient, StubAndyAgentsClient>();
+    // andy-agents lookup → headless-config builder → on-disk writer.
+    // RunsController invokes the facade after persisting a Pending Run.
+    // AP6 picks the file up to spawn andy-cli.
+    //
+    // AX.1 (rivoli-ai/conductor#2088). The REAL andy-agents-backed resolver
+    // (AndyAgentsHttpClient) is the default whenever AndyAgents:ApiBaseUrl is
+    // set — andy-agents becomes the source of truth for agent instructions +
+    // model. When the base URL is empty (dev / embedded mode with no agents
+    // service reachable) we fall back to the in-process StubAndyAgentsClient,
+    // mirroring the AndyDocs wiring posture so startup never fails. Tools are
+    // NOT sourced from andy-agents — they're built into the in-container
+    // assistant (the spec's Tools is always empty); the permission allow-list
+    // is AX.3/AX.4.
+    builder.Services.Configure<AndyAgentsOptions>(
+        builder.Configuration.GetSection(AndyAgentsOptions.SectionName));
+    var agentsBaseUrl = builder.Configuration[$"{AndyAgentsOptions.SectionName}:ApiBaseUrl"];
+    if (!string.IsNullOrWhiteSpace(agentsBaseUrl))
+    {
+        var agentsOptions = builder.Configuration
+            .GetSection(AndyAgentsOptions.SectionName)
+            .Get<AndyAgentsOptions>() ?? new AndyAgentsOptions();
+        var agentsBuilder = builder.Services.AddHttpClient(AndyAgentsHttpClient.HttpClientName, client =>
+        {
+            // Trailing slash so URI resolution preserves any path prefix
+            // (e.g. embedded mode where the base is .../9100/agents).
+            client.BaseAddress = new Uri(agentsBaseUrl.TrimEnd('/') + "/");
+            client.Timeout = agentsOptions.Timeout;
+        });
+        // Attach the M2M bearer (aud=urn:andy-agents-api) when AndyAuth is
+        // configured. In bypass mode (Authority empty) the client is anonymous,
+        // mirroring the AndyDocs / inbound JWT-bearer postures.
+        var agentsAuthority = builder.Configuration["AndyAuth:Authority"];
+        if (!string.IsNullOrWhiteSpace(agentsAuthority))
+        {
+            var audience = agentsOptions.Audience;
+            agentsBuilder.AddHttpMessageHandler(sp =>
+            {
+                var tokens = sp.GetRequiredService<IServiceTokenService>();
+                var logger = sp.GetService<ILogger<ServiceBearerHandler>>();
+                return new ServiceBearerHandler(
+                    async ct =>
+                    {
+                        try
+                        {
+                            return await tokens.GetAccessTokenAsync(audience, ct);
+                        }
+                        catch (ServiceTokenException)
+                        {
+                            // Surface as "no token" — the handler sends
+                            // anonymously and andy-agents replies 401, which
+                            // the client raises as a clear resolution error.
+                            return null;
+                        }
+                    },
+                    logger);
+            });
+        }
+        builder.Services.AddSingleton<IAndyAgentsClient, AndyAgentsHttpClient>();
+    }
+    else
+    {
+        builder.Services.AddSingleton<IAndyAgentsClient, StubAndyAgentsClient>();
+    }
     builder.Services.AddSingleton<IHeadlessConfigBuilder, HeadlessConfigBuilder>();
     builder.Services.AddSingleton<IHeadlessConfigWriter, HeadlessConfigWriter>();
     builder.Services.AddScoped<IRunConfigurator, RunConfigurator>();

--- a/src/Andy.Containers.Api/Services/AndyAgentsHttpClient.cs
+++ b/src/Andy.Containers.Api/Services/AndyAgentsHttpClient.cs
@@ -1,0 +1,310 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Andy.Containers.Configurator;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// AX.1 (rivoli-ai/conductor#2088). Real HTTP client for the andy-agents
+/// service. Replaces <see cref="StubAndyAgentsClient"/> as the default
+/// <see cref="IAndyAgentsClient"/> whenever <c>AndyAgents:ApiBaseUrl</c> is
+/// configured. andy-agents becomes the source of truth for an agent's
+/// INSTRUCTIONS and MODEL.
+///
+/// <para>
+/// Wire contract (consumed, never modified here):
+/// <c>GET /api/agents/by-slug/{slug}</c> → <c>AgentDto</c> JSON, requiring an
+/// M2M bearer minted for audience <c>urn:andy-agents-api</c> (permission
+/// <c>andy-agents:agent:read</c>). The bearer is attached by the named
+/// HttpClient's <c>ServiceBearerHandler</c> (wired in <c>Program.cs</c>) — this
+/// client itself is auth-agnostic.
+/// </para>
+///
+/// <para>
+/// <strong>Tools are intentionally NOT sourced here.</strong> The in-container
+/// code assistant ships with its own built-in tool surface; the resolved
+/// <see cref="AgentSpec.Tools"/> is always EMPTY. The permission allow-list
+/// that gates those built-ins is AX.3/AX.4, not this slice. (andy-agents'
+/// <c>ToolIds</c> are ignored.)
+/// </para>
+///
+/// <para>
+/// <strong>Failure contract:</strong> a 404 (unknown slug) maps to
+/// <c>null</c> so the caller surfaces a clean 404-equivalent; any other
+/// non-success status, transport error, or unparseable body throws a clear
+/// <see cref="AndyAgentsResolutionException"/> — run configuration must NOT
+/// proceed with a half-resolved agent.
+/// </para>
+/// </summary>
+public sealed class AndyAgentsHttpClient : IAndyAgentsClient
+{
+    /// <summary>Named HttpClient registered in DI; tests can override.</summary>
+    public const string HttpClientName = "andy-agents";
+
+    // Forced model wiring. The in-container assistant talks to Conductor's
+    // embedded andy-models proxy, which speaks the OpenAI dialect and reads
+    // its bearer from OPENAI_API_KEY (a per-container aud=urn:andy-models-api
+    // proxy token). So regardless of what provider andy-agents records, the
+    // resolved spec ALWAYS declares the OpenAI dialect + the OPENAI_API_KEY
+    // ref. ("openai" is in HeadlessConfigBuilder's allow-list.)
+    private const string ForcedProvider = "openai";
+    private const string ForcedApiKeyRef = "env:OPENAI_API_KEY";
+
+    // andy-agents uses ASP.NET's default camelCase web JSON options for its
+    // response bodies. Pin a dedicated options object (with enum-as-string,
+    // since AgentDto.Status is an enum) so the deserialiser is independent of
+    // any process-wide defaults.
+    private static readonly JsonSerializerOptions AgentsResponseJson =
+        new(JsonSerializerDefaults.Web)
+        {
+            Converters = { new JsonStringEnumConverter() },
+        };
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly AndyAgentsOptions _options;
+    private readonly ILogger<AndyAgentsHttpClient> _logger;
+
+    public AndyAgentsHttpClient(
+        IHttpClientFactory httpClientFactory,
+        IOptions<AndyAgentsOptions> options,
+        ILogger<AndyAgentsHttpClient> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<AgentSpec?> GetAgentAsync(
+        string agentSlug, int? revision, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(agentSlug))
+        {
+            return null;
+        }
+
+        var http = _httpClientFactory.CreateClient(HttpClientName);
+        var path = $"api/agents/by-slug/{Uri.EscapeDataString(agentSlug)}";
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await http.GetAsync(path, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            throw new AndyAgentsResolutionException(
+                $"andy-agents resolve for slug '{agentSlug}' failed: {ex.Message}", ex);
+        }
+
+        using (response)
+        {
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                _logger.LogInformation(
+                    "andy-agents has no agent for slug {Slug} (404) — resolving to null.", agentSlug);
+                return null;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var body = await SafeReadAsync(response.Content, ct).ConfigureAwait(false);
+                throw new AndyAgentsResolutionException(
+                    $"andy-agents resolve for slug '{agentSlug}' returned HTTP " +
+                    $"{(int)response.StatusCode} ({response.StatusCode}). Body preview: {Truncate(body, 200)}");
+            }
+
+            AgentDtoWire? dto;
+            try
+            {
+                dto = await response.Content
+                    .ReadFromJsonAsync<AgentDtoWire>(AgentsResponseJson, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is JsonException or NotSupportedException)
+            {
+                throw new AndyAgentsResolutionException(
+                    $"andy-agents resolve for slug '{agentSlug}' succeeded with HTTP " +
+                    $"{(int)response.StatusCode} but the response body was unparseable.", ex);
+            }
+
+            if (dto is null)
+            {
+                throw new AndyAgentsResolutionException(
+                    $"andy-agents resolve for slug '{agentSlug}' returned an empty body.");
+            }
+
+            return MapToAgentSpec(dto, revision, _options);
+        }
+    }
+
+    /// <summary>
+    /// Pure, side-effect-free mapping from the andy-agents <see cref="AgentDtoWire"/>
+    /// to the configurator's <see cref="AgentSpec"/>. Extracted so the mapping
+    /// rules (forced provider/key, model-id derivation, empty tools, limits) are
+    /// unit-testable without an HTTP round-trip.
+    ///
+    /// <para>Mapping decisions:</para>
+    /// <list type="bullet">
+    /// <item><c>Slug</c> ← <c>Name</c>; <c>Revision</c> ← the caller's pin
+    /// (andy-agents does not version specs over this endpoint yet).</item>
+    /// <item><c>Instructions</c> ← <c>SystemPrompt</c>; returns <c>null</c> when
+    /// the prompt is empty/whitespace — an instruction-less agent is not
+    /// runnable, so the caller treats null as "no usable agent".</item>
+    /// <item><c>Model.Provider</c> is FORCED to <c>openai</c> and
+    /// <c>Model.ApiKeyRef</c> to <c>env:OPENAI_API_KEY</c> (the proxy dialect /
+    /// per-container key), independent of andy-agents' recorded provider.</item>
+    /// <item><c>Model.Id</c> is the model the proxy knows: from
+    /// <c>ModelPreferences.Preferences[0].Slug</c> take the segment after the
+    /// last '/' if present ("deepseek/deepseek-v4-flash" → "deepseek-v4-flash"),
+    /// else the whole slug; falling back to <c>ModelName</c> when there is no
+    /// usable pinned preference.</item>
+    /// <item><c>Tools</c> is EMPTY (built-ins live in the assistant; AX.3/AX.4
+    /// own the permission allow-list).</item>
+    /// <item><c>Boundaries</c> null; <c>Limits</c> from the options-configurable
+    /// defaults (per-agent limits are a later slice).</item>
+    /// </list>
+    /// </summary>
+    /// <returns>
+    /// The mapped spec, or <c>null</c> when <see cref="AgentDtoWire.SystemPrompt"/>
+    /// is empty (no usable instructions).
+    /// </returns>
+    public static AgentSpec? MapToAgentSpec(AgentDtoWire dto, int? revision, AndyAgentsOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (string.IsNullOrWhiteSpace(dto.SystemPrompt))
+        {
+            // No instructions → not a runnable agent. Treat as "no agent" so the
+            // caller (RunConfigurator) maps it to a 404-equivalent rather than
+            // dispatching a prompt-less run.
+            return null;
+        }
+
+        var slug = string.IsNullOrWhiteSpace(dto.Name) ? "agent" : dto.Name;
+        var modelId = DeriveModelId(dto);
+
+        return new AgentSpec
+        {
+            Slug = slug,
+            Revision = revision,
+            Instructions = dto.SystemPrompt,
+            OutputFormat = null,
+            Model = new AgentSpecModel
+            {
+                Provider = ForcedProvider,
+                Id = modelId,
+                ApiKeyRef = ForcedApiKeyRef,
+            },
+            Tools = Array.Empty<AgentSpecTool>(),
+            EnvVars = null,
+            Boundaries = null,
+            Limits = new AgentSpecLimits
+            {
+                MaxIterations = options.DefaultMaxIterations,
+                TimeoutSeconds = options.DefaultTimeoutSeconds,
+            },
+        };
+    }
+
+    /// <summary>
+    /// Resolves the model id the andy-models proxy knows. Preference order:
+    /// the first pinned preference slug (with any provider prefix stripped),
+    /// then <see cref="AgentDtoWire.ModelName"/>. The provider-prefix strip
+    /// turns andy-models routing slugs like "deepseek/deepseek-v4-flash" into
+    /// the bare "deepseek-v4-flash" the OpenAI-dialect proxy registers.
+    /// </summary>
+    public static string DeriveModelId(AgentDtoWire dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        var pinnedSlug = dto.ModelPreferences?.Preferences?
+            .Select(p => p?.Slug)
+            .FirstOrDefault(s => !string.IsNullOrWhiteSpace(s));
+
+        var raw = !string.IsNullOrWhiteSpace(pinnedSlug) ? pinnedSlug! : dto.ModelName;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            // Last-resort: andy-agents always carries a ModelName, but be
+            // defensive so a malformed DTO never produces an empty model id.
+            return "default";
+        }
+
+        var stripped = StripProviderPrefix(raw);
+        return string.IsNullOrWhiteSpace(stripped) ? raw : stripped;
+    }
+
+    // "deepseek/deepseek-v4-flash" → "deepseek-v4-flash"; "gpt-4o" → "gpt-4o".
+    // Only the segment after the LAST '/' is kept.
+    private static string StripProviderPrefix(string slug)
+    {
+        var idx = slug.LastIndexOf('/');
+        return idx >= 0 && idx + 1 < slug.Length ? slug[(idx + 1)..] : slug;
+    }
+
+    private static async Task<string> SafeReadAsync(HttpContent content, CancellationToken ct)
+    {
+        try
+        {
+            return await content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    private static string? Truncate(string? value, int max)
+    {
+        if (string.IsNullOrEmpty(value)) return value;
+        return value.Length <= max ? value : value[..max] + "...";
+    }
+
+    /// <summary>
+    /// Local read-only view of andy-agents' <c>AgentDto</c>
+    /// (<c>GET /api/agents/by-slug/{slug}</c>). Only the fields AX.1 consumes
+    /// are modelled — instructions (<see cref="SystemPrompt"/>), model
+    /// (<see cref="ModelName"/> + <see cref="ModelPreferences"/>) and the
+    /// echoed <see cref="Name"/>. The rest of the wire shape (id, providerId,
+    /// temperature, maxTokens, status, toolIds, skills, allowedEnvironments, …)
+    /// is present on the wire but deliberately unmodelled so the local record
+    /// stays minimal and decoupled from andy-agents' build graph. The contract
+    /// is duplicated, not referenced — the two services share no code.
+    /// </summary>
+    public sealed record AgentDtoWire(
+        string? Name,
+        string ModelName,
+        string? SystemPrompt,
+        AgentModelPreferencesWire? ModelPreferences);
+
+    /// <summary>Subset of andy-agents' <c>AgentModelPreferences</c>.</summary>
+    public sealed record AgentModelPreferencesWire(
+        IReadOnlyList<AgentModelPreferenceWire?>? Preferences);
+
+    /// <summary>Subset of andy-agents' <c>AgentModelPreference</c> — only the
+    /// pinned <see cref="Slug"/> is consumed; recommendation hints are ignored
+    /// (the proxy resolves a concrete id, not a hint).</summary>
+    public sealed record AgentModelPreferenceWire(string? Slug);
+}
+
+/// <summary>
+/// Thrown when resolving an agent from andy-agents fails for any reason other
+/// than a clean 404 (unknown slug → null). Carries enough context for triage
+/// without leaking response internals.
+/// </summary>
+public sealed class AndyAgentsResolutionException : Exception
+{
+    public AndyAgentsResolutionException(string message) : base(message) { }
+    public AndyAgentsResolutionException(string message, Exception inner) : base(message, inner) { }
+}

--- a/src/Andy.Containers.Api/Services/AndyAgentsOptions.cs
+++ b/src/Andy.Containers.Api/Services/AndyAgentsOptions.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// AX.1 (rivoli-ai/conductor#2088). Configuration for the real andy-agents
+/// HTTP client (<see cref="AndyAgentsHttpClient"/>) that resolves an agent's
+/// definition — instructions + model — from the andy-agents service. Bound
+/// from <c>AndyAgents:</c> in <c>appsettings.json</c> / environment overrides.
+///
+/// <para>
+/// When <see cref="ApiBaseUrl"/> is empty the real client is NOT registered —
+/// the configurator falls back to the in-process
+/// <see cref="StubAndyAgentsClient"/>, matching the pre-AX.1 posture so dev /
+/// embedded mode without an andy-agents instance reachable does NOT fail at
+/// startup. This mirrors the <c>AndyDocs:</c> wiring posture exactly.
+/// </para>
+/// </summary>
+public sealed class AndyAgentsOptions
+{
+    public const string SectionName = "AndyAgents";
+
+    /// <summary>
+    /// Base URL of the andy-agents API — e.g. <c>http://localhost:5460/</c>
+    /// in dev or, in Conductor embedded mode, the unified proxy route
+    /// <c>http://host.docker.internal:9100/agents</c> /
+    /// <c>http://localhost:9100/agents</c>. Empty / null disables the real
+    /// client entirely (configurator falls back to the stub).
+    /// </summary>
+    public string? ApiBaseUrl { get; set; }
+
+    /// <summary>
+    /// Per-request HttpClient timeout. Caps a single agent-resolve before the
+    /// caller cancel fires. Defaults to 15s — generous for a small JSON
+    /// lookup without holding the run-configuration path open indefinitely.
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Audience the M2M bearer should be minted with. Defaults to the
+    /// andy-agents API audience as registered in andy-auth's seed
+    /// (permission <c>andy-agents:agent:read</c> on
+    /// <c>GET /api/agents/by-slug/{slug}</c>).
+    /// </summary>
+    public string Audience { get; set; } = "urn:andy-agents-api";
+
+    /// <summary>
+    /// Default <see cref="Andy.Containers.Configurator.AgentSpecLimits.MaxIterations"/>
+    /// applied to every resolved agent. andy-agents does not yet carry
+    /// per-agent run limits; until it does (a later AX slice) every agent
+    /// shares this options-configurable default. Defaults to 200.
+    /// </summary>
+    public int DefaultMaxIterations { get; set; } = 200;
+
+    /// <summary>
+    /// Default <see cref="Andy.Containers.Configurator.AgentSpecLimits.TimeoutSeconds"/>
+    /// applied to every resolved agent. See <see cref="DefaultMaxIterations"/>
+    /// for the per-agent-override caveat. Defaults to 1800s (30 min).
+    /// </summary>
+    public int DefaultTimeoutSeconds { get; set; } = 1800;
+}

--- a/src/Andy.Containers.Api/Services/StubAndyAgentsClient.cs
+++ b/src/Andy.Containers.Api/Services/StubAndyAgentsClient.cs
@@ -3,8 +3,11 @@ using Andy.Containers.Configurator;
 namespace Andy.Containers.Api.Services;
 
 /// <summary>
-/// AP3 (rivoli-ai/andy-containers#105) placeholder client. The real
-/// andy-agents-backed resolver is Epic W; until it lands this stub
+/// AP3 (rivoli-ai/andy-containers#105) in-process fallback client. As of AX.1
+/// (rivoli-ai/conductor#2088) the real andy-agents-backed resolver is
+/// <see cref="AndyAgentsHttpClient"/> — the default whenever
+/// <c>AndyAgents:ApiBaseUrl</c> is configured. This stub remains the fallback
+/// for dev / embedded mode where no andy-agents instance is reachable, and
 /// synthesises a runnable <see cref="AgentSpec"/> for the agent slugs the
 /// andy-tasks planner actually emits (the andy-agents roster: <c>coding</c>,
 /// <c>review</c>, <c>planning</c>, <c>triage</c>, <c>research</c>,
@@ -22,9 +25,11 @@ namespace Andy.Containers.Api.Services;
 /// to OpenRouter upstream). The api-key ref points at the injected service
 /// token rather than a provider key the container doesn't hold.
 ///
-/// TODO(andy-agents / Epic W): replace with an HTTP client that resolves the
-/// agent (instructions, model, tools, limits) from andy-agents
-/// <c>GET /api/agents/by-slug/{slug}</c>.
+/// AX.1 done: <see cref="AndyAgentsHttpClient"/> resolves the agent
+/// (instructions + model) from andy-agents <c>GET /api/agents/by-slug/{slug}</c>.
+/// Tools are NOT sourced there — they're built into the in-container assistant;
+/// the real spec's Tools is empty (this stub keeps the coding shell/git tools
+/// only as a dev convenience).
 /// </remarks>
 public sealed class StubAndyAgentsClient : IAndyAgentsClient
 {

--- a/src/Andy.Containers.Api/appsettings.json
+++ b/src/Andy.Containers.Api/appsettings.json
@@ -12,6 +12,13 @@
     "Authority": "",
     "Audience": "urn:andy-containers-api"
   },
+  "AndyAgents": {
+    "_comment": "AX.1 (rivoli-ai/conductor#2088). Source of truth for agent instructions + model. When ApiBaseUrl is set the real AndyAgentsHttpClient resolves GET /api/agents/by-slug/{slug} (M2M aud=urn:andy-agents-api, permission andy-agents:agent:read). Empty (the default) falls back to the in-process StubAndyAgentsClient. Conductor embedded mode sets AndyAgents__ApiBaseUrl to the unified-proxy /agents route. DefaultMaxIterations/DefaultTimeoutSeconds apply to every resolved agent until per-agent limits land in a later AX slice.",
+    "ApiBaseUrl": "",
+    "Audience": "urn:andy-agents-api",
+    "DefaultMaxIterations": 200,
+    "DefaultTimeoutSeconds": 1800
+  },
   "Cors": {
     "Origins": [
       "https://localhost:5280",

--- a/tests/Andy.Containers.Api.Tests/Configurator/AndyAgentsHttpClientTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Configurator/AndyAgentsHttpClientTests.cs
@@ -1,0 +1,292 @@
+using System.Net;
+using System.Text;
+using Andy.Containers.Api.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Configurator;
+
+// AX.1 (rivoli-ai/conductor#2088). The real andy-agents resolver replaces the
+// AP3 stub: andy-agents is the source of truth for agent INSTRUCTIONS + MODEL.
+// Tools are NOT sourced here (built into the in-container assistant → empty).
+//
+// The mapping rules (forced provider/key, model-id derivation, empty tools,
+// instructions, limits) are unit-tested via the pure MapToAgentSpec/DeriveModelId
+// methods; the HTTP failure-mode contract (404→null, success-roundtrip,
+// 5xx→throw, unparseable→throw) is tested against a stubbed HttpMessageHandler.
+public class AndyAgentsHttpClientTests
+{
+    private static readonly AndyAgentsOptions DefaultOptions = new();
+
+    // ---- Pure mapping: instructions ----------------------------------------
+
+    [Fact]
+    public void Map_SystemPrompt_BecomesInstructions()
+    {
+        var dto = Dto(systemPrompt: "You are the coding agent. Edit files.");
+
+        var spec = AndyAgentsHttpClient.MapToAgentSpec(dto, revision: 3, DefaultOptions);
+
+        spec.Should().NotBeNull();
+        spec!.Instructions.Should().Be("You are the coding agent. Edit files.");
+        spec.Slug.Should().Be("coding", "Slug is mapped from AgentDto.Name");
+        spec.Revision.Should().Be(3, "the caller's revision pin is propagated");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Map_EmptySystemPrompt_ReturnsNull(string? prompt)
+    {
+        var dto = Dto(systemPrompt: prompt);
+
+        var spec = AndyAgentsHttpClient.MapToAgentSpec(dto, revision: null, DefaultOptions);
+
+        spec.Should().BeNull("an instruction-less agent is not runnable");
+    }
+
+    // ---- Pure mapping: forced model wiring ---------------------------------
+
+    [Fact]
+    public void Map_Model_ProviderForcedOpenAi_ApiKeyForcedOpenAiKey()
+    {
+        // Even though andy-agents records a non-OpenAI ModelName/preference, the
+        // in-container assistant talks the OpenAI dialect to the andy-models
+        // proxy and reads OPENAI_API_KEY — so both are FORCED.
+        var dto = Dto(modelName: "claude-3-5-sonnet", prefSlugs: new[] { "anthropic/claude-3-5-sonnet" });
+
+        var spec = AndyAgentsHttpClient.MapToAgentSpec(dto, revision: null, DefaultOptions);
+
+        spec!.Model.Provider.Should().Be("openai");
+        spec.Model.ApiKeyRef.Should().Be("env:OPENAI_API_KEY");
+    }
+
+    // ---- Pure mapping: model-id derivation ---------------------------------
+
+    [Fact]
+    public void Map_ModelId_FromPreferenceSlug_StripsProviderPrefix()
+    {
+        var dto = Dto(modelName: "ignored", prefSlugs: new[] { "deepseek/deepseek-v4-flash" });
+
+        var spec = AndyAgentsHttpClient.MapToAgentSpec(dto, revision: null, DefaultOptions);
+
+        spec!.Model.Id.Should().Be("deepseek-v4-flash",
+            "the segment after the last '/' is what the proxy registers");
+    }
+
+    [Fact]
+    public void Map_ModelId_FromPreferenceSlug_NoPrefix_UsesWholeSlug()
+    {
+        var dto = Dto(modelName: "ignored", prefSlugs: new[] { "gpt-4o" });
+
+        var spec = AndyAgentsHttpClient.MapToAgentSpec(dto, revision: null, DefaultOptions);
+
+        spec!.Model.Id.Should().Be("gpt-4o");
+    }
+
+    [Fact]
+    public void Map_ModelId_NoPreferences_FallsBackToModelName()
+    {
+        var dto = Dto(modelName: "deepseek-v4-flash", prefSlugs: null);
+
+        var spec = AndyAgentsHttpClient.MapToAgentSpec(dto, revision: null, DefaultOptions);
+
+        spec!.Model.Id.Should().Be("deepseek-v4-flash");
+    }
+
+    [Fact]
+    public void Map_ModelId_EmptyPreferenceList_FallsBackToModelName()
+    {
+        var dto = Dto(modelName: "gpt-4o-mini", prefSlugs: System.Array.Empty<string>());
+
+        var spec = AndyAgentsHttpClient.MapToAgentSpec(dto, revision: null, DefaultOptions);
+
+        spec!.Model.Id.Should().Be("gpt-4o-mini");
+    }
+
+    [Fact]
+    public void Map_ModelId_FirstUsablePreferenceWins_SkipsBlankSlugs()
+    {
+        // A hint-only preference (no Slug) is skipped; the first pinned slug wins.
+        var dto = Dto(modelName: "ignored", prefSlugs: new string?[] { null, "x/cerebras-llama-70b" });
+
+        var spec = AndyAgentsHttpClient.MapToAgentSpec(dto, revision: null, DefaultOptions);
+
+        spec!.Model.Id.Should().Be("cerebras-llama-70b");
+    }
+
+    // ---- Pure mapping: tools empty + limits/boundaries ---------------------
+
+    [Fact]
+    public void Map_Tools_AreEmpty()
+    {
+        var dto = Dto(systemPrompt: "anything");
+
+        var spec = AndyAgentsHttpClient.MapToAgentSpec(dto, revision: null, DefaultOptions);
+
+        spec!.Tools.Should().BeEmpty(
+            "tools are built into the in-container assistant; the allow-list is AX.3/AX.4");
+        spec.Boundaries.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Map_Limits_ComeFromOptions()
+    {
+        var options = new AndyAgentsOptions { DefaultMaxIterations = 42, DefaultTimeoutSeconds = 99 };
+        var dto = Dto(systemPrompt: "anything");
+
+        var spec = AndyAgentsHttpClient.MapToAgentSpec(dto, revision: null, options);
+
+        spec!.Limits.MaxIterations.Should().Be(42);
+        spec.Limits.TimeoutSeconds.Should().Be(99);
+    }
+
+    // ---- HTTP failure-mode contract ----------------------------------------
+
+    [Fact]
+    public async Task GetAgentAsync_404_ReturnsNull()
+    {
+        var client = BuildClient(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        var spec = await client.GetAgentAsync("nonexistent", revision: null);
+
+        spec.Should().BeNull("a 404 is a clean unknown-slug → caller maps to 404-equivalent");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GetAgentAsync_BlankSlug_ReturnsNullWithoutCall(string? slug)
+    {
+        var called = false;
+        var client = BuildClient(_ => { called = true; return new HttpResponseMessage(HttpStatusCode.OK); });
+
+        var spec = await client.GetAgentAsync(slug!, revision: null);
+
+        spec.Should().BeNull();
+        called.Should().BeFalse("a blank slug short-circuits before any HTTP call");
+    }
+
+    [Fact]
+    public async Task GetAgentAsync_Success_MapsFullSpec()
+    {
+        const string json = """
+        {
+          "id": "00000000-0000-0000-0000-000000000001",
+          "name": "coding",
+          "modelName": "fallback-model",
+          "systemPrompt": "You are the coding agent.",
+          "temperature": 0.2,
+          "maxTokens": 4096,
+          "status": "Active",
+          "toolIds": ["00000000-0000-0000-0000-000000000099"],
+          "modelPreferences": { "preferences": [ { "slug": "deepseek/deepseek-v4-flash" } ] }
+        }
+        """;
+        var client = BuildClient(_ => JsonResponse(json));
+
+        var spec = await client.GetAgentAsync("coding", revision: 5);
+
+        spec.Should().NotBeNull();
+        spec!.Slug.Should().Be("coding");
+        spec.Revision.Should().Be(5);
+        spec.Instructions.Should().Be("You are the coding agent.");
+        spec.Model.Provider.Should().Be("openai");
+        spec.Model.ApiKeyRef.Should().Be("env:OPENAI_API_KEY");
+        spec.Model.Id.Should().Be("deepseek-v4-flash", "preference slug wins + prefix stripped");
+        spec.Tools.Should().BeEmpty("ToolIds are ignored; tools are built into the assistant");
+    }
+
+    [Fact]
+    public async Task GetAgentAsync_5xx_Throws()
+    {
+        var client = BuildClient(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent("boom"),
+        });
+
+        var act = () => client.GetAgentAsync("coding", revision: null);
+
+        await act.Should().ThrowAsync<AndyAgentsResolutionException>()
+            .WithMessage("*500*");
+    }
+
+    [Fact]
+    public async Task GetAgentAsync_UnparseableBody_Throws()
+    {
+        var client = BuildClient(_ => JsonResponse("not json at all <<<"));
+
+        var act = () => client.GetAgentAsync("coding", revision: null);
+
+        await act.Should().ThrowAsync<AndyAgentsResolutionException>();
+    }
+
+    [Fact]
+    public async Task GetAgentAsync_NetworkError_Throws()
+    {
+        var client = BuildClient(_ => throw new HttpRequestException("connection refused"));
+
+        var act = () => client.GetAgentAsync("coding", revision: null);
+
+        await act.Should().ThrowAsync<AndyAgentsResolutionException>();
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    private static AndyAgentsHttpClient.AgentDtoWire Dto(
+        string? name = "coding",
+        string modelName = "deepseek-v4-flash",
+        string? systemPrompt = "You are an agent.",
+        string?[]? prefSlugs = null)
+    {
+        AndyAgentsHttpClient.AgentModelPreferencesWire? prefs = null;
+        if (prefSlugs is not null)
+        {
+            var items = prefSlugs
+                .Select(s => (AndyAgentsHttpClient.AgentModelPreferenceWire?)
+                    new AndyAgentsHttpClient.AgentModelPreferenceWire(s))
+                .ToList();
+            prefs = new AndyAgentsHttpClient.AgentModelPreferencesWire(items);
+        }
+        return new AndyAgentsHttpClient.AgentDtoWire(name, modelName, systemPrompt, prefs);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+
+    private static AndyAgentsHttpClient BuildClient(
+        Func<HttpRequestMessage, HttpResponseMessage> responder)
+    {
+        var handler = new StubHandler(responder);
+        var http = new HttpClient(handler) { BaseAddress = new Uri("http://andy-agents.test/") };
+        var factory = new SingleClientFactory(http);
+        return new AndyAgentsHttpClient(
+            factory,
+            Options.Create(new AndyAgentsOptions()),
+            NullLogger<AndyAgentsHttpClient>.Instance);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) => _responder = responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_responder(request));
+    }
+
+    private sealed class SingleClientFactory : IHttpClientFactory
+    {
+        private readonly HttpClient _client;
+        public SingleClientFactory(HttpClient client) => _client = client;
+        public HttpClient CreateClient(string name) => _client;
+    }
+}


### PR DESCRIPTION
Part of rivoli-ai/conductor#2088

## What

Replaces the placeholder `StubAndyAgentsClient` (as the default `IAndyAgentsClient`) with a **real HTTP client** `AndyAgentsHttpClient` that resolves an agent's definition from the andy-agents service (`GET /api/agents/by-slug/{slug}`) and maps it to the configurator's local `AgentSpec`.

**andy-agents becomes the source of truth for agent INSTRUCTIONS and MODEL.** Tools are intentionally NOT sourced here — they're built into the in-container code assistant; the resolved spec's `Tools` is always empty. The permission allow-list that gates those built-ins is AX.3/AX.4.

## Mapping decisions (`AgentDto` → `AgentSpec`)

| AgentSpec field | Source |
|---|---|
| `Slug` | `AgentDto.Name` |
| `Instructions` | `AgentDto.SystemPrompt` — returns **null** (no usable agent) when empty/whitespace |
| `Revision` | the caller's pin (andy-agents doesn't version specs over this endpoint yet) |
| `Model.Provider` | **FORCED `"openai"`** — the in-container client talks the andy-models proxy OpenAI dialect (in `HeadlessConfigBuilder`'s allow-list) |
| `Model.ApiKeyRef` | **FORCED `"env:OPENAI_API_KEY"`** — the per-container proxy token (aud=`urn:andy-models-api`), not the shared `ANDY_SERVICE_TOKEN` |
| `Model.Id` | **model-id derivation** (below) |
| `Tools` | **EMPTY** (`ToolIds` ignored) |
| `Boundaries` | null |
| `Limits` | options-configurable defaults (200 iter / 1800s) — per-agent limits are a later AX slice |

### Model-id derivation (the important one)

Resolves the id the andy-models proxy actually registers:
1. Take the **first pinned** `ModelPreferences.Preferences[*].Slug` (skipping hint-only entries with no slug).
2. Strip any provider prefix — keep the segment after the **last** `/`: `"deepseek/deepseek-v4-flash"` → `"deepseek-v4-flash"`; `"gpt-4o"` (no prefix) stays `"gpt-4o"`.
3. Fall back to `AgentDto.ModelName` when there's no usable pinned preference.
4. Defensive last-resort `"default"` if a malformed DTO has neither.

## Failure contract

- **404** (unknown slug) → `null` (caller maps to a clean 404-equivalent).
- Empty `SystemPrompt` → `null` (an instruction-less agent isn't runnable).
- Any other non-2xx / transport error / unparseable body → `AndyAgentsResolutionException` (run configuration must not proceed with a half-resolved agent).

## Wiring (mirrors AndyDocs)

`Program.cs`: `Configure<AndyAgentsOptions>` → gated on `AndyAgents:ApiBaseUrl`:
`AddHttpClient` → `AddHttpMessageHandler(ServiceBearerHandler)` using `IServiceTokenService.GetAccessTokenAsync("urn:andy-agents-api")` (only when `AndyAuth:Authority` is set) → `AddSingleton<IAndyAgentsClient, AndyAgentsHttpClient>`. When `ApiBaseUrl` is empty (dev / embedded mode with no agents service reachable) it falls back to `StubAndyAgentsClient`, so startup never fails. New `AndyAgents:` section added to `appsettings.json` (empty `ApiBaseUrl` default).

## Integration steps still needed (NOT done in this PR — other repos)

1. **conductor (Swift):** `ContainersServiceConfig` must set `AndyAgents__ApiBaseUrl` to the unified-proxy `/agents` route (e.g. `http://localhost:9100/agents`) so the embedded andy-containers-api uses the real client.
2. **andy-auth seed:** the andy-containers-api M2M client needs the `urn:andy-agents-api` scope (`scp:urn:andy-agents-api` in its `apiClient.scopes`) so it can mint a bearer for `andy-agents:agent:read` — without it andy-auth rejects with `invalid_scope`.

## Test evidence

Pure mapping extracted to `MapToAgentSpec` / `DeriveModelId`; HTTP failure modes tested against a stubbed `HttpMessageHandler`.

```
AndyAgentsHttpClientTests:  Passed!  Failed: 0, Passed: 20, Skipped: 0, Total: 20
StubAndyAgentsClientTests (unchanged):  Passed!  Failed: 0, Passed: 15, Skipped: 0
```

Covered: SystemPrompt→Instructions; empty-SystemPrompt→null; provider forced openai + key forced OPENAI_API_KEY; model-id derivation (prefix strip / no-prefix / ModelName fallback / empty-list fallback / skip-blank-slug); tools empty; limits-from-options; 404→null; blank-slug short-circuit; success full-roundtrip; 5xx→throw; unparseable→throw; network-error→throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)