### PR TITLE
Fix dead-container poll loop: surface NotFound as provider-neutral not-found

### DIFF
--- a/src/Andy.Containers.Infrastructure/Providers/Local/DockerInfrastructureProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Local/DockerInfrastructureProvider.cs
@@ -317,7 +317,26 @@ public class DockerInfrastructureProvider : IInfrastructureProvider
 
     public async Task<ContainerRuntimeInfo> GetContainerInfoAsync(string externalId, CancellationToken ct)
     {
-        var inspect = await _client.Containers.InspectContainerAsync(externalId, ct);
+        ContainerInspectResponse inspect;
+        try
+        {
+            inspect = await _client.Containers.InspectContainerAsync(externalId, ct);
+        }
+        catch (DockerContainerNotFoundException ex)
+        {
+            // The docker daemon has no such container — it was removed
+            // out-of-band (e.g. a later create reused the container name and
+            // removed this one, host reboot, prune). Surface a PROVIDER-NEUTRAL
+            // "not found" so reconcilers (ContainerStatusSyncWorker) flip the
+            // stale DB row to Destroyed instead of busy-looping on the phantom
+            // forever. Docker.DotNet throws DockerContainerNotFoundException
+            // (a DockerApiException, NOT an InvalidOperationException), which
+            // the sync worker's message-based catch never matched — this
+            // translation is what makes that catch fire. rivoli-ai/conductor
+            // dead-container poll loop fix.
+            throw new InvalidOperationException(
+                $"Container {externalId} not found on the docker daemon", ex);
+        }
         return new ContainerRuntimeInfo
         {
             ExternalId = externalId,


### PR DESCRIPTION
## Problem
`ContainerStatusSyncWorker` reconciles stale rows by catching `InvalidOperationException` whose message contains "not found"/"no such" → flips the row to `Destroyed`. But `DockerInfrastructureProvider.GetContainerInfoAsync` lets `DockerContainerNotFoundException` (a `DockerApiException`, **not** an `InvalidOperationException`) propagate raw, so that catch never matched. A container removed out-of-band (a later create reused the container name and removed this one) left its DB row stuck at `Running` forever — the sync worker re-selected it every 15s and `ContainerScreenshotWorker` busy-looped `ExecAsync` on the phantom every 30s (the repeating `DockerContainerNotFoundException` log spam).

## Fix
`GetContainerInfoAsync` catches `DockerContainerNotFoundException` and rethrows it as a provider-neutral `InvalidOperationException("… not found …")`, so the existing reconciler catch fires and marks the row `Destroyed` — stopping both loops on the next sync. Keeps the sync worker provider-agnostic (no Docker.DotNet dependency leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)