### PR TITLE
Dispatch failures are terminal: transition run to Failed + publish run.failed event

### DIFF
--- a/src/Andy.Containers.Api/Services/RunModeDispatcher.cs
+++ b/src/Andy.Containers.Api/Services/RunModeDispatcher.cs
@@ -1,4 +1,6 @@
 using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -43,18 +45,18 @@ public sealed class RunModeDispatcher : IRunModeDispatcher
         var workspaceId = run.WorkspaceRef?.WorkspaceId ?? Guid.Empty;
         if (workspaceId == Guid.Empty)
         {
-            return Fail(run, "Run has no workspace reference; cannot select a container.");
+            return await FailAsync(run, "Run has no workspace reference; cannot select a container.", ct);
         }
 
         var workspace = await _db.Workspaces.FirstOrDefaultAsync(w => w.Id == workspaceId, ct);
         if (workspace is null)
         {
-            return Fail(run, $"Workspace {workspaceId} not found.");
+            return await FailAsync(run, $"Workspace {workspaceId} not found.", ct);
         }
 
         if (workspace.DefaultContainerId is not { } containerId)
         {
-            return Fail(run, $"Workspace {workspaceId} has no default container; provision one before dispatching the run.");
+            return await FailAsync(run, $"Workspace {workspaceId} has no default container; provision one before dispatching the run.", ct);
         }
 
         run.ContainerId = containerId;
@@ -97,7 +99,7 @@ public sealed class RunModeDispatcher : IRunModeDispatcher
         {
             RunMode.Headless => StartHeadlessDetached(run, configPath),
             RunMode.Terminal => RunDispatchOutcome.Attachable(),
-            _ => Fail(run, $"Unknown run mode: {run.Mode}."),
+            _ => await FailAsync(run, $"Unknown run mode: {run.Mode}.", ct),
         };
     }
 
@@ -116,9 +118,33 @@ public sealed class RunModeDispatcher : IRunModeDispatcher
         return RunDispatchOutcome.Detached();
     }
 
-    private RunDispatchOutcome Fail(Run run, string error)
+    // rivoli-ai/conductor#2122: a dispatch-level failure is TERMINAL for
+    // the run, not a log line. Before this, Fail() only logged — the Run
+    // row stayed Pending, no andy.containers.events.run.{id}.failed was
+    // ever published (only provisioning/runner failures publish), and
+    // andy-tasks' RunEventConsumer waited forever on an event that never
+    // comes, leaving its AgentRun row Running with nothing behind it.
+    // Transition the row to Failed, record the reason, and publish the
+    // terminal event through the same outbox the runner uses so every
+    // downstream consumer folds the truth.
+    private async Task<RunDispatchOutcome> FailAsync(Run run, string error, CancellationToken ct)
     {
         _logger.LogWarning("Run {RunId} dispatch failed: {Error}", run.Id, error);
+
+        run.Error = error;
+        if (RunStatusTransitions.CanTransition(run.Status, RunStatus.Failed))
+        {
+            run.TransitionTo(RunStatus.Failed);
+            _db.AppendAgentRunEvent(run, RunEventKind.Failed);
+            await _db.SaveChangesAsync(ct);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Run {RunId} dispatch failure could not transition {Status}→Failed; leaving status untouched.",
+                run.Id, run.Status);
+        }
+
         return RunDispatchOutcome.Failed(error);
     }
 }

--- a/tests/Andy.Containers.Api.Tests/Services/RunModeDispatcherTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/RunModeDispatcherTests.cs
@@ -229,6 +229,75 @@ public class RunModeDispatcherTests : IDisposable
         await act.Should().ThrowAsync<ArgumentException>();
     }
 
+    // rivoli-ai/conductor#2122 — a dispatch-level failure must be TERMINAL:
+    // the Run row transitions to Failed with the reason recorded, and the
+    // andy.containers.events.run.{id}.failed outbox event is published so
+    // downstream consumers (andy-tasks' RunEventConsumer) fold the truth
+    // instead of leaving their AgentRun rows Running forever.
+    [Fact]
+    public async Task Dispatch_NoWorkspaceRef_TransitionsRunToFailed_AndPublishesFailedEvent()
+    {
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "x",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            Status = RunStatus.Pending,
+        };
+        _db.Runs.Add(run);
+        await _db.SaveChangesAsync();
+
+        var outcome = await _dispatcher.DispatchAsync(run, ConfigPath);
+
+        outcome.Kind.Should().Be(RunDispatchKind.Failed);
+        run.Status.Should().Be(RunStatus.Failed);
+        run.Error.Should().Contain("workspace reference");
+        _db.OutboxEntries.Should().ContainSingle(e =>
+            e.Subject == $"andy.containers.events.run.{run.Id}.failed");
+    }
+
+    [Fact]
+    public async Task Dispatch_WorkspaceNotFound_TransitionsRunToFailed_AndPublishesFailedEvent()
+    {
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AgentId = "x",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            Status = RunStatus.Pending,
+            WorkspaceRef = new WorkspaceRef { WorkspaceId = Guid.NewGuid() }, // not seeded
+        };
+        _db.Runs.Add(run);
+        await _db.SaveChangesAsync();
+
+        await _dispatcher.DispatchAsync(run, ConfigPath);
+
+        run.Status.Should().Be(RunStatus.Failed);
+        run.Error.Should().Contain("not found");
+        _db.OutboxEntries.Should().ContainSingle(e =>
+            e.Subject == $"andy.containers.events.run.{run.Id}.failed");
+    }
+
+    // Desktop's NotImplemented bail deliberately keeps the row Pending
+    // (a not-yet-wired mode is retryable, not failed) — pin that the new
+    // terminal handling did not leak into it.
+    [Fact]
+    public async Task Dispatch_Desktop_StaysPending_NoFailedEvent()
+    {
+        var (run, _) = SeedRunAndWorkspace(RunMode.Desktop);
+
+        var outcome = await _dispatcher.DispatchAsync(run, ConfigPath);
+
+        outcome.Kind.Should().Be(RunDispatchKind.NotImplemented);
+        run.Status.Should().Be(RunStatus.Pending);
+        _db.OutboxEntries.Should().NotContain(e =>
+            e.Subject == $"andy.containers.events.run.{run.Id}.failed");
+    }
+
     private (Run run, Workspace workspace) SeedRunAndWorkspace(RunMode mode)
     {
         var workspace = new Workspace


### PR DESCRIPTION
Fixes the andy-containers half of rivoli-ai/conductor#2122 (phantom Running runs).

A dispatch-level failure (no workspace ref / workspace not found / no default container / unknown mode) used to be log-only: the Run row stayed Pending, no `andy.containers.events.run.{id}.failed` event was published, and andy-tasks' RunEventConsumer never folded a terminal state — its AgentRun row showed Running forever for a run that never started.

`Fail()` → `FailAsync()`: records `run.Error`, transitions to `Failed` (guarded by `RunStatusTransitions`), appends the agent-run Failed outbox event, saves. Desktop's `NotImplemented` bail deliberately stays Pending (retryable) — pinned by a new test.

Tests: 3 new in `RunModeDispatcherTests` (terminal transition + event for no-workspace and workspace-not-found; Desktop stays Pending, no event). Run-related scope green: **80/80** (`RunModeDispatcher|RunsController|RunsMcpTools|RunEvent`). Full Api.Tests suite hangs on this dev box on unrelated docker-dependent tests — relying on CI for the full pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)