### PR TITLE
[AX.1] Use the full model slug (incl. provider prefix) for the resolved agent

### DIFF
--- a/src/Andy.Containers.Api/Services/AndyAgentsHttpClient.cs
+++ b/src/Andy.Containers.Api/Services/AndyAgentsHttpClient.cs
@@ -220,10 +220,12 @@ public sealed class AndyAgentsHttpClient : IAndyAgentsClient
 
     /// <summary>
     /// Resolves the model id the andy-models proxy knows. Preference order:
-    /// the first pinned preference slug (with any provider prefix stripped),
-    /// then <see cref="AgentDtoWire.ModelName"/>. The provider-prefix strip
-    /// turns andy-models routing slugs like "deepseek/deepseek-v4-flash" into
-    /// the bare "deepseek-v4-flash" the OpenAI-dialect proxy registers.
+    /// the first pinned preference slug, then <see cref="AgentDtoWire.ModelName"/>.
+    /// The FULL slug is used as-is: the andy-models registry keys on the whole
+    /// slug INCLUDING the provider segment (e.g. "openrouter/qwen3-coder",
+    /// "anthropic/claude-sonnet-4-6"), so stripping the prefix would produce an
+    /// id the proxy can't resolve. (An unprefixed slug like "gpt-4o" passes
+    /// through unchanged.)
     /// </summary>
     public static string DeriveModelId(AgentDtoWire dto)
     {
@@ -241,16 +243,7 @@ public sealed class AndyAgentsHttpClient : IAndyAgentsClient
             return "default";
         }
 
-        var stripped = StripProviderPrefix(raw);
-        return string.IsNullOrWhiteSpace(stripped) ? raw : stripped;
-    }
-
-    // "deepseek/deepseek-v4-flash" → "deepseek-v4-flash"; "gpt-4o" → "gpt-4o".
-    // Only the segment after the LAST '/' is kept.
-    private static string StripProviderPrefix(string slug)
-    {
-        var idx = slug.LastIndexOf('/');
-        return idx >= 0 && idx + 1 < slug.Length ? slug[(idx + 1)..] : slug;
+        return raw.Trim();
     }
 
     private static async Task<string> SafeReadAsync(HttpContent content, CancellationToken ct)

--- a/tests/Andy.Containers.Api.Tests/Configurator/AndyAgentsHttpClientTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Configurator/AndyAgentsHttpClientTests.cs
@@ -67,14 +67,17 @@ public class AndyAgentsHttpClientTests
     // ---- Pure mapping: model-id derivation ---------------------------------
 
     [Fact]
-    public void Map_ModelId_FromPreferenceSlug_StripsProviderPrefix()
+    public void Map_ModelId_FromPreferenceSlug_UsesFullSlug()
     {
-        var dto = Dto(modelName: "ignored", prefSlugs: new[] { "deepseek/deepseek-v4-flash" });
+        // The andy-models registry keys on the FULL slug including the provider
+        // segment (the seed registers e.g. "openrouter/qwen3-coder"), so the
+        // prefix must be preserved — stripping it yields an unresolvable id.
+        var dto = Dto(modelName: "ignored", prefSlugs: new[] { "openrouter/qwen3-coder" });
 
         var spec = AndyAgentsHttpClient.MapToAgentSpec(dto, revision: null, DefaultOptions);
 
-        spec!.Model.Id.Should().Be("deepseek-v4-flash",
-            "the segment after the last '/' is what the proxy registers");
+        spec!.Model.Id.Should().Be("openrouter/qwen3-coder",
+            "the full slug (with provider prefix) is what the andy-models proxy registers");
     }
 
     [Fact]
@@ -111,11 +114,11 @@ public class AndyAgentsHttpClientTests
     public void Map_ModelId_FirstUsablePreferenceWins_SkipsBlankSlugs()
     {
         // A hint-only preference (no Slug) is skipped; the first pinned slug wins.
-        var dto = Dto(modelName: "ignored", prefSlugs: new string?[] { null, "x/cerebras-llama-70b" });
+        var dto = Dto(modelName: "ignored", prefSlugs: new string?[] { null, "openrouter/cerebras-llama-70b" });
 
         var spec = AndyAgentsHttpClient.MapToAgentSpec(dto, revision: null, DefaultOptions);
 
-        spec!.Model.Id.Should().Be("cerebras-llama-70b");
+        spec!.Model.Id.Should().Be("openrouter/cerebras-llama-70b");
     }
 
     // ---- Pure mapping: tools empty + limits/boundaries ---------------------
@@ -197,7 +200,7 @@ public class AndyAgentsHttpClientTests
         spec.Instructions.Should().Be("You are the coding agent.");
         spec.Model.Provider.Should().Be("openai");
         spec.Model.ApiKeyRef.Should().Be("env:OPENAI_API_KEY");
-        spec.Model.Id.Should().Be("deepseek-v4-flash", "preference slug wins + prefix stripped");
+        spec.Model.Id.Should().Be("deepseek/deepseek-v4-flash", "preference slug wins, used as the full registry slug");
         spec.Tools.Should().BeEmpty("ToolIds are ignored; tools are built into the assistant");
     }
 


### PR DESCRIPTION
Follow-up fix to AX.1 (#2088). The provider-prefix strip in `DeriveModelId` broke model resolution for the real OpenRouter seed, whose slugs are all provider-prefixed (`openrouter/qwen3-coder`). The andy-models proxy resolves by the full slug, so the strip yielded a 404. Now the full slug is used as-is. Verified live: a headless run resolved `model.id: openrouter/qwen3-coder` and the agent edited a file. 20 AndyAgentsHttpClient tests pass.