### PR TITLE
[AX.13] andy-containers-api: andy-agents scope + service-principal grant

### DIFF
--- a/config/registration.json
+++ b/config/registration.json
@@ -31,7 +31,8 @@
         "profile",
         "roles",
         "scp:urn:andy-containers-api",
-        "scp:urn:andy-models-api"
+        "scp:urn:andy-models-api",
+        "scp:urn:andy-agents-api"
       ]
     },
     "webClient": {
@@ -75,7 +76,13 @@
       { "code": "user",   "name": "User",          "description": "Standard user",              "isSystem": true },
       { "code": "viewer", "name": "Viewer",        "description": "Read-only access",           "isSystem": true }
     ],
-    "testUserRole": "admin"
+    "testUserRole": "admin",
+    "servicePrincipal": {
+      "clientId": "andy-containers-api",
+      "permissions": [
+        "andy-agents:agent:read"
+      ]
+    }
   },
   "settings": {
     "definitions": [


### PR DESCRIPTION
Part of rivoli-ai/conductor#2087. Lets andy-containers' real AndyAgentsHttpClient (AX.1) reach andy-agents: `scp:urn:andy-agents-api` (mint the M2M token) + `rbac.servicePrincipal {andy-containers-api: [andy-agents:agent:read]}` (authorized at andy-agents). Verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)