### PR TITLE
[Containers] Make WorkingDir a first-class field on the exec contract

### DIFF
--- a/src/Andy.Containers.Api/Controllers/ContainersController.cs
+++ b/src/Andy.Containers.Api/Controllers/ContainersController.cs
@@ -318,7 +318,14 @@ public class ContainersController : ControllerBase
         if (container is null) return ContainerNotFound(id);
         if (!CanAccess(container)) return Forbid();
 
-        var result = await _containerService.ExecAsync(id, request.Command, ct);
+        // Backward compatible: with no WorkingDir we take the exact same
+        // default-timeout path as before. A WorkingDir routes through the
+        // working-dir-aware overload (Docker native -w / cd wrap elsewhere)
+        // honouring the request's TimeoutSeconds.
+        var result = string.IsNullOrWhiteSpace(request.WorkingDir)
+            ? await _containerService.ExecAsync(id, request.Command, ct)
+            : await _containerService.ExecAsync(
+                id, request.Command, TimeSpan.FromSeconds(request.TimeoutSeconds), request.WorkingDir, ct);
         return Ok(result);
     }
 
@@ -964,6 +971,16 @@ public class ExecRequest
 {
     public required string Command { get; set; }
     public int TimeoutSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Optional working directory inside the container the command runs in
+    /// (the repo checkout, e.g. <c>/workspace</c>) — exec working-dir feature.
+    /// Honoured via Docker's native <c>WorkingDir</c> (<c>docker exec -w</c>)
+    /// or a <c>cd '&lt;dir&gt;' &amp;&amp; </c> wrap on providers without a
+    /// native flag. Null/empty ⇒ the image's default WORKDIR (the historical
+    /// behaviour), so existing callers are unaffected.
+    /// </summary>
+    public string? WorkingDir { get; set; }
 }
 
 public class ResizeRequest

--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -1000,13 +1000,18 @@ public class ContainerOrchestrationService : IContainerService
         return await infra.ExecAsync(container.ExternalId!, command, ct);
     }
 
-    public async Task<ExecResult> ExecAsync(Guid containerId, string command, TimeSpan timeout, CancellationToken ct)
+    public Task<ExecResult> ExecAsync(Guid containerId, string command, TimeSpan timeout, CancellationToken ct)
+        => ExecAsync(containerId, command, timeout, workingDir: null, ct);
+
+    public async Task<ExecResult> ExecAsync(Guid containerId, string command, TimeSpan timeout, string? workingDir, CancellationToken ct)
     {
         using var activity = ActivitySources.Provisioning.StartActivity("ExecCommand");
         activity?.SetTag("andy.containers.id", containerId.ToString());
         activity?.SetTag("containerId", containerId.ToString()); // deprecated; removed in Andy.Telemetry 0.3.0 (OT7 / #1265)
         activity?.SetTag("andy.containers.timeout_seconds", timeout.TotalSeconds);
         activity?.SetTag("timeout", timeout.TotalSeconds); // deprecated; removed in Andy.Telemetry 0.3.0 (OT7 / #1265)
+        if (!string.IsNullOrWhiteSpace(workingDir))
+            activity?.SetTag("andy.containers.working_dir", workingDir);
 
         var container = await GetContainerAsync(containerId, ct);
         if (container.Status is not (ContainerStatus.Running or ContainerStatus.Creating))
@@ -1015,7 +1020,7 @@ public class ContainerOrchestrationService : IContainerService
             throw new InvalidOperationException("Container has no external ID yet");
 
         var infra = _providerFactory.GetProvider(container.Provider!);
-        return await infra.ExecAsync(container.ExternalId!, command, timeout, ct);
+        return await infra.ExecAsync(container.ExternalId!, command, timeout, workingDir, ct);
     }
 
     // F4.1 (rivoli-ai/conductor#1934). Mid-run streaming exec. Resolves
@@ -1025,12 +1030,15 @@ public class ContainerOrchestrationService : IContainerService
     // the interface default (buffered, replayed at end).
     public async Task<ExecResult> ExecStreamingAsync(
         Guid containerId, string command, TimeSpan timeout,
-        Action<ExecOutputChunk> onLine, CancellationToken ct)
+        Action<ExecOutputChunk> onLine, CancellationToken ct,
+        string? workingDir = null)
     {
         ArgumentNullException.ThrowIfNull(onLine);
         using var activity = ActivitySources.Provisioning.StartActivity("ExecCommandStreaming");
         activity?.SetTag("andy.containers.id", containerId.ToString());
         activity?.SetTag("andy.containers.timeout_seconds", timeout.TotalSeconds);
+        if (!string.IsNullOrWhiteSpace(workingDir))
+            activity?.SetTag("andy.containers.working_dir", workingDir);
 
         var container = await GetContainerAsync(containerId, ct);
         if (container.Status is not (ContainerStatus.Running or ContainerStatus.Creating))
@@ -1039,7 +1047,7 @@ public class ContainerOrchestrationService : IContainerService
             throw new InvalidOperationException("Container has no external ID yet");
 
         var infra = _providerFactory.GetProvider(container.Provider!);
-        return await infra.ExecStreamingAsync(container.ExternalId!, command, timeout, onLine, ct);
+        return await infra.ExecStreamingAsync(container.ExternalId!, command, timeout, onLine, ct, workingDir);
     }
 
     public async Task<ConnectionInfo> GetConnectionInfoAsync(Guid containerId, CancellationToken ct)

--- a/src/Andy.Containers.Api/Services/HeadlessRunner.cs
+++ b/src/Andy.Containers.Api/Services/HeadlessRunner.cs
@@ -189,24 +189,22 @@ public sealed class HeadlessRunner : IHeadlessRunner
         // conductor MSB1003 / andy-tasks#383. The repo is cloned DIRECTLY into
         // the workspace root (GitCloneService: `cp -a {tmp}/. {target}/`,
         // TargetPath defaults to /workspace), so e.g. /workspace/Andy.Cli.sln
-        // exists. But the exec endpoint runs `sh -c "<command>"` with NO
-        // WorkingDir (the ExecRequest wire shape is {Command, TimeoutSeconds}
-        // only), so andy-cli would otherwise run from the image's default
-        // WORKDIR — NOT the checkout root. andy-cli is normally invoked from
-        // inside the cloned repo and relies on its process CWD being the
-        // checkout, so a missing `cd` makes the agent operate against the wrong
-        // directory (tooling that resolves paths relative to CWD fails). The
-        // companion fix andy-tasks#383 already prefixes the VERIFIER command
-        // with `cd '/workspace' && `; this is the same fix for the dispatched
-        // coding-agent run. Single chokepoint: we prepend exactly one `cd`,
-        // and only the andy-cli sub-command runs under it — the mkdir/stage
-        // steps stay CWD-agnostic (they use absolute /tmp paths).
+        // exists. andy-cli is normally invoked from inside the cloned repo and
+        // relies on its process CWD being the checkout, so running from the
+        // image's default WORKDIR makes the agent operate against the wrong
+        // directory (tooling that resolves paths relative to CWD fails).
+        //
+        // #360 worked around this by prefixing `cd '<root>' && ` onto the
+        // andy-cli sub-command. This now uses the FIRST-CLASS WorkingDir field
+        // on the exec contract instead (Docker native `-w`, cd-wrap elsewhere),
+        // so the whole exec runs under the checkout root via a single
+        // mechanism. The mkdir/stage steps stay correct because they use
+        // absolute /tmp paths — they don't care what the CWD is.
         var workspaceRoot = ResolveWorkspaceRoot(configJson);
 
         var command =
             $"mkdir -p {ShellEscape(stageDir)} && "
             + $"printf %s {ShellEscape(configB64)} | base64 -d > {ShellEscape(inContainerConfigPath)} && "
-            + $"cd {ShellEscape(workspaceRoot)} && "
             + $"{modelKeyPrefix}andy-cli run --headless --config {ShellEscape(inContainerConfigPath)}";
         var execTimeout = await ResolveExecTimeoutAsync(configPath, execToken);
 
@@ -228,15 +226,17 @@ public sealed class HeadlessRunner : IHeadlessRunner
             if (_outputBus is not null)
             {
                 // Mid-run live feed: publish each line as it lands,
-                // redacted, tagged with its stream kind.
+                // redacted, tagged with its stream kind. The agent runs in the
+                // checkout root via the first-class WorkingDir field (#360
+                // migration), not a `cd` prefix.
                 result = await _containers.ExecStreamingAsync(
                     containerId, command, execTimeout,
                     chunk => PublishOutputLine(run.Id, chunk, knownToken),
-                    execToken);
+                    execToken, workspaceRoot);
             }
             else
             {
-                result = await _containers.ExecAsync(containerId, command, execTimeout, execToken);
+                result = await _containers.ExecAsync(containerId, command, execTimeout, workspaceRoot, execToken);
             }
         }
         catch (OperationCanceledException) when (execToken.IsCancellationRequested)

--- a/src/Andy.Containers.Client/ContainersClient.cs
+++ b/src/Andy.Containers.Client/ContainersClient.cs
@@ -81,8 +81,22 @@ public sealed class ContainersClient
     }
 
     public async Task<ExecResultDto> ExecAsync(string id, string command, CancellationToken ct = default)
+        => await ExecAsync(id, command, workingDir: null, ct);
+
+    /// <summary>
+    /// Runs <paramref name="command"/> inside the container. When
+    /// <paramref name="workingDir"/> is non-empty the command runs in that
+    /// directory (the repo checkout, e.g. <c>/workspace</c>) — exec working-dir
+    /// feature. Null/empty ⇒ the image's default WORKDIR (the historical
+    /// behaviour), and the field is omitted from the request body so the wire
+    /// shape is byte-identical to the pre-feature request.
+    /// </summary>
+    public async Task<ExecResultDto> ExecAsync(string id, string command, string? workingDir, CancellationToken ct = default)
     {
-        var r = await _http.PostAsJsonAsync($"api/containers/{id}/exec", new { command }, _json, ct);
+        object body = string.IsNullOrWhiteSpace(workingDir)
+            ? new { command }
+            : new { command, workingDir };
+        var r = await _http.PostAsJsonAsync($"api/containers/{id}/exec", body, _json, ct);
         await EnsureSuccessAsync(r, ct);
         return (await r.Content.ReadFromJsonAsync<ExecResultDto>(_json, ct))!;
     }

--- a/src/Andy.Containers.Infrastructure/Providers/Apple/AppleContainerProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Apple/AppleContainerProvider.cs
@@ -183,11 +183,18 @@ public class AppleContainerProvider : IInfrastructureProvider
         return await ExecAsync(externalId, command, TimeSpan.FromSeconds(30), ct);
     }
 
-    public async Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct)
+    public Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct)
+        => ExecAsync(externalId, command, timeout, workingDir: null, ct);
+
+    public async Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, string? workingDir, CancellationToken ct)
     {
+        // Apple's `container exec` carries no native working-dir flag, so we
+        // wrap the command with `cd '<dir>' && ` (exec working-dir feature).
+        // Null/empty workingDir ⇒ command unchanged (pre-existing behaviour).
+        var effectiveCommand = ExecWorkingDir.Wrap(command, workingDir);
         // Use ArgumentList to avoid shell quoting issues with ProcessStartInfo.Arguments.
         // Apple `container exec` syntax: container exec <id> <command> [args...]
-        var result = await RunCliWithArgsAsync(["exec", externalId, "sh", "-c", command], ct, timeout);
+        var result = await RunCliWithArgsAsync(["exec", externalId, "sh", "-c", effectiveCommand], ct, timeout);
         return new ExecResult
         {
             ExitCode = result.ExitCode,

--- a/src/Andy.Containers.Infrastructure/Providers/Aws/AwsFargateProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Aws/AwsFargateProvider.cs
@@ -279,8 +279,14 @@ public class AwsFargateProvider : IInfrastructureProvider
         return ExecAsync(externalId, command, TimeSpan.FromSeconds(30), ct);
     }
 
-    public async Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct)
+    public Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct)
+        => ExecAsync(externalId, command, timeout, workingDir: null, ct);
+
+    public async Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, string? workingDir, CancellationToken ct)
     {
+        // No native working-dir flag on this exec path — wrap via
+        // `cd '<dir>' && ` (exec working-dir feature). Null/empty ⇒ unchanged.
+        command = ExecWorkingDir.Wrap(command, workingDir);
         // ECS Exec uses SSM to create an interactive session
         var response = await _ecsClient.ExecuteCommandAsync(new ExecuteCommandRequest
         {

--- a/src/Andy.Containers.Infrastructure/Providers/Azure/AzureAciProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Azure/AzureAciProvider.cs
@@ -238,6 +238,12 @@ public class AzureAciProvider : IInfrastructureProvider
         return await ExecAsync(externalId, command, TimeSpan.FromSeconds(30), ct);
     }
 
+    // ACI's exec is an interactive WebSocket session keyed on /bin/sh and does
+    // not honour an inline command, so a working-dir hint has nothing to wrap
+    // onto here; we delegate to the base overload for interface completeness.
+    public Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, string? workingDir, CancellationToken ct)
+        => ExecAsync(externalId, command, timeout, ct);
+
     public async Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct)
     {
         var group = await GetContainerGroupAsync(externalId, ct);

--- a/src/Andy.Containers.Infrastructure/Providers/Gcp/GcpCloudRunProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Gcp/GcpCloudRunProvider.cs
@@ -226,10 +226,14 @@ public class GcpCloudRunProvider : IInfrastructureProvider
     }
 
     public Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct)
+        => ExecAsync(externalId, command, timeout, workingDir: null, ct);
+
+    public Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, string? workingDir, CancellationToken ct)
     {
         // GCP Cloud Run does not have a native exec API.
         // SSH fallback is needed: the container image must include an SSH server,
         // and the provider connects via SSH.NET to execute commands.
+        // (The working-dir hint is moot until that exec path exists.)
         throw new NotSupportedException(
             "GCP Cloud Run does not support native exec. " +
             "Configure SSH in the container image and use the SSH endpoint for command execution.");

--- a/src/Andy.Containers.Infrastructure/Providers/Local/DockerInfrastructureProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Local/DockerInfrastructureProvider.cs
@@ -449,11 +449,18 @@ public class DockerInfrastructureProvider : IInfrastructureProvider
         return await ExecAsync(externalId, command, TimeSpan.FromSeconds(30), ct);
     }
 
-    public async Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct)
+    public Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct)
+        => ExecAsync(externalId, command, timeout, workingDir: null, ct);
+
+    public async Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, string? workingDir, CancellationToken ct)
     {
         var exec = await _client.Exec.ExecCreateContainerAsync(externalId, new ContainerExecCreateParameters
         {
             Cmd = ["sh", "-c", command],
+            // Native Docker working directory (`docker exec -w`). Null/empty
+            // (the default) leaves the image's WORKDIR in effect — byte-
+            // identical to the historical no-working-dir behaviour.
+            WorkingDir = string.IsNullOrWhiteSpace(workingDir) ? null : workingDir.Trim(),
             AttachStdout = true,
             AttachStderr = true
         }, ct);
@@ -482,7 +489,8 @@ public class DockerInfrastructureProvider : IInfrastructureProvider
     /// </summary>
     public async Task<ExecResult> ExecStreamingAsync(
         string externalId, string command, TimeSpan timeout,
-        Action<ExecOutputChunk> onLine, CancellationToken ct)
+        Action<ExecOutputChunk> onLine, CancellationToken ct,
+        string? workingDir = null)
     {
         ArgumentNullException.ThrowIfNull(onLine);
 
@@ -493,6 +501,9 @@ public class DockerInfrastructureProvider : IInfrastructureProvider
         var exec = await _client.Exec.ExecCreateContainerAsync(externalId, new ContainerExecCreateParameters
         {
             Cmd = ["sh", "-c", command],
+            // Native Docker working directory (`docker exec -w`). Null/empty
+            // ⇒ image WORKDIR (pre-existing behaviour).
+            WorkingDir = string.IsNullOrWhiteSpace(workingDir) ? null : workingDir.Trim(),
             AttachStdout = true,
             AttachStderr = true,
         }, token);

--- a/src/Andy.Containers.Infrastructure/Providers/ThirdParty/CivoProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/ThirdParty/CivoProvider.cs
@@ -186,8 +186,14 @@ public class CivoProvider : IInfrastructureProvider
         return ExecAsync(externalId, command, TimeSpan.FromSeconds(30), ct);
     }
 
-    public async Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct)
+    public Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct)
+        => ExecAsync(externalId, command, timeout, workingDir: null, ct);
+
+    public async Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, string? workingDir, CancellationToken ct)
     {
+        // No native working-dir flag on this exec path — wrap via
+        // `cd '<dir>' && ` (exec working-dir feature). Null/empty ⇒ unchanged.
+        command = ExecWorkingDir.Wrap(command, workingDir);
         var (_, containerName) = ParseExternalId(externalId);
         var connInfo = await GetConnectionInfoAsync(externalId, ct);
 

--- a/src/Andy.Containers.Infrastructure/Providers/ThirdParty/DigitalOceanProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/ThirdParty/DigitalOceanProvider.cs
@@ -194,8 +194,14 @@ public class DigitalOceanProvider : IInfrastructureProvider
         return ExecAsync(externalId, command, TimeSpan.FromSeconds(30), ct);
     }
 
-    public async Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct)
+    public Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct)
+        => ExecAsync(externalId, command, timeout, workingDir: null, ct);
+
+    public async Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, string? workingDir, CancellationToken ct)
     {
+        // No native working-dir flag on this exec path — wrap via
+        // `cd '<dir>' && ` (exec working-dir feature). Null/empty ⇒ unchanged.
+        command = ExecWorkingDir.Wrap(command, workingDir);
         var (_, containerName) = ParseExternalId(externalId);
         var connInfo = await GetConnectionInfoAsync(externalId, ct);
 

--- a/src/Andy.Containers.Infrastructure/Providers/ThirdParty/FlyIoProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/ThirdParty/FlyIoProvider.cs
@@ -227,8 +227,14 @@ public class FlyIoProvider : IInfrastructureProvider
         return ExecAsync(externalId, command, TimeSpan.FromSeconds(30), ct);
     }
 
-    public async Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct)
+    public Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct)
+        => ExecAsync(externalId, command, timeout, workingDir: null, ct);
+
+    public async Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, string? workingDir, CancellationToken ct)
     {
+        // No native working-dir flag on this exec path — wrap via
+        // `cd '<dir>' && ` (exec working-dir feature). Null/empty ⇒ unchanged.
+        command = ExecWorkingDir.Wrap(command, workingDir);
         var (appName, machineId) = ParseExternalId(externalId);
 
         // Fly Machines API supports exec via the /exec endpoint

--- a/src/Andy.Containers.Infrastructure/Providers/ThirdParty/HetznerCloudProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/ThirdParty/HetznerCloudProvider.cs
@@ -196,8 +196,14 @@ public class HetznerCloudProvider : IInfrastructureProvider
         return ExecAsync(externalId, command, TimeSpan.FromSeconds(30), ct);
     }
 
-    public async Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct)
+    public Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct)
+        => ExecAsync(externalId, command, timeout, workingDir: null, ct);
+
+    public async Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, string? workingDir, CancellationToken ct)
     {
+        // No native working-dir flag on this exec path — wrap via
+        // `cd '<dir>' && ` (exec working-dir feature). Null/empty ⇒ unchanged.
+        command = ExecWorkingDir.Wrap(command, workingDir);
         var (_, containerName) = ParseExternalId(externalId);
         var connInfo = await GetConnectionInfoAsync(externalId, ct);
 

--- a/src/Andy.Containers/Abstractions/ExecWorkingDir.cs
+++ b/src/Andy.Containers/Abstractions/ExecWorkingDir.cs
@@ -1,0 +1,57 @@
+namespace Andy.Containers.Abstractions;
+
+/// <summary>
+/// Shared composition of the optional working-directory facet of the exec
+/// contract (rivoli-ai/andy-containers, exec working-dir feature).
+///
+/// <para>
+/// The exec endpoint historically ran <c>sh -c "&lt;command&gt;"</c> with NO
+/// working directory, so every command ran in the image's default WORKDIR
+/// rather than the repo checkout (<c>/workspace</c>). Two shipped fixes worked
+/// around this by prefixing <c>cd '&lt;dir&gt;' &amp;&amp; </c> at the caller
+/// (andy-tasks#383 verifier path, andy-containers#360 HeadlessRunner). This
+/// makes the working directory a first-class field on the exec contract.
+/// </para>
+///
+/// <para>
+/// Providers that expose a native working-directory mechanism (Docker's
+/// <c>ContainerExecCreateParameters.WorkingDir</c>, i.e. <c>docker exec -w</c>)
+/// should prefer it and ignore <see cref="Wrap"/>. Providers that only carry a
+/// command string (Apple <c>container exec sh -c</c>, the SSH/cloud paths) wrap
+/// the command with <see cref="Wrap"/>.
+/// </para>
+///
+/// <para>
+/// <b>Backward compatibility is mandatory:</b> a null/whitespace
+/// <c>workingDir</c> returns the command byte-identical, so existing callers
+/// (including andy-tasks' own <c>cd</c>-prefix workaround) are unaffected.
+/// </para>
+/// </summary>
+public static class ExecWorkingDir
+{
+    /// <summary>
+    /// Wraps <paramref name="command"/> so it runs inside
+    /// <paramref name="workingDir"/> via <c>cd '&lt;dir&gt;' &amp;&amp;
+    /// &lt;command&gt;</c>. The directory is single-quote-escaped for
+    /// <c>/bin/sh -c</c>. When <paramref name="workingDir"/> is null/empty/
+    /// whitespace the command is returned unchanged (the pre-existing
+    /// no-working-dir behaviour).
+    /// </summary>
+    public static string Wrap(string command, string? workingDir)
+    {
+        if (string.IsNullOrWhiteSpace(workingDir))
+        {
+            return command;
+        }
+
+        return $"cd {ShellSingleQuote(workingDir.Trim())} && {command}";
+    }
+
+    /// <summary>
+    /// POSIX single-quote escape — safe for <c>/bin/sh -c "..."</c>. A single
+    /// quote inside the value closes the quote, inserts an escaped literal
+    /// quote (<c>'\''</c>), then reopens.
+    /// </summary>
+    private static string ShellSingleQuote(string value)
+        => "'" + value.Replace("'", "'\\''") + "'";
+}

--- a/src/Andy.Containers/Abstractions/IContainerService.cs
+++ b/src/Andy.Containers/Abstractions/IContainerService.cs
@@ -18,6 +18,20 @@ public interface IContainerService
     Task<ExecResult> ExecAsync(Guid containerId, string command, TimeSpan timeout, CancellationToken ct = default);
 
     /// <summary>
+    /// Working-dir-aware exec overload (exec working-dir feature). When
+    /// <paramref name="workingDir"/> is non-empty the command runs in that
+    /// directory inside the container (the repo checkout, e.g.
+    /// <c>/workspace</c>) — Docker via its native <c>WorkingDir</c>, other
+    /// providers via a <c>cd '&lt;dir&gt;' &amp;&amp; </c> wrap. A null/empty
+    /// <paramref name="workingDir"/> is byte-identical to
+    /// <see cref="ExecAsync(Guid, string, TimeSpan, CancellationToken)"/>,
+    /// so existing callers (and andy-tasks' own cd-prefix workaround) are
+    /// unaffected. The default delegates to the no-working-dir overload.
+    /// </summary>
+    Task<ExecResult> ExecAsync(Guid containerId, string command, TimeSpan timeout, string? workingDir, CancellationToken ct = default)
+        => ExecAsync(containerId, command, timeout, ct);
+
+    /// <summary>
     /// F4.1 (rivoli-ai/conductor#1934). Streaming variant of
     /// <see cref="ExecAsync(Guid, string, TimeSpan, CancellationToken)"/>:
     /// the same exec, but each stdout/stderr line is surfaced to
@@ -25,6 +39,10 @@ public interface IContainerService
     /// until the process exits. Returns the same terminal
     /// <see cref="ExecResult"/> (with the full buffered stdout/stderr)
     /// so existing callers keep their exit-code + final-output contract.
+    ///
+    /// <paramref name="workingDir"/> carries the same first-class working
+    /// directory as the buffered overload (exec working-dir feature);
+    /// null/empty ⇒ no working directory (pre-existing behaviour).
     /// </summary>
     /// <remarks>
     /// Honours decision #17 (no new Docker-Engine verb beyond the
@@ -41,10 +59,11 @@ public interface IContainerService
         string command,
         TimeSpan timeout,
         Action<ExecOutputChunk> onLine,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        string? workingDir = null)
     {
         ArgumentNullException.ThrowIfNull(onLine);
-        var result = await ExecAsync(containerId, command, timeout, ct);
+        var result = await ExecAsync(containerId, command, timeout, workingDir, ct);
         foreach (var line in SplitLines(result.StdOut))
         {
             onLine(new ExecOutputChunk(ExecStreamKind.Stdout, line));

--- a/src/Andy.Containers/Abstractions/IInfrastructureProvider.cs
+++ b/src/Andy.Containers/Abstractions/IInfrastructureProvider.cs
@@ -57,6 +57,20 @@ public interface IInfrastructureProvider
     Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, CancellationToken ct = default);
 
     /// <summary>
+    /// Working-dir-aware exec overload (exec working-dir feature). When
+    /// <paramref name="workingDir"/> is non-empty the command runs in that
+    /// directory — Docker uses its native <c>WorkingDir</c> (<c>docker exec
+    /// -w</c>), other providers wrap via <see cref="ExecWorkingDir.Wrap"/>.
+    /// A null/empty <paramref name="workingDir"/> is byte-identical to the
+    /// no-working-dir <see cref="ExecAsync(string, string, TimeSpan, CancellationToken)"/>
+    /// overload. The default implementation delegates to that overload (no
+    /// working dir), so providers that don't override it simply ignore the
+    /// hint — backward compatible by construction.
+    /// </summary>
+    Task<ExecResult> ExecAsync(string externalId, string command, TimeSpan timeout, string? workingDir, CancellationToken ct = default)
+        => ExecAsync(externalId, command, timeout, ct);
+
+    /// <summary>
     /// F4.1 (rivoli-ai/conductor#1934). Streaming exec: same exec/attach
     /// surface as <see cref="ExecAsync(string, string, TimeSpan, CancellationToken)"/>
     /// (decision #17 — no new Docker-Engine verb), but each stdout/stderr
@@ -64,16 +78,21 @@ public interface IInfrastructureProvider
     /// default delegates to the buffered overload and replays the final
     /// output line-by-line — correct for providers that can't stream
     /// incrementally; Docker overrides for a true live tail.
+    ///
+    /// <paramref name="workingDir"/> carries the same first-class working
+    /// directory as the buffered overload (exec working-dir feature);
+    /// null/empty ⇒ no working directory (pre-existing behaviour).
     /// </summary>
     async Task<ExecResult> ExecStreamingAsync(
         string externalId,
         string command,
         TimeSpan timeout,
         Action<ExecOutputChunk> onLine,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        string? workingDir = null)
     {
         ArgumentNullException.ThrowIfNull(onLine);
-        var result = await ExecAsync(externalId, command, timeout, ct);
+        var result = await ExecAsync(externalId, command, timeout, workingDir, ct);
         Replay(result.StdOut, ExecStreamKind.Stdout, onLine);
         Replay(result.StdErr, ExecStreamKind.Stderr, onLine);
         return result;

--- a/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerTests.cs
@@ -219,6 +219,41 @@ public class ContainersControllerTests : IDisposable
 
         var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
         okResult.Value.Should().Be(execResult);
+
+        // Backward compat: no WorkingDir ⇒ the byte-identical default-timeout
+        // overload, NOT the working-dir-aware one.
+        _mockService.Verify(s => s.ExecAsync(id, "echo hello", It.IsAny<CancellationToken>()), Times.Once);
+        _mockService.Verify(s => s.ExecAsync(
+            It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // exec working-dir feature. A request carrying WorkingDir routes through
+    // the working-dir-aware overload (Docker native -w / cd wrap downstream),
+    // passing the directory and honouring the request's TimeoutSeconds.
+    [Fact]
+    public async Task Exec_WithWorkingDir_RoutesThroughWorkingDirOverload()
+    {
+        var id = Guid.NewGuid();
+        var container = new Container { Id = id, Name = "test", OwnerId = "test-user" };
+        var execResult = new ExecResult { ExitCode = 0, StdOut = "/workspace" };
+        _mockService
+            .Setup(s => s.GetContainerAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(container);
+        _mockService
+            .Setup(s => s.ExecAsync(id, "pwd", TimeSpan.FromSeconds(45), "/workspace", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(execResult);
+
+        var result = await _controller.Exec(
+            id, new ExecRequest { Command = "pwd", TimeoutSeconds = 45, WorkingDir = "/workspace" },
+            CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>().Subject.Value.Should().Be(execResult);
+        _mockService.Verify(
+            s => s.ExecAsync(id, "pwd", TimeSpan.FromSeconds(45), "/workspace", It.IsAny<CancellationToken>()),
+            Times.Once);
+        // The no-working-dir overload must NOT be used on this path.
+        _mockService.Verify(s => s.ExecAsync(id, "pwd", It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/tests/Andy.Containers.Api.Tests/Services/Ap6Aq3SmokeTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/Ap6Aq3SmokeTests.cs
@@ -165,10 +165,18 @@ public class Ap6Aq3SmokeTests : IDisposable
         public Task<ExecResult> ExecAsync(Guid containerId, string command, CancellationToken ct = default)
             => ExecAsync(containerId, command, TimeSpan.FromMinutes(15), ct);
 
-        public async Task<ExecResult> ExecAsync(Guid containerId, string command, TimeSpan timeout, CancellationToken ct = default)
+        public Task<ExecResult> ExecAsync(Guid containerId, string command, TimeSpan timeout, CancellationToken ct = default)
+            => ExecAsync(containerId, command, timeout, workingDir: null, ct);
+
+        // The runner now spawns through the working-dir-aware overload
+        // (exec working-dir feature / #360 migration). We honour WorkingDir by
+        // wrapping the command with `cd '<dir>' && ` exactly like the
+        // non-Docker providers, so the host subprocess runs in the checkout
+        // root just as the real container exec would.
+        public async Task<ExecResult> ExecAsync(Guid containerId, string command, TimeSpan timeout, string? workingDir, CancellationToken ct = default)
         {
-            // AP6's command shape (HeadlessRunner.cs:66) — the only one
-            // this smoke handles.
+            command = ExecWorkingDir.Wrap(command, workingDir);
+            // AP6's command shape — the only one this smoke handles.
             const string prefix = "andy-cli ";
             if (!command.StartsWith(prefix, StringComparison.Ordinal))
             {

--- a/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerOutputStreamTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerOutputStreamTests.cs
@@ -129,9 +129,9 @@ public class HeadlessRunnerOutputStreamTests : IDisposable
         _containers
             .Setup(c => c.ExecStreamingAsync(
                 run.ContainerId!.Value, It.IsAny<string>(), It.IsAny<TimeSpan>(),
-                It.IsAny<Action<ExecOutputChunk>>(), It.IsAny<CancellationToken>()))
-            .Returns<Guid, string, TimeSpan, Action<ExecOutputChunk>, CancellationToken>(
-                async (_, _, _, onLine, _) =>
+                It.IsAny<Action<ExecOutputChunk>>(), It.IsAny<CancellationToken>(), It.IsAny<string?>()))
+            .Returns<Guid, string, TimeSpan, Action<ExecOutputChunk>, CancellationToken, string?>(
+                async (_, _, _, onLine, _, _) =>
                 {
                     onLine(new ExecOutputChunk(ExecStreamKind.Stdout, "live-1"));
                     onLine(new ExecOutputChunk(ExecStreamKind.Stdout, "live-2"));
@@ -177,9 +177,9 @@ public class HeadlessRunnerOutputStreamTests : IDisposable
         _containers
             .Setup(c => c.ExecStreamingAsync(
                 containerId, It.IsAny<string>(), It.IsAny<TimeSpan>(),
-                It.IsAny<Action<ExecOutputChunk>>(), It.IsAny<CancellationToken>()))
-            .Returns<Guid, string, TimeSpan, Action<ExecOutputChunk>, CancellationToken>(
-                (_, _, _, onLine, _) =>
+                It.IsAny<Action<ExecOutputChunk>>(), It.IsAny<CancellationToken>(), It.IsAny<string?>()))
+            .Returns<Guid, string, TimeSpan, Action<ExecOutputChunk>, CancellationToken, string?>(
+                (_, _, _, onLine, _, _) =>
                 {
                     foreach (var (kind, line) in lines)
                     {

--- a/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
@@ -242,7 +242,7 @@ public class HeadlessRunnerTests : IDisposable
         var run = SeedRun();
         _containers
             .Setup(c => c.ExecAsync(
-                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("docker daemon unreachable"));
 
         var outcome = await _runner.StartAsync(run, _configPath);
@@ -269,7 +269,7 @@ public class HeadlessRunnerTests : IDisposable
         var run = SeedRun();
         _containers
             .Setup(c => c.ExecAsync(
-                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new OperationCanceledException("exec timeout"));
 
         var outcome = await _runner.StartAsync(run, _configPath, CancellationToken.None);
@@ -289,7 +289,7 @@ public class HeadlessRunnerTests : IDisposable
         cts.Cancel();
         _containers
             .Setup(c => c.ExecAsync(
-                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new OperationCanceledException(cts.Token));
 
         var outcome = await _runner.StartAsync(run, _configPath, cts.Token);
@@ -310,8 +310,8 @@ public class HeadlessRunnerTests : IDisposable
         var spawnedTcs = new TaskCompletionSource<bool>();
         _containers
             .Setup(c => c.ExecAsync(
-                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
-            .Returns<Guid, string, TimeSpan, CancellationToken>(async (_, _, _, token) =>
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns<Guid, string, TimeSpan, string?, CancellationToken>(async (_, _, _, _, token) =>
             {
                 spawnedTcs.TrySetResult(true);
                 await Task.Delay(Timeout.InfiniteTimeSpan, token);
@@ -370,7 +370,7 @@ public class HeadlessRunnerTests : IDisposable
         outcome.Error.Should().Contain("ContainerId");
 
         _containers.Verify(c => c.ExecAsync(
-            It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()),
+            It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Never);
 
         var entry = await _db.OutboxEntries.SingleAsync();
@@ -438,8 +438,8 @@ public class HeadlessRunnerTests : IDisposable
         string? captured = null;
         _containers
             .Setup(c => c.ExecAsync(
-                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, string, TimeSpan, CancellationToken>((_, cmd, _, _) => captured = cmd)
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, string?, CancellationToken>((_, cmd, _, _, _) => captured = cmd)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
 
         await _runner.StartAsync(run, _configPath);
@@ -451,50 +451,65 @@ public class HeadlessRunnerTests : IDisposable
         captured.Should().Contain($"andy-cli run --headless --config '/tmp/andy-runs/{run.Id}/config.json'");
     }
 
-    // conductor MSB1003 / andy-tasks#383. The repo is cloned DIRECTLY into the
-    // workspace root (/workspace/Andy.Cli.sln exists), but the exec endpoint
-    // runs `sh -c "<command>"` with NO WorkingDir — so without an explicit
-    // `cd` andy-cli runs from the image's default WORKDIR, not the checkout.
-    // andy-cli relies on its process CWD being the checkout root, so the
-    // dispatched coding-agent command MUST be prefixed with `cd '/workspace' &&`
-    // before the andy-cli invocation (mirroring andy-tasks#383's verifier fix).
-    // This test FAILS against the old code (no `cd`) and passes with the fix.
+    // conductor MSB1003 / andy-tasks#383 / #360 → exec working-dir feature. The
+    // repo is cloned DIRECTLY into the workspace root (/workspace/Andy.Cli.sln
+    // exists). andy-cli relies on its process CWD being the checkout root, so
+    // the agent must run THERE, not in the image's default WORKDIR.
+    //
+    // #360 originally prefixed `cd '/workspace' && ` onto the andy-cli
+    // sub-command. This is now the FIRST-CLASS WorkingDir field on the exec
+    // contract: the runner passes WorkingDir = /workspace and the command
+    // carries NO `cd` prefix. This test FAILS against the #360 code (which
+    // emitted a `cd` and left workingDir null) and passes with the migration.
     [Fact]
-    public async Task StartAsync_CdsIntoWorkspaceRoot_BeforeRunningAndyCli()
+    public async Task StartAsync_RunsAndyCliInWorkspaceRoot_ViaWorkingDirNotCdPrefix()
     {
         var run = SeedRun();
-        string? captured = null;
+        string? capturedCmd = null;
+        string? capturedWorkingDir = null;
         _containers
             .Setup(c => c.ExecAsync(
-                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, string, TimeSpan, CancellationToken>((_, cmd, _, _) => captured = cmd)
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, string?, CancellationToken>((_, cmd, _, wd, _) =>
+            {
+                capturedCmd = cmd;
+                capturedWorkingDir = wd;
+            })
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
 
         await _runner.StartAsync(run, _configPath);
 
-        captured.Should().NotBeNull();
-        // The `cd` must land immediately before the andy-cli invocation so the
-        // agent's process CWD is the checkout root.
-        captured.Should().Contain("cd '/workspace' && andy-cli run --headless",
-            "the dispatched agent must run with CWD at the checkout root");
+        capturedCmd.Should().NotBeNull();
+        // The agent runs in the checkout root via the first-class WorkingDir
+        // field — no `cd` prefix on the command any more (#360 migration).
+        capturedWorkingDir.Should().Be("/workspace",
+            "the dispatched agent must run with CWD at the checkout root via the first-class field");
+        capturedCmd.Should().NotContain("cd '/workspace'",
+            "the `cd` prefix is replaced by the WorkingDir field");
+        capturedCmd.Should().Contain("andy-cli run --headless");
     }
 
-    // conductor MSB1003. The `cd` and the #2231 model-key override compose:
-    // the OPENAI_API_KEY assignment must stay attached to the andy-cli process
-    // and the whole thing must run under the `cd`.
+    // conductor MSB1003 / #360 migration. The #2231 model-key override still
+    // composes with the run: OPENAI_API_KEY stays attached to the andy-cli
+    // process; the working directory is the first-class field, not a `cd`.
     [Fact]
-    public async Task StartAsync_CdsIntoWorkspaceRoot_BeforeModelScopedKeyAndAndyCli()
+    public async Task StartAsync_RunsAndyCliInWorkspaceRoot_WithModelScopedKey_ViaWorkingDir()
     {
         var run = SeedRun();
         SeedContainer(run.ContainerId!.Value, ownerId: "owner-42");
         const string modelId = "openrouter/qwen3-coder";
         var configPath = WriteRealConfigWithModel(modelId);
 
-        string? captured = null;
+        string? capturedCmd = null;
+        string? capturedWorkingDir = null;
         _containers
             .Setup(c => c.ExecAsync(
-                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, string, TimeSpan, CancellationToken>((_, cmd, _, _) => captured = cmd)
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, string?, CancellationToken>((_, cmd, _, wd, _) =>
+            {
+                capturedCmd = cmd;
+                capturedWorkingDir = wd;
+            })
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
 
         var proxy = new RecordingProxyTokenService("jwt-scoped-to-qwen");
@@ -502,9 +517,12 @@ public class HeadlessRunnerTests : IDisposable
 
         await runner.StartAsync(run, configPath);
 
-        captured.Should().NotBeNull();
-        captured.Should().Contain("cd '/workspace' && OPENAI_API_KEY='jwt-scoped-to-qwen' andy-cli run --headless",
-            "the model-key override and andy-cli must both run under the workspace `cd`");
+        capturedCmd.Should().NotBeNull();
+        capturedWorkingDir.Should().Be("/workspace",
+            "the agent runs in the checkout root via the first-class WorkingDir field");
+        capturedCmd.Should().NotContain("cd '/workspace'");
+        capturedCmd.Should().Contain("OPENAI_API_KEY='jwt-scoped-to-qwen' andy-cli run --headless",
+            "the model-key override must stay attached to the andy-cli process");
         File.Delete(configPath);
     }
 
@@ -532,8 +550,8 @@ public class HeadlessRunnerTests : IDisposable
         string? captured = null;
         _containers
             .Setup(c => c.ExecAsync(
-                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, string, TimeSpan, CancellationToken>((_, cmd, _, _) => captured = cmd)
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, string?, CancellationToken>((_, cmd, _, _, _) => captured = cmd)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
 
         var proxy = new RecordingProxyTokenService("jwt-scoped-to-qwen");
@@ -566,8 +584,8 @@ public class HeadlessRunnerTests : IDisposable
         string? captured = null;
         _containers
             .Setup(c => c.ExecAsync(
-                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, string, TimeSpan, CancellationToken>((_, cmd, _, _) => captured = cmd)
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, string?, CancellationToken>((_, cmd, _, _, _) => captured = cmd)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
 
         // Default _runner has no proxy service.
@@ -593,8 +611,8 @@ public class HeadlessRunnerTests : IDisposable
         string? captured = null;
         _containers
             .Setup(c => c.ExecAsync(
-                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, string, TimeSpan, CancellationToken>((_, cmd, _, _) => captured = cmd)
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, string?, CancellationToken>((_, cmd, _, _, _) => captured = cmd)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
 
         var proxy = new RecordingProxyTokenService("unused");
@@ -621,8 +639,8 @@ public class HeadlessRunnerTests : IDisposable
         string? captured = null;
         _containers
             .Setup(c => c.ExecAsync(
-                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, string, TimeSpan, CancellationToken>((_, cmd, _, _) => captured = cmd)
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, string?, CancellationToken>((_, cmd, _, _, _) => captured = cmd)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
 
         var proxy = new RecordingProxyTokenService("unused") { ThrowOnMint = true };
@@ -684,8 +702,8 @@ public class HeadlessRunnerTests : IDisposable
         TimeSpan? capturedTimeout = null;
         _containers
             .Setup(c => c.ExecAsync(
-                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, string, TimeSpan, CancellationToken>((_, _, t, _) => capturedTimeout = t)
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, string?, CancellationToken>((_, _, t, _, _) => capturedTimeout = t)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
 
         await _runner.StartAsync(run, configPath);
@@ -708,8 +726,8 @@ public class HeadlessRunnerTests : IDisposable
         string? spawnCommand = null;
         _containers
             .Setup(c => c.ExecAsync(
-                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, string, TimeSpan, CancellationToken>((_, cmd, _, _) => spawnCommand = cmd)
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, string?, CancellationToken>((_, cmd, _, _, _) => spawnCommand = cmd)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
 
         var outcome = await _runner.StartAsync(run, missingPath);
@@ -732,8 +750,8 @@ public class HeadlessRunnerTests : IDisposable
         TimeSpan? capturedTimeout = null;
         _containers
             .Setup(c => c.ExecAsync(
-                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, string, TimeSpan, CancellationToken>((_, _, t, _) => capturedTimeout = t)
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, string?, CancellationToken>((_, _, t, _, _) => capturedTimeout = t)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
 
         await _runner.StartAsync(run, configPath);
@@ -914,9 +932,12 @@ public class HeadlessRunnerTests : IDisposable
 
     private void SetupExec(Guid containerId, int exitCode, string? stdOut = null, string? stdErr = null)
     {
+        // The runner now spawns andy-cli through the working-dir-aware overload
+        // (exec working-dir feature / #360 migration), passing WorkingDir =
+        // checkout root instead of a `cd` prefix.
         _containers
             .Setup(c => c.ExecAsync(
-                containerId, It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+                containerId, It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ExecResult
             {
                 ExitCode = exitCode,
@@ -966,8 +987,8 @@ public class HeadlessRunnerTests : IDisposable
         string? spawnCommand = null;
         _containers
             .Setup(c => c.ExecAsync(
-                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, string, TimeSpan, CancellationToken>((_, cmd, _, _) => spawnCommand = cmd)
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, string?, CancellationToken>((_, cmd, _, _, _) => spawnCommand = cmd)
             .ReturnsAsync(new ExecResult { ExitCode = 0 });
 
         var docId = Guid.NewGuid();

--- a/tests/Andy.Containers.Integration.Tests/DockerProviderTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/DockerProviderTests.cs
@@ -148,4 +148,48 @@ public class DockerProviderTests : IAsyncLifetime
         // is already gone.
         _externalId = null;
     }
+
+    // exec working-dir feature. The exec endpoint historically ran
+    // `sh -c "<command>"` with NO working directory, so every command ran in
+    // the image's default WORKDIR rather than the repo checkout. This proves
+    // the first-class WorkingDir field routes through Docker's native `-w`:
+    //   * WorkingDir = "/tmp" ⇒ `pwd` reports /tmp (command ran THERE).
+    //   * WorkingDir = null   ⇒ `pwd` reports the image WORKDIR (here `/`),
+    //                            byte-identical to the historical behaviour.
+    [Fact]
+    public async Task Exec_WithWorkingDir_RunsCommandInThatDirectory_NullLeavesImageWorkdir()
+    {
+        var spec = new ContainerSpec
+        {
+            Name = $"workingdir-test-{Guid.NewGuid().ToString()[..8]}",
+            ImageReference = "alpine:latest",
+            Resources = new ResourceSpec { CpuCores = 1, MemoryMb = 64 }
+        };
+        var created = await _provider.CreateContainerAsync(spec, CancellationToken.None);
+        _externalId = created.ExternalId;
+
+        // 1. A non-empty WorkingDir runs the command in that directory.
+        var inTmp = await _provider.ExecAsync(
+            _externalId!, "pwd", TimeSpan.FromSeconds(30), workingDir: "/tmp", CancellationToken.None);
+        inTmp.ExitCode.Should().Be(0);
+        inTmp.StdOut!.Trim().Should().Be("/tmp",
+            "a non-empty WorkingDir must run the command in that directory via docker exec -w");
+
+        // 2. Null WorkingDir ⇒ the image's default WORKDIR (alpine: `/`),
+        //    i.e. NO `cd`/`-w` applied — byte-identical to the pre-feature
+        //    behaviour that existing callers rely on.
+        var noDir = await _provider.ExecAsync(
+            _externalId!, "pwd", TimeSpan.FromSeconds(30), workingDir: null, CancellationToken.None);
+        noDir.ExitCode.Should().Be(0);
+        noDir.StdOut!.Trim().Should().Be("/",
+            "a null WorkingDir must leave the image's default WORKDIR untouched");
+
+        // 3. The legacy no-working-dir overload is identical to (2).
+        var legacy = await _provider.ExecAsync(_externalId!, "pwd", CancellationToken.None);
+        legacy.StdOut!.Trim().Should().Be(noDir.StdOut!.Trim(),
+            "the new overload with null workingDir must match the legacy overload exactly");
+
+        await _provider.DestroyContainerAsync(_externalId!, CancellationToken.None);
+        _externalId = null;
+    }
 }

--- a/tests/Andy.Containers.Tests/Abstractions/ExecWorkingDirTests.cs
+++ b/tests/Andy.Containers.Tests/Abstractions/ExecWorkingDirTests.cs
@@ -1,0 +1,52 @@
+using Andy.Containers.Abstractions;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Tests.Abstractions;
+
+// exec working-dir feature. Unit coverage for the shared command-wrap helper
+// the non-Docker providers (Apple, SSH/cloud) use to honour the first-class
+// WorkingDir field. Docker uses its native `-w` and never touches this; these
+// tests prove the fallback's correctness and the mandatory backward-compat
+// guarantee (null/empty ⇒ command unchanged).
+public class ExecWorkingDirTests
+{
+    [Fact]
+    public void Wrap_WithWorkingDir_PrefixesCdIntoThatDirectory()
+    {
+        var wrapped = ExecWorkingDir.Wrap("andy-cli run --headless", "/workspace");
+
+        wrapped.Should().Be("cd '/workspace' && andy-cli run --headless");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Wrap_NullOrWhitespaceWorkingDir_ReturnsCommandUnchanged(string? workingDir)
+    {
+        // THE backward-compat guarantee: existing callers (including
+        // andy-tasks' own cd-prefix workaround) must be byte-for-byte
+        // unaffected when no working dir is supplied.
+        const string command = "mkdir -p /tmp/x && andy-cli run";
+
+        ExecWorkingDir.Wrap(command, workingDir).Should().Be(command);
+    }
+
+    [Fact]
+    public void Wrap_SingleQuoteInDirectory_IsPosixEscaped()
+    {
+        // A single quote inside the path must close/escape/reopen so the
+        // wrapped command stays a valid `/bin/sh -c` string.
+        var wrapped = ExecWorkingDir.Wrap("ls", "/work'space");
+
+        wrapped.Should().Be("cd '/work'\\''space' && ls");
+    }
+
+    [Fact]
+    public void Wrap_TrimsSurroundingWhitespaceFromDirectory()
+    {
+        ExecWorkingDir.Wrap("ls", "  /workspace  ")
+            .Should().Be("cd '/workspace' && ls");
+    }
+}


### PR DESCRIPTION
## Root cause

The container exec endpoint (`POST api/containers/{id}/exec`) historically ran `sh -c "<command>"` with **no working directory** — the `ExecRequest` wire shape was `{Command, TimeoutSeconds}` only — so every command ran in the image's default `WORKDIR` instead of the repo checkout (`/workspace`). Tools that resolve paths relative to CWD (andy-cli, the verifier) operated against the wrong directory.

Two shipped fixes worked around this by prefixing `cd '<dir>' && <command>` at the caller:
- andy-tasks#383 — the verifier path
- andy-containers#360 — the `HeadlessRunner` agent-run path

This PR is the proper long-term fix: **make the working directory a first-class field on the exec contract.**

## The new field

- `ExecRequest` gains an optional `WorkingDir` (`string?`).
- A working-dir-aware overload `ExecAsync(..., string? workingDir, ...)` and a `workingDir` arg on `ExecStreamingAsync` are added across `IContainerService` and `IInfrastructureProvider`. These are **new overloads / a trailing optional parameter** — the existing exec signatures are untouched, so providers that don't override them compile unchanged and fall through to the no-working-dir path.
- **Docker** honours it through its **native** mechanism — `docker exec -w`, i.e. `ContainerExecCreateParameters.WorkingDir`.
- Providers without a native working-dir flag (**Apple** `container exec`, the **SSH/cloud** paths) wrap the command through the shared `ExecWorkingDir.Wrap` helper: `cd '<dir>' && <command>`, single-quote-escaped. Azure ACI's exec is an interactive-only WebSocket session that doesn't honour an inline command, so it has nothing to wrap and delegates to the base overload.
- `ContainersClient.ExecAsync` gains an optional `workingDir`; the field is omitted from the request body when null/empty.

## Backward compatibility (mandatory)

A null/empty `WorkingDir` is **byte-identical** to the prior behaviour: no `-w`, no `cd`, the image's `WORKDIR` is untouched. The controller still routes the no-`WorkingDir` request through the exact same default-timeout overload as before. Existing callers — **including andy-tasks' own `cd`-prefix workaround** — are unaffected.

## HeadlessRunner migration (#360)

`HeadlessRunner` no longer prefixes `cd '<root>' && ` onto the andy-cli command. It now passes `WorkingDir = ResolveWorkspaceRoot(configJson)` (the checkout root, default `/workspace`) so the agent-run path uses the first-class field — a single mechanism. The `mkdir`/config-stage steps stay correct because they use absolute `/tmp` paths and don't depend on CWD.

## andy-tasks follow-up

`AndyContainersWorkspaceProvider` (andy-tasks) can drop its `cd`-prefix workaround in favour of passing `WorkingDir` — a follow-up, not touched in this PR.

## Tests (all run, green)

- `ExecWorkingDirTests` — **6/6**: the wrap helper + the null/empty backward-compat guarantee.
- `DockerProviderTests.Exec_WithWorkingDir_RunsCommandInThatDirectory_NullLeavesImageWorkdir` — **1/1 against a real Docker daemon**: `WorkingDir=/tmp` ⇒ `pwd=/tmp`; `WorkingDir=null` ⇒ `pwd=/` (image WORKDIR, no `-w`); the legacy overload matches the null path exactly.
- `ContainersControllerTests` exec tests — **2/2**: a `WorkingDir` request routes through the working-dir overload with the request's timeout; a no-`WorkingDir` request does not (uses the legacy overload).
- `HeadlessRunnerTests` — **40/40**: the #360 migration tests now assert the runner passes `WorkingDir=/workspace` and emits **no** `cd` prefix on the command (they fail against the #360 code and pass against this change).

`dotnet build` of the full solution is green (0 warnings, 0 errors).

**Pre-existing, not from this change:** `HeadlessRunnerOutputStreamTests` crashes the test host (large hangdump) on **both** this branch and `origin/main` — verified by building and running it on a clean `origin/main` worktree, where it crashes identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)