### PR TITLE
[AX.16] Detach headless andy-cli exec from POST /api/runs

### DIFF
--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -567,6 +567,11 @@ try
     // success.
     builder.Services.AddScoped<IRunModeDispatcher, RunModeDispatcher>();
 
+    // AX.16 (rivoli-ai/conductor#2104). Singleton: outlives any request so a
+    // multi-minute andy-cli exec keeps running after POST /api/runs returns.
+    // Each launched run gets its own DI scope (fresh DbContext + runner).
+    builder.Services.AddSingleton<IHeadlessRunLauncher, HeadlessRunLauncher>();
+
     var app = builder.Build();
 
     // Auto-migrate on both providers. Conductor #883.

--- a/src/Andy.Containers.Api/Services/HeadlessRunLauncher.cs
+++ b/src/Andy.Containers.Api/Services/HeadlessRunLauncher.cs
@@ -1,0 +1,115 @@
+using System.Collections.Concurrent;
+using Andy.Containers.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// AX.16 (rivoli-ai/conductor#2104). Detaches the headless andy-cli
+/// execution from the HTTP request that created the run. The dispatcher
+/// calls <see cref="Launch"/> and returns immediately; the run is driven
+/// to its terminal state on a background task in a fresh DI scope, and
+/// callers observe completion through the run events the runner already
+/// publishes over NATS (plus <c>GET /api/runs/{id}</c> polling).
+/// </summary>
+/// <remarks>
+/// Why a fresh scope: <see cref="IHeadlessRunner"/> and
+/// <see cref="ContainersDbContext"/> are scoped to the HTTP request that
+/// would otherwise own them — by the time a multi-minute agent run
+/// finishes, that request (and its DbContext) is long gone. The launcher
+/// re-loads the <see cref="Andy.Containers.Models.Run"/> row inside its own
+/// scope; the create-time-only <c>[NotMapped]</c> fields (Objective,
+/// PolicyInstructions, AllowedTools) are not needed here because the
+/// configurator already baked them into the headless config file.
+/// Cancellation: the per-run cancel endpoint signals through
+/// <see cref="IRunCancellationRegistry"/>, which is scope-independent;
+/// the launcher's own token only fires on host shutdown.
+/// </remarks>
+public interface IHeadlessRunLauncher
+{
+    /// <summary>
+    /// Start the headless run in the background. Returns the tracking task
+    /// (callers in production discard it; tests await it).
+    /// </summary>
+    Task Launch(Guid runId, string configPath);
+
+    /// <summary>The in-flight background task for a run, if any.</summary>
+    Task? GetInFlight(Guid runId);
+}
+
+public sealed class HeadlessRunLauncher : IHeadlessRunLauncher
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IHostApplicationLifetime _lifetime;
+    private readonly ILogger<HeadlessRunLauncher> _logger;
+    private readonly ConcurrentDictionary<Guid, Task> _inFlight = new();
+
+    public HeadlessRunLauncher(
+        IServiceScopeFactory scopeFactory,
+        IHostApplicationLifetime lifetime,
+        ILogger<HeadlessRunLauncher> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _lifetime = lifetime;
+        _logger = logger;
+    }
+
+    public Task Launch(Guid runId, string configPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(configPath);
+
+        var task = Task.Run(() => RunDetachedAsync(runId, configPath));
+        _inFlight[runId] = task;
+        _ = task.ContinueWith(
+            _ => _inFlight.TryRemove(runId, out Task? _),
+            TaskScheduler.Default);
+        return task;
+    }
+
+    public Task? GetInFlight(Guid runId)
+        => _inFlight.TryGetValue(runId, out var task) ? task : null;
+
+    private async Task RunDetachedAsync(Guid runId, string configPath)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ContainersDbContext>();
+            var runner = scope.ServiceProvider.GetRequiredService<IHeadlessRunner>();
+
+            var run = await db.Runs.FirstOrDefaultAsync(
+                r => r.Id == runId, _lifetime.ApplicationStopping);
+            if (run is null)
+            {
+                _logger.LogError(
+                    "HeadlessRunLauncher: run {RunId} vanished between dispatch and background start; nothing to execute.",
+                    runId);
+                return;
+            }
+
+            var outcome = await runner.StartAsync(run, configPath, _lifetime.ApplicationStopping);
+            _logger.LogInformation(
+                "HeadlessRunLauncher: run {RunId} completed in background (kind={Kind}, status={Status}).",
+                runId, outcome.Kind, outcome.Status);
+        }
+        catch (OperationCanceledException) when (_lifetime.ApplicationStopping.IsCancellationRequested)
+        {
+            _logger.LogWarning(
+                "HeadlessRunLauncher: run {RunId} interrupted by host shutdown; the run row keeps its last persisted status.",
+                runId);
+        }
+        catch (Exception ex)
+        {
+            // The runner owns terminal-event writes; if it threw before
+            // reaching them the row stays mid-flight — same posture as the
+            // old synchronous path, but the failure must be logged HERE
+            // because no HTTP caller is waiting to observe it.
+            _logger.LogError(ex,
+                "HeadlessRunLauncher: run {RunId} background execution threw: {Message}",
+                runId, ex.Message);
+        }
+    }
+}

--- a/src/Andy.Containers.Api/Services/IRunModeDispatcher.cs
+++ b/src/Andy.Containers.Api/Services/IRunModeDispatcher.cs
@@ -21,19 +21,19 @@ public interface IRunModeDispatcher
 }
 
 /// <summary>
-/// Outcome of a dispatch attempt. <see cref="RunDispatchKind.Started"/>
-/// carries the inner <see cref="HeadlessRunOutcome"/> so callers can
-/// observe headless runs end-to-end without reaching for AP6 directly;
-/// the other kinds leave that null.
+/// Outcome of a dispatch attempt. <see cref="RunDispatchKind.Detached"/>
+/// (AX.16, rivoli-ai/conductor#2104) means the headless execution was
+/// handed to <see cref="IHeadlessRunLauncher"/> and is running in the
+/// background — terminal state is observed via run events / polling,
+/// never through this return value.
 /// </summary>
 public sealed record RunDispatchOutcome
 {
     public required RunDispatchKind Kind { get; init; }
     public string? Error { get; init; }
-    public HeadlessRunOutcome? HeadlessOutcome { get; init; }
 
-    public static RunDispatchOutcome Started(HeadlessRunOutcome inner)
-        => new() { Kind = RunDispatchKind.Started, HeadlessOutcome = inner };
+    public static RunDispatchOutcome Detached()
+        => new() { Kind = RunDispatchKind.Detached };
 
     public static RunDispatchOutcome Attachable()
         => new() { Kind = RunDispatchKind.Attachable };
@@ -47,8 +47,8 @@ public sealed record RunDispatchOutcome
 
 public enum RunDispatchKind
 {
-    /// <summary>Headless run started via AP6; <c>HeadlessOutcome</c> populated.</summary>
-    Started,
+    /// <summary>Headless execution detached to the background launcher (AX.16).</summary>
+    Detached,
 
     /// <summary>Terminal mode run is bound to a container and ready for WebSocket attach.</summary>
     Attachable,

--- a/src/Andy.Containers.Api/Services/RunModeDispatcher.cs
+++ b/src/Andy.Containers.Api/Services/RunModeDispatcher.cs
@@ -9,18 +9,18 @@ namespace Andy.Containers.Api.Services;
 public sealed class RunModeDispatcher : IRunModeDispatcher
 {
     private readonly ContainersDbContext _db;
-    private readonly IHeadlessRunner _runner;
+    private readonly IHeadlessRunLauncher _launcher;
     private readonly IRunBranchService _runBranch;
     private readonly ILogger<RunModeDispatcher> _logger;
 
     public RunModeDispatcher(
         ContainersDbContext db,
-        IHeadlessRunner runner,
+        IHeadlessRunLauncher launcher,
         IRunBranchService runBranch,
         ILogger<RunModeDispatcher> logger)
     {
         _db = db;
-        _runner = runner;
+        _launcher = launcher;
         _runBranch = runBranch;
         _logger = logger;
     }
@@ -95,31 +95,25 @@ public sealed class RunModeDispatcher : IRunModeDispatcher
 
         return run.Mode switch
         {
-            RunMode.Headless => await StartHeadlessAsync(run, configPath, ct),
+            RunMode.Headless => StartHeadlessDetached(run, configPath),
             RunMode.Terminal => RunDispatchOutcome.Attachable(),
             _ => Fail(run, $"Unknown run mode: {run.Mode}."),
         };
     }
 
-    private async Task<RunDispatchOutcome> StartHeadlessAsync(Run run, string configPath, CancellationToken ct)
+    // AX.16 (rivoli-ai/conductor#2104). The andy-cli exec can outlast any
+    // sane HTTP timeout (a 480B coding model legitimately runs for many
+    // minutes), so the dispatch hands off to the background launcher and
+    // returns immediately. Terminal state reaches callers through the run
+    // events the runner publishes over NATS + GET /api/runs/{id} polling —
+    // the contract andy-tasks' ConductorExecutor already consumes.
+    private RunDispatchOutcome StartHeadlessDetached(Run run, string configPath)
     {
-        try
-        {
-            var outcome = await _runner.StartAsync(run, configPath, ct);
-            return RunDispatchOutcome.Started(outcome);
-        }
-        catch (Exception ex)
-        {
-            // The runner owns its own terminal-event writes — if it threw
-            // before getting there the row is stuck mid-flight. Surface the
-            // failure to the caller; transitioning the run row to Failed is
-            // intentionally not done here because the runner's TerminateAsync
-            // path is the canonical place for that and reaching in around it
-            // would race with a slow-but-recovering runner.
-            _logger.LogError(ex,
-                "Run {RunId} headless dispatch threw: {Message}", run.Id, ex.Message);
-            return RunDispatchOutcome.Failed(ex.Message);
-        }
+        _ = _launcher.Launch(run.Id, configPath);
+        _logger.LogInformation(
+            "Run {RunId} headless execution detached to background; POST returns with status {Status}.",
+            run.Id, run.Status);
+        return RunDispatchOutcome.Detached();
     }
 
     private RunDispatchOutcome Fail(Run run, string error)

--- a/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
@@ -40,18 +40,13 @@ public class RunsControllerTests : IDisposable
         _configurator
             .Setup(c => c.ConfigureAsync(It.IsAny<Run>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(RunConfiguratorResult.Ok("/tmp/noop/config.json"));
-        // AP5 wires the dispatcher into Create. Default stub: Started outcome
+        // AP5 wires the dispatcher into Create. Default stub: Detached outcome (AX.16)
         // (the controller doesn't act on the result besides logging). The
         // dedicated RunModeDispatcherTests cover routing/container selection.
         _dispatcher = new Mock<IRunModeDispatcher>();
         _dispatcher
             .Setup(d => d.DispatchAsync(It.IsAny<Run>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(RunDispatchOutcome.Started(new HeadlessRunOutcome
-            {
-                Kind = RunEventKind.Finished,
-                Status = RunStatus.Succeeded,
-                ExitCode = 0,
-            }));
+            .ReturnsAsync(RunDispatchOutcome.Detached());
         // AP7 wires the cancellation registry into Cancel. Use the real
         // implementation — it's a leaf class with no other deps and
         // mocking it would just duplicate its surface.

--- a/tests/Andy.Containers.Api.Tests/Mcp/RunsMcpToolsTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Mcp/RunsMcpToolsTests.cs
@@ -43,12 +43,7 @@ public class RunsMcpToolsTests : IDisposable
         _dispatcher = new Mock<IRunModeDispatcher>();
         _dispatcher
             .Setup(d => d.DispatchAsync(It.IsAny<Run>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(RunDispatchOutcome.Started(new HeadlessRunOutcome
-            {
-                Kind = RunEventKind.Finished,
-                Status = RunStatus.Succeeded,
-                ExitCode = 0,
-            }));
+            .ReturnsAsync(RunDispatchOutcome.Detached());
 
         _cancellation = new RunCancellationRegistry();
 

--- a/tests/Andy.Containers.Api.Tests/Services/HeadlessRunLauncherTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/HeadlessRunLauncherTests.cs
@@ -1,0 +1,249 @@
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Messaging.Events;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+// AX.16 (rivoli-ai/conductor#2104). The headless andy-cli exec is detached
+// from the HTTP request: POST /api/runs returns as soon as the run is
+// Provisioning, and the launcher drives the exec on a background task in a
+// fresh DI scope. The headline regression here — Dispatch_ReturnsPromptly_
+// WhileRunnerStillExecuting — HANGS on the old code, where the dispatcher
+// awaited the runner inside the request and andy-tasks' 100 s HttpClient
+// timeout failed every plan task whose agent ran longer than that.
+public class HeadlessRunLauncherTests
+{
+    private const string ConfigPath = "/tmp/runs/x/config.json";
+
+    private sealed class TestLifetime : IHostApplicationLifetime
+    {
+        private readonly CancellationTokenSource _stopping = new();
+        public CancellationToken ApplicationStarted => CancellationToken.None;
+        public CancellationToken ApplicationStopping => _stopping.Token;
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+        public void StopApplication() => _stopping.Cancel();
+    }
+
+    private static Run SeedRun(ContainersDbContext db)
+    {
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "coding",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            Status = RunStatus.Provisioning,
+            ContainerId = Guid.NewGuid(),
+            WorkspaceRef = new WorkspaceRef { WorkspaceId = Guid.NewGuid() },
+        };
+        db.Runs.Add(run);
+        db.SaveChanges();
+        return run;
+    }
+
+    [Fact]
+    public async Task Dispatch_ReturnsPromptly_WhileRunnerStillExecuting()
+    {
+        // THE AX.16 regression test. Wire the REAL launcher into the REAL
+        // dispatcher with a runner that does not complete until released.
+        // On the old (synchronous) dispatcher this test never returns from
+        // DispatchAsync; on the new one it returns Detached immediately.
+        var dbName = Guid.NewGuid().ToString();
+        var db = InMemoryDbHelper.CreateContext(dbName);
+
+        var workspace = new Workspace
+        {
+            Id = Guid.NewGuid(),
+            Name = "ws",
+            OwnerId = "u",
+            DefaultContainerId = Guid.NewGuid(),
+        };
+        db.Workspaces.Add(workspace);
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "coding",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            Status = RunStatus.Pending,
+            WorkspaceRef = new WorkspaceRef { WorkspaceId = workspace.Id },
+        };
+        db.Runs.Add(run);
+        db.SaveChanges();
+
+        var release = new TaskCompletionSource<HeadlessRunOutcome>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var runnerStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var runner = new Mock<IHeadlessRunner>();
+        runner
+            .Setup(r => r.StartAsync(It.IsAny<Run>(), ConfigPath, It.IsAny<CancellationToken>()))
+            .Returns<Run, string, CancellationToken>((_, _, _) =>
+            {
+                runnerStarted.TrySetResult();
+                return release.Task; // blocks until the test releases it
+            });
+
+        var services = new ServiceCollection()
+            .AddScoped<ContainersDbContext>(_ => InMemoryDbHelper.CreateContext(dbName))
+            .AddScoped<IHeadlessRunner>(_ => runner.Object)
+            .BuildServiceProvider();
+        var launcher = new HeadlessRunLauncher(
+            services.GetRequiredService<IServiceScopeFactory>(),
+            new TestLifetime(),
+            NullLogger<HeadlessRunLauncher>.Instance);
+        var dispatcher = new RunModeDispatcher(
+            db, launcher, Mock.Of<IRunBranchService>(),
+            NullLogger<RunModeDispatcher>.Instance);
+
+        var dispatch = dispatcher.DispatchAsync(run, ConfigPath);
+        var completedFirst = await Task.WhenAny(dispatch, Task.Delay(TimeSpan.FromSeconds(10)));
+
+        completedFirst.Should().BeSameAs(dispatch,
+            "the dispatch must return while the agent exec is still in flight");
+        (await dispatch).Kind.Should().Be(RunDispatchKind.Detached);
+
+        // The exec genuinely started in the background...
+        await runnerStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        launcher.GetInFlight(run.Id).Should().NotBeNull();
+
+        // ...and completes once the (long) agent run finishes.
+        release.SetResult(new HeadlessRunOutcome
+        {
+            Kind = RunEventKind.Finished,
+            Status = RunStatus.Succeeded,
+            ExitCode = 0,
+        });
+        await launcher.GetInFlight(run.Id)!.WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task Launch_ReloadsRunInFreshScope_AndInvokesRunnerWithConfigPath()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var db = InMemoryDbHelper.CreateContext(dbName);
+        var run = SeedRun(db);
+
+        Run? seenByRunner = null;
+        var runner = new Mock<IHeadlessRunner>();
+        runner
+            .Setup(r => r.StartAsync(It.IsAny<Run>(), ConfigPath, It.IsAny<CancellationToken>()))
+            .Callback<Run, string, CancellationToken>((r, _, _) => seenByRunner = r)
+            .ReturnsAsync(new HeadlessRunOutcome { Kind = RunEventKind.Finished, Status = RunStatus.Succeeded });
+
+        var services = new ServiceCollection()
+            .AddScoped<ContainersDbContext>(_ => InMemoryDbHelper.CreateContext(dbName))
+            .AddScoped<IHeadlessRunner>(_ => runner.Object)
+            .BuildServiceProvider();
+        var launcher = new HeadlessRunLauncher(
+            services.GetRequiredService<IServiceScopeFactory>(),
+            new TestLifetime(),
+            NullLogger<HeadlessRunLauncher>.Instance);
+
+        await launcher.Launch(run.Id, ConfigPath);
+
+        runner.Verify(r => r.StartAsync(
+            It.Is<Run>(rn => rn.Id == run.Id && rn.ContainerId == run.ContainerId),
+            ConfigPath,
+            It.IsAny<CancellationToken>()), Times.Once);
+        // The background scope re-loaded its own tracked instance — it must
+        // not be the request-scoped entity (whose DbContext is disposed by
+        // the time a long run completes).
+        seenByRunner.Should().NotBeSameAs(run);
+    }
+
+    [Fact]
+    public async Task Launch_RunVanished_LogsAndCompletes_WithoutInvokingRunner()
+    {
+        var runner = new Mock<IHeadlessRunner>();
+        var services = new ServiceCollection()
+            .AddScoped<ContainersDbContext>(_ => InMemoryDbHelper.CreateContext())
+            .AddScoped<IHeadlessRunner>(_ => runner.Object)
+            .BuildServiceProvider();
+        var launcher = new HeadlessRunLauncher(
+            services.GetRequiredService<IServiceScopeFactory>(),
+            new TestLifetime(),
+            NullLogger<HeadlessRunLauncher>.Instance);
+
+        var task = launcher.Launch(Guid.NewGuid(), ConfigPath);
+        await task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        task.IsCompletedSuccessfully.Should().BeTrue();
+        runner.Verify(r => r.StartAsync(It.IsAny<Run>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Launch_RunnerThrows_BackgroundTaskCompletesWithoutCrashing()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var db = InMemoryDbHelper.CreateContext(dbName);
+        var run = SeedRun(db);
+
+        var runner = new Mock<IHeadlessRunner>();
+        runner
+            .Setup(r => r.StartAsync(It.IsAny<Run>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("kaboom"));
+
+        var services = new ServiceCollection()
+            .AddScoped<ContainersDbContext>(_ => InMemoryDbHelper.CreateContext(dbName))
+            .AddScoped<IHeadlessRunner>(_ => runner.Object)
+            .BuildServiceProvider();
+        var launcher = new HeadlessRunLauncher(
+            services.GetRequiredService<IServiceScopeFactory>(),
+            new TestLifetime(),
+            NullLogger<HeadlessRunLauncher>.Instance);
+
+        var task = launcher.Launch(run.Id, ConfigPath);
+        await task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // No unobserved exception escapes — the failure is logged, the run
+        // row keeps whatever status the runner last persisted.
+        task.IsCompletedSuccessfully.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetInFlight_RemovesEntry_AfterCompletion()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var db = InMemoryDbHelper.CreateContext(dbName);
+        var run = SeedRun(db);
+
+        var runner = new Mock<IHeadlessRunner>();
+        runner
+            .Setup(r => r.StartAsync(It.IsAny<Run>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HeadlessRunOutcome { Kind = RunEventKind.Finished, Status = RunStatus.Succeeded });
+
+        var services = new ServiceCollection()
+            .AddScoped<ContainersDbContext>(_ => InMemoryDbHelper.CreateContext(dbName))
+            .AddScoped<IHeadlessRunner>(_ => runner.Object)
+            .BuildServiceProvider();
+        var launcher = new HeadlessRunLauncher(
+            services.GetRequiredService<IServiceScopeFactory>(),
+            new TestLifetime(),
+            NullLogger<HeadlessRunLauncher>.Instance);
+
+        var task = launcher.Launch(run.Id, ConfigPath);
+        await task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // The continuation that evicts the entry races the awaited task by
+        // design; poll briefly rather than assert instantly.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (launcher.GetInFlight(run.Id) is not null && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(10);
+        }
+        launcher.GetInFlight(run.Id).Should().BeNull();
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Services/RunModeDispatcherTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/RunModeDispatcherTests.cs
@@ -18,7 +18,7 @@ namespace Andy.Containers.Api.Tests.Services;
 public class RunModeDispatcherTests : IDisposable
 {
     private readonly ContainersDbContext _db;
-    private readonly Mock<IHeadlessRunner> _runner = new();
+    private readonly Mock<IHeadlessRunLauncher> _launcher = new();
     private readonly Mock<IRunBranchService> _runBranch = new();
     private readonly RunModeDispatcher _dispatcher;
     private const string ConfigPath = "/tmp/runs/x/config.json";
@@ -26,7 +26,10 @@ public class RunModeDispatcherTests : IDisposable
     public RunModeDispatcherTests()
     {
         _db = InMemoryDbHelper.CreateContext();
-        _dispatcher = new RunModeDispatcher(_db, _runner.Object, _runBranch.Object, NullLogger<RunModeDispatcher>.Instance);
+        _launcher
+            .Setup(l => l.Launch(It.IsAny<Guid>(), It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+        _dispatcher = new RunModeDispatcher(_db, _launcher.Object, _runBranch.Object, NullLogger<RunModeDispatcher>.Instance);
     }
 
     public void Dispose() => _db.Dispose();
@@ -37,9 +40,6 @@ public class RunModeDispatcherTests : IDisposable
     public async Task Dispatch_Headless_EnsuresRunBranchOnSelectedContainer()
     {
         var (run, workspace) = SeedRunAndWorkspace(RunMode.Headless);
-        _runner
-            .Setup(r => r.StartAsync(It.IsAny<Run>(), ConfigPath, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new HeadlessRunOutcome { Kind = RunEventKind.Finished, Status = RunStatus.Succeeded });
 
         await _dispatcher.DispatchAsync(run, ConfigPath);
 
@@ -56,59 +56,30 @@ public class RunModeDispatcherTests : IDisposable
         _runBranch
             .Setup(b => b.EnsureRunBranchAsync(It.IsAny<Run>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("branch boom"));
-        _runner
-            .Setup(r => r.StartAsync(It.IsAny<Run>(), ConfigPath, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new HeadlessRunOutcome { Kind = RunEventKind.Finished, Status = RunStatus.Succeeded });
 
         var outcome = await _dispatcher.DispatchAsync(run, ConfigPath);
 
-        outcome.Kind.Should().Be(RunDispatchKind.Started);
+        outcome.Kind.Should().Be(RunDispatchKind.Detached);
     }
 
     [Fact]
-    public async Task Dispatch_HeadlessHappyPath_AssignsContainer_TransitionsProvisioning_InvokesRunner()
+    public async Task Dispatch_HeadlessHappyPath_AssignsContainer_TransitionsProvisioning_DetachesToLauncher()
     {
+        // AX.16 (rivoli-ai/conductor#2104): the dispatcher no longer awaits
+        // the runner — it hands the run id + config path to the background
+        // launcher and returns Detached immediately. Terminal state reaches
+        // callers via run events / polling.
         var (run, workspace) = SeedRunAndWorkspace(RunMode.Headless);
-        _runner
-            .Setup(r => r.StartAsync(It.IsAny<Run>(), ConfigPath, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new HeadlessRunOutcome
-            {
-                Kind = RunEventKind.Finished,
-                Status = RunStatus.Succeeded,
-                ExitCode = 0,
-            });
 
         var outcome = await _dispatcher.DispatchAsync(run, ConfigPath);
 
-        outcome.Kind.Should().Be(RunDispatchKind.Started);
-        outcome.HeadlessOutcome.Should().NotBeNull();
-        outcome.HeadlessOutcome!.Status.Should().Be(RunStatus.Succeeded);
-
+        outcome.Kind.Should().Be(RunDispatchKind.Detached);
         run.ContainerId.Should().Be(workspace.DefaultContainerId);
-        // The runner advances Provisioning → Running → terminal; we observe
-        // the final state, but ContainerId proves AP5 ran first.
-        _runner.Verify(r => r.StartAsync(
-            It.Is<Run>(rn => rn.ContainerId == workspace.DefaultContainerId),
-            ConfigPath,
-            It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task Dispatch_Headless_TransitionsToProvisioningBeforeRunnerCall()
-    {
-        // Pin the runner-side state at call time: dispatcher must have moved
-        // Pending → Provisioning before invoking the runner so AP6 sees the
-        // expected starting status.
-        var (run, _) = SeedRunAndWorkspace(RunMode.Headless);
-        RunStatus? statusSeenByRunner = null;
-        _runner
-            .Setup(r => r.StartAsync(It.IsAny<Run>(), ConfigPath, It.IsAny<CancellationToken>()))
-            .Callback<Run, string, CancellationToken>((r, _, _) => statusSeenByRunner = r.Status)
-            .ReturnsAsync(new HeadlessRunOutcome { Kind = RunEventKind.Finished, Status = RunStatus.Succeeded });
-
-        await _dispatcher.DispatchAsync(run, ConfigPath);
-
-        statusSeenByRunner.Should().Be(RunStatus.Provisioning);
+        // Detach happens AFTER the Provisioning transition is persisted, so
+        // the background scope re-loads a row that already carries the
+        // container assignment.
+        run.Status.Should().Be(RunStatus.Provisioning);
+        _launcher.Verify(l => l.Launch(run.Id, ConfigPath), Times.Once);
     }
 
     [Fact]
@@ -119,13 +90,11 @@ public class RunModeDispatcherTests : IDisposable
         var outcome = await _dispatcher.DispatchAsync(run, ConfigPath);
 
         outcome.Kind.Should().Be(RunDispatchKind.Attachable);
-        outcome.HeadlessOutcome.Should().BeNull();
         run.ContainerId.Should().Be(workspace.DefaultContainerId);
         run.Status.Should().Be(RunStatus.Provisioning,
             "Terminal-mode runs are still provisioned — the user attaches separately via the terminal WS");
 
-        _runner.Verify(r => r.StartAsync(It.IsAny<Run>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+        _launcher.Verify(l => l.Launch(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
     }
 
     [Fact]
@@ -142,7 +111,7 @@ public class RunModeDispatcherTests : IDisposable
         outcome.Error.Should().NotBeNullOrEmpty();
         run.ContainerId.Should().BeNull();
         run.Status.Should().Be(RunStatus.Pending);
-        _runner.VerifyNoOtherCalls();
+        _launcher.VerifyNoOtherCalls();
     }
 
     [Fact]
@@ -221,21 +190,28 @@ public class RunModeDispatcherTests : IDisposable
     }
 
     [Fact]
-    public async Task Dispatch_RunnerThrows_ReturnsFailed()
+    public async Task Dispatch_FailurePaths_NeverReachTheLauncher()
     {
-        var (run, _) = SeedRunAndWorkspace(RunMode.Headless);
-        _runner
-            .Setup(r => r.StartAsync(It.IsAny<Run>(), ConfigPath, It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("kaboom"));
+        // A run that fails container selection must not be detached — the
+        // launcher would re-load a row with no ContainerId and fail later,
+        // losing the actionable error the dispatcher already has.
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "x",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            Status = RunStatus.Pending,
+            WorkspaceRef = new WorkspaceRef { WorkspaceId = Guid.NewGuid() }, // not seeded
+        };
+        _db.Runs.Add(run);
+        await _db.SaveChangesAsync();
 
         var outcome = await _dispatcher.DispatchAsync(run, ConfigPath);
 
         outcome.Kind.Should().Be(RunDispatchKind.Failed);
-        outcome.Error.Should().Be("kaboom");
-        // ContainerId is still set — the runner is the canonical place to
-        // mark the run Failed; we leave the row in Provisioning so the
-        // operator can see exactly where it stopped.
-        run.ContainerId.Should().NotBeNull();
+        _launcher.Verify(l => l.Launch(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes rivoli-ai/conductor#2104.

**Problem:** `RunsController.Create` → `RunModeDispatcher` awaited the ENTIRE andy-cli exec inside the POST. Any agent run >100 s blew andy-tasks' `HttpClient.Timeout`, marking the task Failed and halting the plan even when the agent succeeded (reproduced live with `openrouter/qwen3-coder`, which legitimately runs minutes).

**Fix:** new singleton `HeadlessRunLauncher` — the dispatcher hands off `(runId, configPath)` and returns `Detached` immediately (run row at `Provisioning`). The launcher drives the exec in a background task with a fresh DI scope (request-scoped DbContext/runner are long gone by completion) and the host-lifetime token (an HTTP disconnect no longer cancels a legitimate run). Terminal state propagates exactly as before: the runner owns terminal transitions + NATS run events (the contract andy-tasks' ConductorExecutor consumes since #345/#346); cancel still works via the scope-independent `RunCancellationRegistry`.

**Evidence:**
- `Dispatch_ReturnsPromptly_WhileRunnerStillExecuting` **fails on the old code** (dispatch blocks on the runner) and passes here.
- Full suite: **1363 passed / 0 failed** excluding 3 problems proven pre-existing on main (run on unmodified main: `Mint_ObOExchangeFailure_WrappedAsProxyTokenException` FAIL, `CreateContainer_OpenCodeWithCustomBaseUrl_KeepsUserUrlAndSkipsProxyOverride` FAIL, `HeadlessRunnerOutputStreamTests` hang — hang dumps captured on both branch AND main; flaky-test issue filed separately).
- 5 new `HeadlessRunLauncherTests` (prompt-return, fresh-scope reload, vanished-run, runner-throw containment, in-flight tracking).