### PR TITLE
Run dispatched coding agent with CWD at the workspace checkout root

### DIFF
--- a/src/Andy.Containers.Api/Services/HeadlessRunner.cs
+++ b/src/Andy.Containers.Api/Services/HeadlessRunner.cs
@@ -186,9 +186,27 @@ public sealed class HeadlessRunner : IHeadlessRunner
         // no proxy service / no base url / mint failure → no prefix.
         var modelKeyPrefix = await BuildModelKeyOverrideAsync(run, configJson, containerId, execToken);
 
+        // conductor MSB1003 / andy-tasks#383. The repo is cloned DIRECTLY into
+        // the workspace root (GitCloneService: `cp -a {tmp}/. {target}/`,
+        // TargetPath defaults to /workspace), so e.g. /workspace/Andy.Cli.sln
+        // exists. But the exec endpoint runs `sh -c "<command>"` with NO
+        // WorkingDir (the ExecRequest wire shape is {Command, TimeoutSeconds}
+        // only), so andy-cli would otherwise run from the image's default
+        // WORKDIR — NOT the checkout root. andy-cli is normally invoked from
+        // inside the cloned repo and relies on its process CWD being the
+        // checkout, so a missing `cd` makes the agent operate against the wrong
+        // directory (tooling that resolves paths relative to CWD fails). The
+        // companion fix andy-tasks#383 already prefixes the VERIFIER command
+        // with `cd '/workspace' && `; this is the same fix for the dispatched
+        // coding-agent run. Single chokepoint: we prepend exactly one `cd`,
+        // and only the andy-cli sub-command runs under it — the mkdir/stage
+        // steps stay CWD-agnostic (they use absolute /tmp paths).
+        var workspaceRoot = ResolveWorkspaceRoot(configJson);
+
         var command =
             $"mkdir -p {ShellEscape(stageDir)} && "
             + $"printf %s {ShellEscape(configB64)} | base64 -d > {ShellEscape(inContainerConfigPath)} && "
+            + $"cd {ShellEscape(workspaceRoot)} && "
             + $"{modelKeyPrefix}andy-cli run --headless --config {ShellEscape(inContainerConfigPath)}";
         var execTimeout = await ResolveExecTimeoutAsync(configPath, execToken);
 
@@ -573,6 +591,31 @@ public sealed class HeadlessRunner : IHeadlessRunner
                 "#2231: could not mint model-scoped proxy token for Run {RunId} (model {Model}); falling back to the container-default OPENAI_API_KEY. Reason: {Reason}",
                 run.Id, modelId, ex.Message);
             return string.Empty;
+        }
+    }
+
+    // conductor MSB1003 / andy-tasks#383. The directory the dispatched
+    // coding-agent run must `cd` into before invoking andy-cli — the repo
+    // checkout root. The on-disk headless config carries the authoritative
+    // value at `workspace.root` (HeadlessConfigBuilder sets it from the
+    // container's ContainerGitRepository.TargetPath, default "/workspace").
+    // We honour that so a non-default TargetPath would still land us in the
+    // right place; we fall back to the same DefaultWorkspaceRoot constant when
+    // the config can't be parsed or doesn't pin a root (e.g. the bare "{}"
+    // configs the runner's standalone test surface uses).
+    private const string DefaultWorkspaceRoot = "/workspace";
+
+    private static string ResolveWorkspaceRoot(string configJson)
+    {
+        try
+        {
+            var config = JsonSerializer.Deserialize<HeadlessRunConfig>(configJson, HeadlessConfigJson.Options);
+            var root = config?.Workspace?.Root;
+            return string.IsNullOrWhiteSpace(root) ? DefaultWorkspaceRoot : root.Trim();
+        }
+        catch (Exception)
+        {
+            return DefaultWorkspaceRoot;
         }
     }
 

--- a/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
@@ -451,6 +451,63 @@ public class HeadlessRunnerTests : IDisposable
         captured.Should().Contain($"andy-cli run --headless --config '/tmp/andy-runs/{run.Id}/config.json'");
     }
 
+    // conductor MSB1003 / andy-tasks#383. The repo is cloned DIRECTLY into the
+    // workspace root (/workspace/Andy.Cli.sln exists), but the exec endpoint
+    // runs `sh -c "<command>"` with NO WorkingDir — so without an explicit
+    // `cd` andy-cli runs from the image's default WORKDIR, not the checkout.
+    // andy-cli relies on its process CWD being the checkout root, so the
+    // dispatched coding-agent command MUST be prefixed with `cd '/workspace' &&`
+    // before the andy-cli invocation (mirroring andy-tasks#383's verifier fix).
+    // This test FAILS against the old code (no `cd`) and passes with the fix.
+    [Fact]
+    public async Task StartAsync_CdsIntoWorkspaceRoot_BeforeRunningAndyCli()
+    {
+        var run = SeedRun();
+        string? captured = null;
+        _containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, CancellationToken>((_, cmd, _, _) => captured = cmd)
+            .ReturnsAsync(new ExecResult { ExitCode = 0 });
+
+        await _runner.StartAsync(run, _configPath);
+
+        captured.Should().NotBeNull();
+        // The `cd` must land immediately before the andy-cli invocation so the
+        // agent's process CWD is the checkout root.
+        captured.Should().Contain("cd '/workspace' && andy-cli run --headless",
+            "the dispatched agent must run with CWD at the checkout root");
+    }
+
+    // conductor MSB1003. The `cd` and the #2231 model-key override compose:
+    // the OPENAI_API_KEY assignment must stay attached to the andy-cli process
+    // and the whole thing must run under the `cd`.
+    [Fact]
+    public async Task StartAsync_CdsIntoWorkspaceRoot_BeforeModelScopedKeyAndAndyCli()
+    {
+        var run = SeedRun();
+        SeedContainer(run.ContainerId!.Value, ownerId: "owner-42");
+        const string modelId = "openrouter/qwen3-coder";
+        var configPath = WriteRealConfigWithModel(modelId);
+
+        string? captured = null;
+        _containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, CancellationToken>((_, cmd, _, _) => captured = cmd)
+            .ReturnsAsync(new ExecResult { ExitCode = 0 });
+
+        var proxy = new RecordingProxyTokenService("jwt-scoped-to-qwen");
+        var runner = MakeRunnerWithProxy(proxy, modelsBaseUrlConfigured: true);
+
+        await runner.StartAsync(run, configPath);
+
+        captured.Should().NotBeNull();
+        captured.Should().Contain("cd '/workspace' && OPENAI_API_KEY='jwt-scoped-to-qwen' andy-cli run --headless",
+            "the model-key override and andy-cli must both run under the workspace `cd`");
+        File.Delete(configPath);
+    }
+
     // ----- #2231 model-scoped OPENAI_API_KEY override -----
 
     // #2231. THE bug GOAL-23 hit: the container's create-time OPENAI_API_KEY


### PR DESCRIPTION
## The bug

The container exec endpoint (`POST api/containers/{id}/exec`) runs `sh -c "<command>"` with **no WorkingDir** — the `ExecRequest` wire shape is `{Command, TimeoutSeconds}` only, so any command runs in the image's default `WORKDIR`, **not** the repo checkout.

The repo is cloned **directly** into the workspace root (`GitCloneService`: `cp -a {tmp}/. {target}/`, `TargetPath` defaults to `/workspace`), so e.g. `/workspace/Andy.Cli.sln` exists. `andy-cli` is normally invoked from inside the cloned repo and relies on its process CWD being the checkout root.

`HeadlessRunner` built the dispatched `andy-cli run --headless` command with **no `cd`** into the checkout, so the coding agent ran with the wrong working directory — CWD-relative tooling (path resolution, build/test invocation) operates against the image WORKDIR instead of the repo. This is the same working-directory failure class as conductor **MSB1003** and the exact same gap the companion fix **andy-tasks#383** already closed for the **verifier** path (which now prefixes `cd '/workspace' && <command>`). This PR is that same fix for the dispatched coding-agent run.

## The fix

At the single command-build chokepoint in `HeadlessRunner.StartAsync`, prefix the `andy-cli` sub-command with `cd '<workspaceRoot>' && `.

- The workspace root is read from the on-disk headless config's `workspace.root` (set by `HeadlessConfigBuilder` from `ContainerGitRepository.TargetPath`, default `/workspace`), so a non-default `TargetPath` would still land the agent in the right place. Falls back to `/workspace` when the config can't be parsed or pins no root.
- The `mkdir`/base64-stage steps keep their absolute `/tmp` paths, so they stay CWD-agnostic — the `cd` runs only between staging and `andy-cli`. Single chokepoint, no double-`cd`, composes correctly with the #2231 `OPENAI_API_KEY=...` override (it stays attached to the andy-cli process under the `cd`).

## Tests

New `HeadlessRunnerTests` (capture the exec'd command via the mocked `IContainerService.ExecAsync`):

- `StartAsync_CdsIntoWorkspaceRoot_BeforeRunningAndyCli` — asserts the command contains `cd '/workspace' && andy-cli run --headless`.
- `StartAsync_CdsIntoWorkspaceRoot_BeforeModelScopedKeyAndAndyCli` — asserts `cd '/workspace' && OPENAI_API_KEY='<jwt>' andy-cli run --headless` (composes with the #2231 override).

Both **fail against the old code** (verified: `Expected ... to contain "cd '/workspace' && andy-cli run --headless"`) and **pass with the fix**.

`dotnet build` green. `HeadlessRunnerTests`: **40/40 pass**. The 3 unrelated failures in the wider `Andy.Containers.Api.Tests` project (`AndyModelsProxyTokenServiceTests.Mint_ObOExchangeFailure`, `HeadlessRunLauncherTests.Dispatch_ReturnsPromptly`, `ContainerOrchestrationServicePerToolEnvTests.CreateContainer_OpenCodeWithCustomBaseUrl`) reproduce **identically on unmodified `origin/main`** — confirmed pre-existing, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)