### PR TITLE
[Containers] Land agent run summary into the collected outputs root (conductor#2250)

### DIFF
--- a/docs/run-configurator.md
+++ b/docs/run-configurator.md
@@ -81,7 +81,7 @@ Unknown transports (anything other than `"mcp"` or `"cli"`) throw at the builder
 
 | Output field | Source | Notes |
 |---|---|---|
-| `output.file` | constant `"/workspace/.andy-run/output.json"` | Path andy-cli atomically writes the agent's structured response to. Read by Conductor / consumers. |
+| `output.file` | constant `"/workspace/.andy/outputs/run-summary.md"` | Path andy-cli atomically writes the agent's final prose report to. **Lands under the collected outputs root** (`FilesystemOutputArtifactCollector.OutputsRoot`) so the terminal-event artifact collector picks it up, uploads it to andy-docs, and emits it as a `RunOutputArtifact` with a `DocsRef` — surfacing the summary in Conductor's task detail (rivoli-ai/conductor#2250). Before #2250 it was parked at `/workspace/.andy-run/output.json`, which no collector scanned, so the report was written and then dropped. |
 | `output.stream` | constant `"stdout"` | Where structured events are emitted (parsed by AP6). |
 
 ### Event sink (`HeadlessEventSink`)

--- a/src/Andy.Containers/Configurator/HeadlessConfigBuilder.cs
+++ b/src/Andy.Containers/Configurator/HeadlessConfigBuilder.cs
@@ -25,7 +25,31 @@ public sealed class HeadlessConfigBuilder : IHeadlessConfigBuilder
     };
 
     private const string DefaultWorkspaceRoot = "/workspace";
-    private const string DefaultOutputFile = "/workspace/.andy-run/output.json";
+
+    // rivoli-ai/conductor#2250. The agent's final prose report (andy-cli's
+    // `result.Response`, written verbatim to `output.file`) was historically
+    // parked at `/workspace/.andy-run/output.json` — a path NO collector ever
+    // scans. FilesystemOutputArtifactCollector only walks its OutputsRoot
+    // (`/workspace/.andy/outputs`), so the summary was written to disk inside
+    // the container and then dropped on the floor: it never reached andy-docs,
+    // never rode the RunEventPayload OutputArtifacts list, and never surfaced
+    // in Conductor's task detail.
+    //
+    // Pointing the output file INTO the collected outputs root, under a
+    // well-known name, means the existing #320 collector picks it up, uploads
+    // it to andy-docs, and emits it as a RunOutputArtifact with a DocsRef —
+    // with ZERO new collection/upload/event code. Conductor keys off the
+    // `RunSummaryFileName` to render it as the run's summary card rather than a
+    // generic artifact row. Kept as `.md` because the report is prose, not a
+    // structured JSON document (andy-cli writes the raw LLM response text).
+    //
+    // NOTE: the literal `/workspace/.andy/outputs` is duplicated from
+    // FilesystemOutputArtifactCollector.OutputsRoot (API project) — the core
+    // lib can't reference the API project, so the linkage is enforced by
+    // HeadlessConfigBuilderTests.OutputFile_LandsUnderCollectedOutputsRoot.
+    public const string RunSummaryFileName = "run-summary.md";
+    private const string DefaultOutputFile =
+        DefaultWorkspaceRoot + "/.andy/outputs/" + RunSummaryFileName;
     private const string DefaultStream = "stdout";
 
     public HeadlessRunConfig Build(Run run, AgentSpec agent)

--- a/tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigBuilderTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Configurator/HeadlessConfigBuilderTests.cs
@@ -43,7 +43,7 @@ public class HeadlessConfigBuilderTests
         config.Workspace.Root.Should().Be("/workspace");
         config.Workspace.Branch.Should().Be("main", "branch flows from Run.WorkspaceRef.Branch");
 
-        config.Output.File.Should().Be("/workspace/.andy-run/output.json");
+        config.Output.File.Should().Be("/workspace/.andy/outputs/run-summary.md");
         config.Output.Stream.Should().Be("stdout");
 
         config.EventSink!.NatsSubject.Should().Be(
@@ -54,6 +54,30 @@ public class HeadlessConfigBuilderTests
         config.Boundaries.Should().Equal("read-only");
         config.Limits.MaxIterations.Should().Be(50);
         config.Limits.TimeoutSeconds.Should().Be(300);
+    }
+
+    // rivoli-ai/conductor#2250. The summary drop: andy-cli writes its prose
+    // report to config.Output.File, but the collector only walks
+    // FilesystemOutputArtifactCollector.OutputsRoot. If the output file does
+    // not land under that root the report is written into the container and
+    // never collected/uploaded/surfaced — exactly the bug this fix closes.
+    // This guard fails against the old `/workspace/.andy-run/output.json`
+    // default (which is NOT under OutputsRoot) and passes against the new one.
+    [Fact]
+    public void OutputFile_LandsUnderCollectedOutputsRoot()
+    {
+        var config = _builder.Build(SeedRun(), TriageAgent());
+
+        var outputsRoot =
+            Andy.Containers.Api.Services.FilesystemOutputArtifactCollector.OutputsRoot;
+
+        config.Output.File.Should().StartWith(outputsRoot + "/",
+            "the agent's summary report must land under the path the artifact " +
+            "collector scans, or it never reaches andy-docs / Conductor (#2250)");
+        config.Output.File.Should().EndWith(
+            "/" + HeadlessConfigBuilder.RunSummaryFileName,
+            "Conductor keys off the well-known summary file name to render the " +
+            "run-summary card rather than a generic artifact row");
     }
 
     [Fact]

--- a/tests/Andy.Containers.Api.Tests/Configurator/__snapshots__/execute.json
+++ b/tests/Andy.Containers.Api.Tests/Configurator/__snapshots__/execute.json
@@ -41,7 +41,7 @@
     "ANDY_PROXY_URL": "https://proxy.andy.local"
   },
   "output": {
-    "file": "/workspace/.andy-run/output.json",
+    "file": "/workspace/.andy/outputs/run-summary.md",
     "stream": "stdout"
   },
   "event_sink": {

--- a/tests/Andy.Containers.Api.Tests/Configurator/__snapshots__/plan.json
+++ b/tests/Andy.Containers.Api.Tests/Configurator/__snapshots__/plan.json
@@ -23,7 +23,7 @@
     "branch": "feature/x"
   },
   "output": {
-    "file": "/workspace/.andy-run/output.json",
+    "file": "/workspace/.andy/outputs/run-summary.md",
     "stream": "stdout"
   },
   "event_sink": {

--- a/tests/Andy.Containers.Api.Tests/Configurator/__snapshots__/triage.json
+++ b/tests/Andy.Containers.Api.Tests/Configurator/__snapshots__/triage.json
@@ -33,7 +33,7 @@
     "branch": "main"
   },
   "output": {
-    "file": "/workspace/.andy-run/output.json",
+    "file": "/workspace/.andy/outputs/run-summary.md",
     "stream": "stdout"
   },
   "event_sink": {


### PR DESCRIPTION
## What

The agent's final prose report (andy-cli's `result.Response`) is written verbatim to the headless `output.file`, which `HeadlessConfigBuilder` hard-coded to `/workspace/.andy-run/output.json`. **No collector ever scans that path** — `FilesystemOutputArtifactCollector` only walks its `OutputsRoot` (`/workspace/.andy/outputs`). So the summary was written to disk inside the container and then dropped: it never reached andy-docs, never rode the `RunEventPayload.OutputArtifacts` list, and never surfaced in Conductor's task detail.

This is **drop #1** of the three root-caused in conductor#2250 (the summary is never surfaced).

## Fix

Point the default output file at `/workspace/.andy/outputs/run-summary.md` (new `HeadlessConfigBuilder.RunSummaryFileName` constant). The existing #320 collector now picks it up, uploads it to andy-docs, and emits it as a `RunOutputArtifact` with a `DocsRef` — **with zero new collection / upload / event code**. Conductor (companion PR) keys off the well-known file name to render the run-summary card.

## Tests

- `HeadlessConfigBuilderTests.OutputFile_LandsUnderCollectedOutputsRoot` — new guard asserting the output file lands under the collector's scan root and ends with the well-known name. **Verified fail-then-pass**: fails against the old `/workspace/.andy-run/output.json` default, passes against the new path.
- Golden snapshots (`triage`/`plan`/`execute`) updated for the new `output.file`.
- `run-configurator.md` updated.
- **Configurator suite: 104 passed, 0 failed.**

## Cross-reference

Part of conductor#2250 (run summaries / transcript / token-cost). Companion: conductor PR on branch `feat/2250-run-summaries-transcript`.

Remaining #2250 drops are out of this slice (transcript persistence + token/cost), blocked at the andy-cli floor — see the conductor PR body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)