### PR TITLE
fix: 404 for unknown container on all sub-resource endpoints (conductor#1972)

### DIFF
--- a/src/Andy.Containers.Api/Controllers/ContainersController.cs
+++ b/src/Andy.Containers.Api/Controllers/ContainersController.cs
@@ -246,7 +246,8 @@ public class ContainersController : ControllerBase
     [RequirePermission("container:execute")]
     public async Task<IActionResult> Start(Guid id, CancellationToken ct)
     {
-        var container = await _containerService.GetContainerAsync(id, ct);
+        var container = await FindContainerAsync(id, ct);
+        if (container is null) return ContainerNotFound(id);
         if (!CanAccess(container)) return Forbid();
 
         try
@@ -270,7 +271,8 @@ public class ContainersController : ControllerBase
     [RequirePermission("container:execute")]
     public async Task<IActionResult> Stop(Guid id, CancellationToken ct)
     {
-        var container = await _containerService.GetContainerAsync(id, ct);
+        var container = await FindContainerAsync(id, ct);
+        if (container is null) return ContainerNotFound(id);
         if (!CanAccess(container)) return Forbid();
 
         try
@@ -297,7 +299,8 @@ public class ContainersController : ControllerBase
     [RequirePermission("container:delete")]
     public async Task<IActionResult> Destroy(Guid id, CancellationToken ct)
     {
-        var container = await _containerService.GetContainerAsync(id, ct);
+        var container = await FindContainerAsync(id, ct);
+        if (container is null) return ContainerNotFound(id);
         if (!CanAccess(container)) return Forbid();
 
         await _containerService.DestroyContainerAsync(id, ct);
@@ -308,7 +311,8 @@ public class ContainersController : ControllerBase
     [RequirePermission("container:execute")]
     public async Task<IActionResult> Exec(Guid id, [FromBody] ExecRequest request, CancellationToken ct)
     {
-        var container = await _containerService.GetContainerAsync(id, ct);
+        var container = await FindContainerAsync(id, ct);
+        if (container is null) return ContainerNotFound(id);
         if (!CanAccess(container)) return Forbid();
 
         var result = await _containerService.ExecAsync(id, request.Command, ct);
@@ -330,7 +334,8 @@ public class ContainersController : ControllerBase
         [FromServices] ICodeAssistantInstallExecutor executor,
         CancellationToken ct)
     {
-        var container = await _containerService.GetContainerAsync(id, ct);
+        var container = await FindContainerAsync(id, ct);
+        if (container is null) return ContainerNotFound(id);
         if (!CanAccess(container)) return Forbid();
 
         if (container.Status != ContainerStatus.Running)
@@ -401,7 +406,8 @@ public class ContainersController : ControllerBase
     [RequirePermission("container:read")]
     public async Task<IActionResult> GetConnectionInfo(Guid id, CancellationToken ct)
     {
-        var container = await _containerService.GetContainerAsync(id, ct);
+        var container = await FindContainerAsync(id, ct);
+        if (container is null) return ContainerNotFound(id);
         if (!CanAccess(container)) return Forbid();
 
         var info = await _containerService.GetConnectionInfoAsync(id, ct);
@@ -571,7 +577,8 @@ public class ContainersController : ControllerBase
     [RequirePermission("container:read")]
     public async Task<IActionResult> GetEvents(Guid id, CancellationToken ct)
     {
-        var container = await _containerService.GetContainerAsync(id, ct);
+        var container = await FindContainerAsync(id, ct);
+        if (container is null) return ContainerNotFound(id);
         if (!CanAccess(container)) return Forbid();
 
         var events = await _db.Events
@@ -586,7 +593,8 @@ public class ContainersController : ControllerBase
     [RequirePermission("container:read")]
     public async Task<IActionResult> ListRepositories(Guid id, CancellationToken ct)
     {
-        var container = await _containerService.GetContainerAsync(id, ct);
+        var container = await FindContainerAsync(id, ct);
+        if (container is null) return ContainerNotFound(id);
         if (!CanAccess(container)) return Forbid();
 
         var repos = await _db.ContainerGitRepositories
@@ -604,7 +612,8 @@ public class ContainersController : ControllerBase
     [RequirePermission("container:write")]
     public async Task<IActionResult> AddRepository(Guid id, [FromBody] AddRepositoryDto dto, CancellationToken ct)
     {
-        var container = await _containerService.GetContainerAsync(id, ct);
+        var container = await FindContainerAsync(id, ct);
+        if (container is null) return ContainerNotFound(id);
         if (!CanAccess(container)) return Forbid();
 
         if (container.Status != ContainerStatus.Running)
@@ -658,7 +667,8 @@ public class ContainersController : ControllerBase
     [RequirePermission("container:execute")]
     public async Task<IActionResult> PullRepository(Guid id, Guid repoId, CancellationToken ct)
     {
-        var container = await _containerService.GetContainerAsync(id, ct);
+        var container = await FindContainerAsync(id, ct);
+        if (container is null) return ContainerNotFound(id);
         if (!CanAccess(container)) return Forbid();
 
         if (container.Status != ContainerStatus.Running)
@@ -692,7 +702,8 @@ public class ContainersController : ControllerBase
     [RequirePermission("container:read")]
     public async Task<IActionResult> GetGitDiff(Guid id, [FromQuery] Guid? repoId, CancellationToken ct)
     {
-        var container = await _containerService.GetContainerAsync(id, ct);
+        var container = await FindContainerAsync(id, ct);
+        if (container is null) return ContainerNotFound(id);
         if (!CanAccess(container)) return Forbid();
 
         var diff = await _gitDiffService.GetDiffAsync(id, repoId, ct);
@@ -717,7 +728,8 @@ public class ContainersController : ControllerBase
     [RequirePermission("container:read")]
     public async Task<IActionResult> GetPorts(Guid id, CancellationToken ct)
     {
-        var container = await _containerService.GetContainerAsync(id, ct);
+        var container = await FindContainerAsync(id, ct);
+        if (container is null) return ContainerNotFound(id);
         if (!CanAccess(container)) return Forbid();
 
         var ports = await _portDiscoveryService.GetPortsAsync(id, ct);
@@ -770,6 +782,42 @@ public class ContainersController : ControllerBase
     {
         if (_currentUser.IsAdmin()) return true;
         return container.OwnerId == _currentUser.GetUserId();
+    }
+
+    /// <summary>
+    /// Resolves a container for sub-resource endpoints, translating the
+    /// store's <see cref="KeyNotFoundException"/> into <c>null</c> so the
+    /// caller can return the structured 404 envelope instead of leaking a
+    /// 500 (rivoli-ai/conductor#1972 — observed live on
+    /// <c>GET /api/containers/{id}/git/diff</c> with an unknown id).
+    /// </summary>
+    private async Task<Container?> FindContainerAsync(Guid id, CancellationToken ct)
+    {
+        try
+        {
+            return await _containerService.GetContainerAsync(id, ct);
+        }
+        catch (KeyNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Structured 404 envelope for an unknown container id — same shape as
+    /// the classified <c>GET /api/containers/{id}</c> response (SM.2.6):
+    /// <c>{ code, message, correlationId }</c> plus the
+    /// <c>X-Correlation-Id</c> header.
+    /// </summary>
+    private NotFoundObjectResult ContainerNotFound(Guid id)
+    {
+        Response.Headers["X-Correlation-Id"] = id.ToString();
+        return NotFound(new
+        {
+            code = ContainerNotFoundException.ErrorCode,
+            message = $"Container {id} not found.",
+            correlationId = id,
+        });
     }
 }
 

--- a/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerUnknownContainerNotFoundTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerUnknownContainerNotFoundTests.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Containers.Abstractions;
+using Andy.Containers.Api.Controllers;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Storage;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Controllers;
+
+/// <summary>
+/// rivoli-ai/conductor#1972. An unknown container id on any
+/// <c>/api/containers/{id}/…</c> sub-resource endpoint must surface the
+/// same structured 404 envelope as <c>GET /api/containers/{id}</c>
+/// (SM.2.6: <c>{ code, message, correlationId }</c> + the
+/// <c>X-Correlation-Id</c> header) — never a 500.
+///
+/// Observed live: <c>GET /api/containers/{id}/git/diff</c> with id
+/// <c>c5705ed9-29c2-4a13-ba89-d5080ddb546e</c> returned 500 with
+/// <c>KeyNotFoundException: Container … not found</c>, which Conductor
+/// rendered as <c>[PC-TASKLIVE-001] … [API-SERVER-500]</c>.
+/// </summary>
+public class ContainersControllerUnknownContainerNotFoundTests : IDisposable
+{
+    private readonly Mock<IContainerService> _mockService = new();
+    private readonly Mock<ICurrentUserService> _mockCurrentUser = new();
+    private readonly ContainersDbContext _db;
+    private readonly ContainersController _controller;
+    private readonly Guid _unknownId = Guid.NewGuid();
+
+    public ContainersControllerUnknownContainerNotFoundTests()
+    {
+        _mockCurrentUser.Setup(u => u.GetUserId()).Returns("test-user");
+        _mockCurrentUser.Setup(u => u.IsAdmin()).Returns(true);
+
+        // The orchestration store's contract for an unknown id
+        // (ContainerOrchestrationService.GetContainerAsync).
+        _mockService.Setup(s => s.GetContainerAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException($"Container {_unknownId} not found"));
+
+        _db = InMemoryDbHelper.CreateContext();
+        _controller = new ContainersController(
+            _mockService.Object,
+            _mockCurrentUser.Object,
+            _db,
+            new Mock<IGitCloneService>().Object,
+            new Mock<IGitCredentialService>().Object,
+            new Mock<IGitRepositoryProbeService>().Object,
+            new Mock<IOrganizationMembershipService>().Object,
+            new Mock<IGitDiffService>().Object,
+            new Mock<IPortDiscoveryService>().Object,
+            new Mock<IContainerLifecycleBus>().Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            },
+        };
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private void AssertNotFoundEnvelope(IActionResult result)
+    {
+        var notFound = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFound.StatusCode.Should().Be(404);
+
+        var json = System.Text.Json.JsonSerializer.Serialize(notFound.Value);
+        json.Should().Contain(ContainerNotFoundException.ErrorCode);
+        json.Should().Contain(_unknownId.ToString());
+
+        _controller.Response.Headers.Should().ContainKey("X-Correlation-Id");
+        _controller.Response.Headers["X-Correlation-Id"].ToString()
+            .Should().Be(_unknownId.ToString());
+    }
+
+    // ---- The two endpoints observed broken live (F6.1 / F6.4) ----
+
+    [Fact]
+    public async Task GetGitDiff_UnknownContainer_Returns404Envelope_Not500()
+    {
+        var result = await _controller.GetGitDiff(_unknownId, null, CancellationToken.None);
+        AssertNotFoundEnvelope(result);
+    }
+
+    [Fact]
+    public async Task GetPorts_UnknownContainer_Returns404Envelope_Not500()
+    {
+        var result = await _controller.GetPorts(_unknownId, CancellationToken.None);
+        AssertNotFoundEnvelope(result);
+    }
+
+    // ---- Every other sub-resource endpoint sharing the same lookup ----
+
+    [Fact]
+    public async Task Start_UnknownContainer_Returns404Envelope()
+    {
+        var result = await _controller.Start(_unknownId, CancellationToken.None);
+        AssertNotFoundEnvelope(result);
+    }
+
+    [Fact]
+    public async Task Stop_UnknownContainer_Returns404Envelope()
+    {
+        var result = await _controller.Stop(_unknownId, CancellationToken.None);
+        AssertNotFoundEnvelope(result);
+    }
+
+    [Fact]
+    public async Task Destroy_UnknownContainer_Returns404Envelope()
+    {
+        var result = await _controller.Destroy(_unknownId, CancellationToken.None);
+        AssertNotFoundEnvelope(result);
+    }
+
+    [Fact]
+    public async Task Exec_UnknownContainer_Returns404Envelope()
+    {
+        var result = await _controller.Exec(
+            _unknownId, new ExecRequest { Command = "echo hi" }, CancellationToken.None);
+        AssertNotFoundEnvelope(result);
+    }
+
+    [Fact]
+    public async Task RetryCodeAssistantInstall_UnknownContainer_Returns404Envelope()
+    {
+        var result = await _controller.RetryCodeAssistantInstall(
+            _unknownId, new Mock<ICodeAssistantInstallExecutor>().Object, CancellationToken.None);
+        AssertNotFoundEnvelope(result);
+    }
+
+    [Fact]
+    public async Task GetConnectionInfo_UnknownContainer_Returns404Envelope()
+    {
+        var result = await _controller.GetConnectionInfo(_unknownId, CancellationToken.None);
+        AssertNotFoundEnvelope(result);
+    }
+
+    [Fact]
+    public async Task GetEvents_UnknownContainer_Returns404Envelope()
+    {
+        var result = await _controller.GetEvents(_unknownId, CancellationToken.None);
+        AssertNotFoundEnvelope(result);
+    }
+
+    [Fact]
+    public async Task ListRepositories_UnknownContainer_Returns404Envelope()
+    {
+        var result = await _controller.ListRepositories(_unknownId, CancellationToken.None);
+        AssertNotFoundEnvelope(result);
+    }
+
+    [Fact]
+    public async Task AddRepository_UnknownContainer_Returns404Envelope()
+    {
+        var dto = new AddRepositoryDto { Url = "https://github.com/owner/repo.git" };
+        var result = await _controller.AddRepository(_unknownId, dto, CancellationToken.None);
+        AssertNotFoundEnvelope(result);
+    }
+
+    [Fact]
+    public async Task PullRepository_UnknownContainer_Returns404Envelope()
+    {
+        var result = await _controller.PullRepository(
+            _unknownId, Guid.NewGuid(), CancellationToken.None);
+        AssertNotFoundEnvelope(result);
+    }
+}


### PR DESCRIPTION
Part of the conductor#1972 container-run blocker chain.

`GET /api/containers/{id}/git/diff` with an unknown container id returned **500** (`KeyNotFoundException: Container … not found`) — observed live via Conductor's task live-activity pane (`[PC-TASKLIVE-001] … [API-SERVER-500]`, stale goal→container binding). Eleven sibling sub-resource endpoints shared the same lookup and bug.

**Fix:** `FindContainerAsync` translates the store's `KeyNotFoundException` to null; callers return a structured 404 envelope matching the SM.2.6 classified `GET /api/containers/{id}` shape (`{ code, message, correlationId }` + `X-Correlation-Id`). Applied to: start, stop, destroy, exec, retry-code-assistant-install, connection-info, events, repositories list/add/pull, git/diff, ports.

**Tests:** `ContainersControllerUnknownContainerNotFoundTests` — 12 cases (one per endpoint), proven fail-against-old (KeyNotFoundException) / pass-against-fix (404 + envelope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)