### PR TITLE
[AX.8/AX.9] andy-containers: inject policy text + allowed-tools into the headless config

### DIFF
--- a/src/Andy.Containers.Api/Controllers/RunsController.cs
+++ b/src/Andy.Containers.Api/Controllers/RunsController.cs
@@ -97,6 +97,11 @@ public class RunsController : ControllerBase
             // Transient (NotMapped): consumed by the configurator at create-time
             // to bake the task into the headless agent's system prompt.
             Objective = request.Objective,
+            // AX.8/AX.9 (rivoli-ai/conductor#2095, #2096). Transient governance
+            // fields: policy text appended to the system prompt and the
+            // permission allow-list written into permissions.allowed_tools.
+            PolicyInstructions = request.PolicyInstructions,
+            AllowedTools = request.AllowedTools,
             Status = RunStatus.Pending,
             CreatedAt = now,
             UpdatedAt = now,

--- a/src/Andy.Containers/Configurator/HeadlessConfigBuilder.cs
+++ b/src/Andy.Containers/Configurator/HeadlessConfigBuilder.cs
@@ -57,8 +57,11 @@ public sealed class HeadlessConfigBuilder : IHeadlessConfigBuilder
         // (it asks for clarification and edits nothing). The AgentSpec carries
         // only the generic role prompt; the per-run objective lives on the
         // Run (forwarded from the andy-tasks TaskNode's delegation contract).
-        // Compose: role instructions + the concrete task.
-        var instructions = ComposeInstructions(agent.Instructions, run.Objective);
+        // Compose: role instructions + the concrete task + governing policy text
+        // (AX.8). The policy text arrives pre-rendered from andy-tasks and is
+        // appended verbatim under a short header so the in-container agent is
+        // bound by the same policy the planner resolved.
+        var instructions = ComposeInstructions(agent.Instructions, run.Objective, run.PolicyInstructions);
 
         return new HeadlessRunConfig
         {
@@ -109,7 +112,39 @@ public sealed class HeadlessConfigBuilder : IHeadlessConfigBuilder
             // posture as env_vars / boundaries) so a run without inputs
             // emits no `inputs` key — wire shape identical to pre-EX.7.
             Inputs = MapInputs(run.Inputs),
+            // AX.9 (rivoli-ai/conductor#2096). Project the resolved permission
+            // allow-list onto the headless config's permissions block. Empty
+            // collapses to null so a run without an allow-list emits no
+            // `permissions` key — andy-cli treats absent as unchanged
+            // fail-closed (wire shape identical to pre-AX.9).
+            Permissions = MapPermissions(run.AllowedTools),
         };
+    }
+
+    // AX.9 (rivoli-ai/conductor#2096). Project the run's resolved permission
+    // allow-list onto the headless config. A null/empty list returns null so
+    // the `permissions` key is omitted entirely (fail-closed default). Blank
+    // entries are dropped and the list is de-duplicated to satisfy the
+    // andy-cli schema's `uniqueItems` constraint on `allowed_tools`.
+    private static HeadlessPermissions? MapPermissions(IReadOnlyList<string>? allowedTools)
+    {
+        if (allowedTools is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        var cleaned = allowedTools
+            .Where(t => !string.IsNullOrWhiteSpace(t))
+            .Select(t => t.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (cleaned.Count == 0)
+        {
+            return null;
+        }
+
+        return new HeadlessPermissions { AllowedTools = cleaned };
     }
 
     // EX.7 (rivoli-ai/andy-containers#328). Validate + project the run's
@@ -203,19 +238,31 @@ public sealed class HeadlessConfigBuilder : IHeadlessConfigBuilder
     }
 
     // Compose the agent's generic role prompt with the concrete per-run task
-    // objective into a single system prompt. When no objective is supplied
-    // (e.g. a read-only role, or a caller that didn't forward one) the role
-    // instructions stand alone — preserving the prior behaviour.
-    internal static string ComposeInstructions(string roleInstructions, string? objective)
+    // objective (AX) and the governing policy text (AX.8) into a single system
+    // prompt. Order: role instructions + "## Task\n{objective}" + "## Policies\n
+    // {policyInstructions}". Each section is independent — when no objective is
+    // supplied the task section is omitted (preserving prior behaviour), and
+    // when no policy text is supplied the policies section is omitted. The
+    // policy text arrives pre-formatted from andy-tasks, so it is appended
+    // verbatim under the header rather than reshaped.
+    public static string ComposeInstructions(
+        string roleInstructions,
+        string? objective,
+        string? policyInstructions = null)
     {
-        if (string.IsNullOrWhiteSpace(objective))
+        var composed = roleInstructions;
+
+        if (!string.IsNullOrWhiteSpace(objective))
         {
-            return roleInstructions;
+            composed += "\n\n## Task\n" + objective.Trim();
         }
 
-        return roleInstructions
-            + "\n\n## Task\n"
-            + objective.Trim();
+        if (!string.IsNullOrWhiteSpace(policyInstructions))
+        {
+            composed += "\n\n## Policies\n" + policyInstructions.Trim();
+        }
+
+        return composed;
     }
 
     private static HeadlessTool MapTool(AgentSpecTool tool)

--- a/src/Andy.Containers/Configurator/HeadlessRunConfig.cs
+++ b/src/Andy.Containers/Configurator/HeadlessRunConfig.cs
@@ -42,6 +42,33 @@ public sealed record HeadlessRunConfig
     /// staging" — behaviour identical to pre-EX.7.
     /// </summary>
     public IReadOnlyList<HeadlessInput>? Inputs { get; init; }
+
+    /// <summary>
+    /// AX.9 (rivoli-ai/conductor#2096). Per-run permission allow-list. Maps to
+    /// the andy-cli AX.4 schema's <c>permissions</c> block. Headless is
+    /// fail-closed: mutating built-ins and <c>execute_command</c> default to
+    /// deny; tools listed in <see cref="HeadlessPermissions.AllowedTools"/> are
+    /// relaxed to allow. <c>null</c> (and the empty allow-list, which the
+    /// builder collapses to <c>null</c>) means the <c>permissions</c> key is
+    /// omitted entirely — andy-cli treats absent as unchanged fail-closed
+    /// behaviour (wire shape identical to pre-AX.9).
+    /// </summary>
+    public HeadlessPermissions? Permissions { get; init; }
+}
+
+/// <summary>
+/// AX.9 (rivoli-ai/conductor#2096). The <c>permissions</c> block of the
+/// andy-cli headless config. Serialises to <c>{"allowed_tools": [...]}</c>.
+/// </summary>
+public sealed record HeadlessPermissions
+{
+    /// <summary>
+    /// Tool ids the run is permitted to execute (e.g. <c>write_file</c>,
+    /// <c>execute_command</c>). Serialises to <c>allowed_tools</c>. A normally
+    /// fail-closed tool becomes executable when listed; a tool not listed
+    /// stays denied.
+    /// </summary>
+    public IReadOnlyList<string> AllowedTools { get; init; } = [];
 }
 
 /// <summary>

--- a/src/Andy.Containers/Models/Run.cs
+++ b/src/Andy.Containers/Models/Run.cs
@@ -96,6 +96,38 @@ public class Run
     public string? Objective { get; set; }
 
     /// <summary>
+    /// AX.8 (rivoli-ai/conductor#2095). Pre-rendered policy text resolved by
+    /// andy-tasks from the run's governing policy (andy-policies). The
+    /// configurator APPENDS it verbatim under a short header to the headless
+    /// agent's system prompt (after the task objective) so the in-container
+    /// agent is bound by the policy. It arrives already formatted, so the
+    /// configurator does not reshape it. <c>null</c>/empty means no policy
+    /// text — behaviour unchanged.
+    /// <para>
+    /// Not persisted (<c>[NotMapped]</c>): consumed at create-time alongside
+    /// <see cref="Objective"/>, mirroring the same transient rail.
+    /// </para>
+    /// </summary>
+    [System.ComponentModel.DataAnnotations.Schema.NotMapped]
+    public string? PolicyInstructions { get; set; }
+
+    /// <summary>
+    /// AX.9 (rivoli-ai/conductor#2096). The resolved permission allow-list —
+    /// the tool ids this run is permitted to execute, resolved by andy-tasks
+    /// from the run's policy. The configurator writes it into the headless
+    /// config's <c>permissions.allowed_tools</c> block so andy-cli's
+    /// fail-closed permission engine relaxes exactly these tools (everything
+    /// else stays denied). <c>null</c>/empty means no permissions block is
+    /// emitted — andy-cli treats absent as unchanged fail-closed.
+    /// <para>
+    /// Not persisted (<c>[NotMapped]</c>): consumed at create-time alongside
+    /// <see cref="Objective"/>, mirroring the same transient rail.
+    /// </para>
+    /// </summary>
+    [System.ComponentModel.DataAnnotations.Schema.NotMapped]
+    public IReadOnlyList<string>? AllowedTools { get; set; }
+
+    /// <summary>
     /// Transition the run to <paramref name="next"/> according to AP1's state-machine
     /// invariants. Throws <see cref="InvalidOperationException"/> for illegal
     /// transitions so callers cannot silently corrupt history.

--- a/src/Andy.Containers/Models/RunDtos.cs
+++ b/src/Andy.Containers/Models/RunDtos.cs
@@ -39,6 +39,27 @@ public class CreateRunRequest
     /// runs with no task context (the agent then sees only the role prompt).
     /// </summary>
     public string? Objective { get; set; }
+
+    /// <summary>
+    /// AX.8 (rivoli-ai/conductor#2095). Pre-rendered policy text (resolved by
+    /// andy-tasks from the run's governing policy). The configurator appends
+    /// it verbatim to the headless agent's system prompt, after the task
+    /// objective. Optional — omitted for ungoverned runs (the prompt then
+    /// carries only role + objective). Wire shape: <c>policyInstructions:
+    /// string</c>.
+    /// </summary>
+    public string? PolicyInstructions { get; set; }
+
+    /// <summary>
+    /// AX.9 (rivoli-ai/conductor#2096). The resolved permission allow-list:
+    /// tool ids this run may execute, resolved by andy-tasks from the run's
+    /// policy. The configurator writes it into the headless config's
+    /// <c>permissions.allowed_tools</c> so andy-cli's fail-closed permission
+    /// engine relaxes exactly these tools. Optional — omitted/empty means no
+    /// permissions block (andy-cli stays fail-closed). Wire shape:
+    /// <c>allowedTools: string[]</c>.
+    /// </summary>
+    public IReadOnlyList<string>? AllowedTools { get; set; }
 }
 
 public class WorkspaceRefRequest

--- a/tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigBuilderTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigBuilderTests.cs
@@ -318,6 +318,173 @@ public class HeadlessConfigBuilderTests
         HeadlessConfigBuilder.ValidateDestRelativePath(raw).Should().Be(expected);
     }
 
+    // --- AX.8: policy text appended to the system prompt ---
+
+    [Fact]
+    public void ComposeInstructions_AppendsPolicyAfterObjective()
+    {
+        // The final system prompt must layer: role + ## Task + ## Policies,
+        // in that order, so the in-container agent sees the role, then the
+        // concrete task, then the governing policy.
+        var result = HeadlessConfigBuilder.ComposeInstructions(
+            "ROLE",
+            "OBJECTIVE",
+            "POLICY-TEXT");
+
+        result.Should().Be("ROLE\n\n## Task\nOBJECTIVE\n\n## Policies\nPOLICY-TEXT");
+
+        // Explicit ordering guard: the policy section comes after the task.
+        result.IndexOf("## Policies", StringComparison.Ordinal)
+            .Should().BeGreaterThan(result.IndexOf("## Task", StringComparison.Ordinal),
+                "policy text must be appended after the task objective");
+    }
+
+    [Fact]
+    public void ComposeInstructions_NoPolicy_LeavesPromptUnchanged()
+    {
+        // When no policy text is supplied the prompt is exactly role + task —
+        // no trailing Policies header (backward compatible with AX/pre-AX.8).
+        var result = HeadlessConfigBuilder.ComposeInstructions("ROLE", "OBJECTIVE");
+
+        result.Should().Be("ROLE\n\n## Task\nOBJECTIVE");
+        result.Should().NotContain("## Policies");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ComposeInstructions_BlankPolicy_OmitsPoliciesSection(string? policy)
+    {
+        var result = HeadlessConfigBuilder.ComposeInstructions("ROLE", "OBJECTIVE", policy);
+
+        result.Should().Be("ROLE\n\n## Task\nOBJECTIVE");
+    }
+
+    [Fact]
+    public void Build_WithPolicyInstructions_AppendsPolicyToSystemPrompt()
+    {
+        var run = SeedRun();
+        run.Objective = "Add a Quick Start section to README.md.";
+        run.PolicyInstructions = "You may not modify files under /infra. Never push to main.";
+        var spec = TriageAgent();
+
+        var config = _builder.Build(run, spec);
+
+        config.Agent.Instructions.Should().Contain(spec.Instructions, "role prompt is preserved");
+        config.Agent.Instructions.Should().Contain("Add a Quick Start section to README.md.",
+            "the task objective is preserved");
+        config.Agent.Instructions.Should().Contain("## Policies",
+            "the policy section header is appended");
+        config.Agent.Instructions.Should().Contain(
+            "You may not modify files under /infra. Never push to main.",
+            "the pre-rendered policy text is appended verbatim");
+
+        // Ordering: policy text comes after the objective in the final prompt.
+        config.Agent.Instructions.IndexOf("## Policies", StringComparison.Ordinal)
+            .Should().BeGreaterThan(
+                config.Agent.Instructions.IndexOf("Add a Quick Start", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Build_WithoutPolicyInstructions_PromptUnchanged()
+    {
+        var run = SeedRun();
+        run.Objective = "Add a Quick Start section to README.md.";
+        // PolicyInstructions null
+        var spec = TriageAgent();
+
+        var config = _builder.Build(run, spec);
+
+        config.Agent.Instructions.Should().NotContain("## Policies");
+    }
+
+    // --- AX.9: allowed-tools written to permissions.allowed_tools ---
+
+    [Fact]
+    public void Build_WithAllowedTools_EmitsPermissionsAllowedToolsSnakeCase()
+    {
+        var run = SeedRun();
+        run.AllowedTools = new[] { "write_file", "execute_command" };
+        var spec = TriageAgent();
+
+        var config = _builder.Build(run, spec);
+
+        config.Permissions.Should().NotBeNull();
+        config.Permissions!.AllowedTools.Should().Equal("write_file", "execute_command");
+
+        // Serialises to the andy-cli AX.4 schema shape:
+        // "permissions": { "allowed_tools": [...] } (snake_case).
+        var json = HeadlessConfigJson.Serialize(config);
+        json.Should().Contain("\"permissions\"");
+        json.Should().Contain("\"allowed_tools\"");
+        json.Should().Contain("\"write_file\"");
+        json.Should().Contain("\"execute_command\"");
+
+        // Round-trips back through the configurator's serializer.
+        var roundTripped = System.Text.Json.JsonSerializer.Deserialize<HeadlessRunConfig>(
+            json, HeadlessConfigJson.Options);
+        roundTripped!.Permissions.Should().NotBeNull();
+        roundTripped.Permissions!.AllowedTools.Should().Equal("write_file", "execute_command");
+    }
+
+    [Fact]
+    public void Build_NoAllowedTools_OmitsPermissionsBlock()
+    {
+        var run = SeedRun(); // AllowedTools null
+        var spec = TriageAgent();
+
+        var config = _builder.Build(run, spec);
+
+        config.Permissions.Should().BeNull(
+            "absent allow-list means no permissions block — andy-cli stays fail-closed");
+
+        var json = HeadlessConfigJson.Serialize(config);
+        json.Should().NotContain("\"permissions\"",
+            "the WhenWritingNull policy must drop the absent permissions key entirely");
+    }
+
+    [Fact]
+    public void Build_EmptyAllowedTools_CollapseToNull()
+    {
+        var run = SeedRun();
+        run.AllowedTools = Array.Empty<string>();
+        var spec = TriageAgent();
+
+        var config = _builder.Build(run, spec);
+
+        config.Permissions.Should().BeNull(
+            "empty allow-list collapses to null, matching inputs/env_vars posture");
+    }
+
+    [Fact]
+    public void Build_AllowedTools_DropsBlanksAndDeduplicates()
+    {
+        // The schema requires uniqueItems on allowed_tools; the builder must
+        // strip blank/whitespace entries and de-duplicate before emitting.
+        var run = SeedRun();
+        run.AllowedTools = new[] { "write_file", "  ", "write_file", "read_file", "" };
+        var spec = TriageAgent();
+
+        var config = _builder.Build(run, spec);
+
+        config.Permissions.Should().NotBeNull();
+        config.Permissions!.AllowedTools.Should().Equal("write_file", "read_file");
+    }
+
+    [Fact]
+    public void Build_AllowedTools_OnlyBlanks_CollapseToNull()
+    {
+        var run = SeedRun();
+        run.AllowedTools = new[] { "", "   " };
+        var spec = TriageAgent();
+
+        var config = _builder.Build(run, spec);
+
+        config.Permissions.Should().BeNull(
+            "an allow-list of only blanks carries no real grant — omit the block");
+    }
+
     private static Run SeedRun() => new()
     {
         Id = Guid.NewGuid(),

--- a/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
@@ -132,6 +132,37 @@ public class RunsControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task Create_ThreadsGovernanceFieldsOntoRunForConfigurator()
+    {
+        // AX.8/AX.9 (rivoli-ai/conductor#2095, #2096). The controller forwards
+        // policyInstructions + allowedTools from the request onto the (transient,
+        // NotMapped) Run fields the configurator consumes. Capture the Run the
+        // configurator receives and assert both governance fields arrived.
+        Run? captured = null;
+        _configurator
+            .Setup(c => c.ConfigureAsync(It.IsAny<Run>(), It.IsAny<CancellationToken>()))
+            .Callback<Run, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync(RunConfiguratorResult.Ok("/tmp/noop/config.json"));
+
+        var request = new CreateRunRequest
+        {
+            AgentId = "triage-agent",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            Objective = "Add a Quick Start section.",
+            PolicyInstructions = "Never push to main.",
+            AllowedTools = new[] { "write_file", "execute_command" },
+        };
+
+        await _controller.Create(request, CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.Objective.Should().Be("Add a Quick Start section.");
+        captured.PolicyInstructions.Should().Be("Never push to main.");
+        captured.AllowedTools.Should().Equal("write_file", "execute_command");
+    }
+
+    [Fact]
     public async Task Create_InvokesDispatcher_AfterConfiguratorSuccess()
     {
         // AP5 wiring: configurator success hands off to the dispatcher with


### PR DESCRIPTION
Part of rivoli-ai/conductor#2095 and #2096

Carries two new governance fields on the run request and injects them into the headless config the in-container agent runs, mirroring the existing objective-injection rail.

## Wire contract consumed (camelCase, on `CreateRunRequest`)
- `policyInstructions: string` — pre-rendered policy text resolved by andy-tasks.
- `allowedTools: string[]` — the resolved permission allow-list.

Both are added to `CreateRunRequest` and forwarded onto `[NotMapped]` transient fields on `Run` (`PolicyInstructions`, `AllowedTools`) in `RunsController.Create`, exactly like the existing `Objective` rail (consumed at create-time by the configurator; no schema change).

## AX.8 — policyInstructions appends to the system prompt
`HeadlessConfigBuilder.ComposeInstructions(role, objective, policyInstructions)` now layers, in order:

```
{role instructions}

## Task
{objective}

## Policies
{policyInstructions}
```

The policy text arrives pre-formatted from andy-tasks, so it is appended **verbatim** under a short `## Policies` header, after the objective. When `policyInstructions` is null/empty/whitespace the section is omitted — prompt unchanged (backward compatible).

## AX.9 — allowedTools maps to `permissions.allowed_tools`
`AllowedTools` threads `Run -> HeadlessRunConfig.Permissions -> JSON`, emitting the andy-cli AX.4 schema shape (confirmed against `schemas/headless-config.v1.json`):

```json
"permissions": { "allowed_tools": ["write_file", "execute_command"] }
```

- snake_case via the configurator's `SnakeCaseLower` serializer (new `HeadlessPermissions` record).
- Empty/blank-only list collapses to `null` so the **entire `permissions` block is omitted** — andy-cli treats absent as unchanged fail-closed (wire shape identical to pre-AX.9).
- Blank entries dropped + de-duplicated to satisfy the schema's `uniqueItems` constraint.

## Tests (xUnit + FluentAssertions)
- `ComposeInstructions_*` — policy appended after objective; ordering guard; omitted when blank/absent.
- `Build_WithPolicyInstructions_*` / `Build_WithoutPolicyInstructions_*` — full build path.
- `Build_WithAllowedTools_EmitsPermissionsAllowedToolsSnakeCase` — built + serialized config carries `permissions.allowed_tools` (+ round-trip).
- `Build_NoAllowedTools_OmitsPermissionsBlock`, `Build_EmptyAllowedTools_CollapseToNull`, `Build_AllowedTools_DropsBlanksAndDeduplicates`, `Build_AllowedTools_OnlyBlanks_CollapseToNull`.
- `Create_ThreadsGovernanceFieldsOntoRunForConfigurator` — request -> Run threading of both fields.
- Golden snapshots (`triage/plan/execute`) unchanged — fixtures set neither governance field, so absent-block behavior is preserved.

Configurator + controller suite: **110 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)