### PR TITLE
Fix local registry push on Docker Desktop: rewrite target to host.docker.internal

### DIFF
--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -84,6 +84,87 @@ Local (non-Docker) `dotnet run`: API `5200/5201`, Angular `4200`, Postgres `5434
 | Andy RBAC API | andy-rbac | 7003 | 7004 |
 | Andy RBAC Web | andy-rbac | 5180 | 5181 |
 
+## Embedded local registry (zot) — Docker Desktop push target
+
+In Conductor's embedded mode, andy-containers re-hosts images into a
+local [zot](https://zotregistry.dev/) registry by shelling out to the
+Docker CLI (`docker tag` + `docker push`) for both template builds
+(`LocalZotAdapter`) and the `POST /api/images/ensure-pull` rehost path
+(`DockerCliImagePullService`).
+
+### The Docker Desktop loopback gap
+
+The embedded zot binds the host's loopback (`127.0.0.1:5050`) and
+Conductor's HTTP reads talk to `http://localhost:5050` — both correct,
+both on the host. But `docker push` runs **inside the Docker Desktop
+VM**, where `localhost` is the VM, not the host. The VM has no route to
+the host's loopback, so the push hangs and dies with:
+
+```
+Get "http://localhost:5050/v2/": net/http: request canceled while
+waiting for connection (Client.Timeout exceeded while awaiting headers)
+```
+
+even though `curl http://localhost:5050/v2/` returns 200 from the host.
+
+### The fix: rewrite the push target to `host.docker.internal`
+
+`PushTargetHostResolver` rewrites the push/tag **target authority** from
+a loopback host to `host.docker.internal` (which Docker Desktop routes
+back to the host) whenever the daemon is Docker Desktop — i.e. Docker
+engine on a non-Linux host. The HTTP API client keeps using `localhost`.
+On native Linux Docker the daemon shares the host network namespace, so
+`localhost` already works and **no rewrite happens** (the default `Auto`
+mode is OS-aware).
+
+Configure via the `ImageManagement:PushTarget` section:
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `ImageManagement:PushTarget:Mode` | `Auto` | `Auto` (rewrite only on Docker Desktop), `Never`, or `Always` |
+| `ImageManagement:PushTarget:DockerDesktopHostAlias` | `host.docker.internal` | Host alias the VM can reach the host on |
+
+### Required Docker Desktop setting: `insecure-registries`
+
+`host.docker.internal:5050` is served over **plain HTTP**, and Docker
+treats any non-`localhost` registry as **HTTPS** by default. Without the
+host in the daemon's insecure-registries list, the rewritten push fails
+with:
+
+```
+Get "https://host.docker.internal:5050/v2/": http: server gave HTTP
+response to HTTPS client
+```
+
+andy-containers surfaces this loudly (it does not fail silently) — the
+push error names the exact address and the entry to add. To resolve it,
+add the registry to the Docker daemon's insecure-registries:
+
+**Docker Desktop → Settings → Docker Engine**, add:
+
+```json
+{
+  "insecure-registries": ["host.docker.internal:5050"]
+}
+```
+
+then **Apply & Restart**. (CLI equivalent: add the entry to
+`~/.docker/daemon.json` and restart Docker Desktop.)
+
+> If the registry's port is dynamically allocated, use that port instead
+> of `5050`. Conductor pins zot to `5050` by default
+> (`ZotServiceConfig.usesDynamicPort = false`).
+
+### (Optional) bind zot to a VM-reachable interface
+
+On some Docker Desktop versions `host.docker.internal` is proxied to the
+host's loopback and reaches a `127.0.0.1`-bound zot fine. If a future
+Docker Desktop version routes `host.docker.internal` to the VM gateway
+instead, the embedded zot must bind a VM-reachable interface
+(`0.0.0.0:5050` instead of `127.0.0.1:5050`). That bind is owned by
+Conductor's zot launch config (`config.template.json`), not by
+andy-containers.
+
 ## Database
 
 - **Engine**: PostgreSQL 16-alpine

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -190,6 +190,14 @@ try
     // engine detector + LocalBuildBackend; the orchestrator
     // ties the lot together for ImagesController.Build.
     builder.Services.AddImageManagement(builder.Configuration);
+    // Docker Desktop loopback gap (rivoli-ai/andy-containers). Bind the
+    // push-target rewrite policy from `ImageManagement:PushTarget`.
+    // Defaults are safe (Auto: rewrite a loopback registry authority to
+    // host.docker.internal ONLY when the daemon is Docker Desktop), so
+    // an absent section needs no config and Linux is unaffected.
+    builder.Services.Configure<Andy.Containers.Infrastructure.Registries.Local.PushTargetHostOptions>(
+        builder.Configuration.GetSection(
+            Andy.Containers.Infrastructure.Registries.Local.PushTargetHostOptions.SectionName));
     builder.Services.AddLocalZotRegistry();
     builder.Services.AddLocalBuildBackend();
     builder.Services.AddScoped<Andy.Containers.Storage.IImageBuildOrchestrator, Andy.Containers.Infrastructure.Build.ImageBuildOrchestrator>();

--- a/src/Andy.Containers.Infrastructure/Images/DockerCliImagePullService.cs
+++ b/src/Andy.Containers.Infrastructure/Images/DockerCliImagePullService.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Andy.Containers.Abstractions.Images;
 using Andy.Containers.Configuration;
+using Andy.Containers.Infrastructure.Registries.Local;
 using Andy.Containers.Models.ImageManagement;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -33,17 +34,20 @@ public sealed class DockerCliImagePullService : IImagePullService
     private readonly IOptions<RegistryConfigurationOptions> _registryConfig;
     private readonly ILogger<DockerCliImagePullService> _logger;
     private readonly DockerCliImagePullOptions _options;
+    private readonly PushTargetHostOptions _pushTargetOptions;
 
     public DockerCliImagePullService(
         IEnumerable<IRegistryAdapter> registryAdapters,
         IOptions<RegistryConfigurationOptions> registryConfig,
         ILogger<DockerCliImagePullService> logger,
-        IOptions<DockerCliImagePullOptions>? options = null)
+        IOptions<DockerCliImagePullOptions>? options = null,
+        IOptions<PushTargetHostOptions>? pushTargetOptions = null)
     {
         _registryAdapters = registryAdapters;
         _registryConfig = registryConfig;
         _logger = logger;
         _options = options?.Value ?? new DockerCliImagePullOptions();
+        _pushTargetOptions = pushTargetOptions?.Value ?? new PushTargetHostOptions();
     }
 
     public async Task<EnsurePullResponse> EnsurePullAsync(
@@ -92,11 +96,18 @@ public sealed class DockerCliImagePullService : IImagePullService
         // not a URL.
         var sourceRef = $"{request.SourceRegistry.TrimEnd('/')}/{request.SourceRepository}:{request.SourceTag}";
         var destHost = ExtractHost(destRegistryEntry.Url);
-        var destRef = $"{destHost}/{destRepo}:{destTag}";
+        // Docker Desktop loopback gap: `docker push` runs inside the
+        // Docker Desktop VM, where `localhost` is the VM, not the host
+        // running zot. Rewrite the destination authority to a
+        // VM-reachable host (host.docker.internal) on Docker Desktop;
+        // on Linux the daemon shares the host network so it's left as
+        // configured. See PushTargetHostResolver.
+        var destResolution = PushTargetHostResolver.Resolve(destHost, _pushTargetOptions);
+        var destRef = $"{destResolution.TargetAuthority}/{destRepo}:{destTag}";
 
-        await RunDockerAsync("Pull", new[] { "pull", sourceRef }, ct);
-        await RunDockerAsync("Tag", new[] { "tag", sourceRef, destRef }, ct);
-        await RunDockerAsync("Push", new[] { "push", destRef }, ct);
+        await RunDockerAsync("Pull", new[] { "pull", sourceRef }, ct, destResolution);
+        await RunDockerAsync("Tag", new[] { "tag", sourceRef, destRef }, ct, destResolution);
+        await RunDockerAsync("Push", new[] { "push", destRef }, ct, destResolution);
 
         // Re-probe to read the authoritative digest the destination
         // recorded post-push. Parsing it from `docker push` stderr
@@ -184,7 +195,11 @@ public sealed class DockerCliImagePullService : IImagePullService
         }
     }
 
-    private async Task RunDockerAsync(string operationCode, string[] arguments, CancellationToken ct)
+    private async Task RunDockerAsync(
+        string operationCode,
+        string[] arguments,
+        CancellationToken ct,
+        PushTargetHostResolution? pushResolution = null)
     {
         var psi = new ProcessStartInfo
         {
@@ -224,6 +239,23 @@ public sealed class DockerCliImagePullService : IImagePullService
         if (process.ExitCode != 0)
         {
             var combined = stdout + (string.IsNullOrWhiteSpace(stderr) ? string.Empty : Environment.NewLine + stderr);
+
+            // Loud, actionable Docker Desktop diagnostics on the push
+            // step — a bare Go networking timeout is useless to a human.
+            var hint = pushResolution is { } resolution
+                ? RegistryPushFailureDiagnostics.BuildHint(resolution.TargetAuthority, combined, resolution.WasRewritten)
+                : null;
+
+            if (hint is not null)
+            {
+                _logger.LogError(
+                    "ImagePull.{OpCode}.DockerDesktopMisconfig: {Hint}", operationCode, hint);
+                throw new ImagePullException(
+                    code: $"ensure_pull_docker_desktop_unreachable.{operationCode}",
+                    message: $"docker exited with code {process.ExitCode} during {operationCode.ToLowerInvariant()}: {Truncate(stderr, 200)}\n\n{hint}",
+                    capturedOutput: combined);
+            }
+
             throw new ImagePullException(
                 code: $"ensure_pull_docker_nonzero_exit_{process.ExitCode}.{operationCode}",
                 message: $"docker exited with code {process.ExitCode} during {operationCode.ToLowerInvariant()}: {Truncate(stderr, 200)}",

--- a/src/Andy.Containers.Infrastructure/Registries/Local/LocalZotAdapter.cs
+++ b/src/Andy.Containers.Infrastructure/Registries/Local/LocalZotAdapter.cs
@@ -29,17 +29,20 @@ public sealed class LocalZotAdapter : IRegistryAdapter
     private readonly HttpClient _http;
     private readonly IRegistryUploader _uploader;
     private readonly ILogger<LocalZotAdapter> _logger;
+    private readonly PushTargetHostOptions _pushTargetOptions;
 
     public LocalZotAdapter(
         HttpClient http,
         IRegistryUploader uploader,
         ILogger<LocalZotAdapter> logger,
-        string registryId = "local-zot")
+        string registryId = "local-zot",
+        PushTargetHostOptions? pushTargetOptions = null)
     {
         _http = http;
         _uploader = uploader;
         _logger = logger;
         RegistryId = registryId;
+        _pushTargetOptions = pushTargetOptions ?? new PushTargetHostOptions();
     }
 
     public string RegistryId { get; }
@@ -58,14 +61,44 @@ public sealed class LocalZotAdapter : IRegistryAdapter
         // talks to — the registry's host:port plus the repo path
         // and tag. zot at localhost:5050 accepts repo paths with
         // slashes (foo/bar/baz) and standard tag syntax.
+        //
+        // Docker Desktop loopback gap: `docker push` runs inside the
+        // Docker Desktop VM, where `localhost` is the VM — not the host
+        // running zot. Rewrite the push/tag authority to a VM-reachable
+        // host (host.docker.internal) on Docker Desktop while the HTTP
+        // client (_http) keeps using the host's localhost for the
+        // post-push HEAD. See PushTargetHostResolver.
         var baseAuthority = ExtractAuthority(_http.BaseAddress);
-        var remoteRef = $"{baseAuthority}/{repoPath}:{tag}";
+        var targetResolution = PushTargetHostResolver.Resolve(baseAuthority, _pushTargetOptions);
+        var remoteRef = $"{targetResolution.TargetAuthority}/{repoPath}:{tag}";
 
         _logger.LogInformation(
-            "LocalZotAdapter.Push.Start registryId={RegistryId} local={Local} remote={Remote}",
-            RegistryId, artifact.LocalReference, remoteRef);
+            "LocalZotAdapter.Push.Start registryId={RegistryId} local={Local} remote={Remote} rewritten={Rewritten}",
+            RegistryId, artifact.LocalReference, remoteRef, targetResolution.WasRewritten);
 
-        await _uploader.PushAsync(artifact.LocalReference, remoteRef, ct);
+        try
+        {
+            await _uploader.PushAsync(artifact.LocalReference, remoteRef, ct);
+        }
+        catch (RegistryUploadException ex)
+        {
+            var hint = RegistryPushFailureDiagnostics.BuildHint(
+                targetResolution.TargetAuthority, ex.CapturedOutput ?? ex.Message, targetResolution.WasRewritten);
+            if (hint is null)
+            {
+                throw;
+            }
+
+            _logger.LogError(
+                "LocalZotAdapter.Push.DockerDesktopMisconfig registryId={RegistryId} remote={Remote}: {Hint}",
+                RegistryId, remoteRef, hint);
+
+            throw new RegistryUploadException(
+                code: "LocalZotAdapter.Push.DockerDesktopUnreachable",
+                message: $"push of '{remoteRef}' to '{RegistryId}' failed: {ex.Message}\n\n{hint}",
+                capturedOutput: ex.CapturedOutput,
+                innerException: ex);
+        }
 
         // Resolve the digest authoritatively from the registry's
         // own HEAD response. Docker-Content-Digest is the contract.

--- a/src/Andy.Containers.Infrastructure/Registries/Local/LocalZotRegistryServiceCollectionExtensions.cs
+++ b/src/Andy.Containers.Infrastructure/Registries/Local/LocalZotRegistryServiceCollectionExtensions.cs
@@ -72,7 +72,14 @@ public static class LocalZotRegistryServiceCollectionExtensions
 
             var uploader = sp.GetRequiredService<IRegistryUploader>();
             var logger = sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<LocalZotAdapter>>();
-            return new LocalZotAdapter(http, uploader, logger, registryId);
+            // Docker Desktop loopback gap (rivoli-ai/andy-containers).
+            // The push/tag target authority may differ from the HTTP
+            // client's authority — the resolver rewrites loopback →
+            // host.docker.internal on Docker Desktop so `docker push`
+            // from inside the VM can reach the host's zot.
+            var pushTargetOptions = sp.GetService<IOptions<PushTargetHostOptions>>()?.Value
+                ?? new PushTargetHostOptions();
+            return new LocalZotAdapter(http, uploader, logger, registryId, pushTargetOptions);
         });
 
         return services;

--- a/src/Andy.Containers.Infrastructure/Registries/Local/PushTargetHostResolver.cs
+++ b/src/Andy.Containers.Infrastructure/Registries/Local/PushTargetHostResolver.cs
@@ -1,0 +1,266 @@
+using System.Runtime.InteropServices;
+
+namespace Andy.Containers.Infrastructure.Registries.Local;
+
+/// <summary>
+/// Resolves the <em>push/tag target authority</em> (<c>host:port</c>)
+/// that the Docker CLI is told to push to, which is NOT always the
+/// same authority Conductor's HTTP API client uses to talk to zot.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The Docker Desktop loopback gap (rivoli-ai/andy-containers).</b>
+/// The embedded zot registry binds the host's loopback interface
+/// (<c>127.0.0.1:5050</c>) and Conductor's in-process HTTP reads talk
+/// to <c>http://localhost:5050</c> — both correct, both on the host.
+/// But <c>docker push localhost:5050/...</c> runs <em>inside the Docker
+/// Desktop VM</em>, where <c>localhost</c> is the VM, not the host. The
+/// VM has no route to the host's loopback, so the push hangs and dies
+/// with:
+/// </para>
+/// <code>
+/// Get "http://localhost:5050/v2/": net/http: request canceled while
+/// waiting for connection (Client.Timeout exceeded while awaiting headers)
+/// </code>
+/// <para>
+/// even though <c>curl http://localhost:5050/v2/</c> returns 200 from
+/// the host. The fix is to point the daemon's push/tag at a
+/// VM-reachable address — Docker Desktop publishes the host as
+/// <c>host.docker.internal</c> — while the host-side HTTP client keeps
+/// using <c>localhost</c>. This resolver owns that rewrite.
+/// </para>
+/// <para>
+/// <b>Two extra preconditions the rewrite depends on</b> (outside this
+/// type's control, surfaced via <see cref="PushTargetHostResolution"/>
+/// so the call sites can warn loudly):
+/// <list type="number">
+/// <item>zot must bind a VM-reachable interface (e.g. <c>0.0.0.0:5050</c>,
+/// not loopback-only) — owned by Conductor's zot launch config.</item>
+/// <item><c>host.docker.internal:5050</c> is plain HTTP, and Docker
+/// treats every non-<c>localhost</c> registry as HTTPS by default, so
+/// the host must be in the daemon's <c>insecure-registries</c> list.</item>
+/// </list>
+/// </para>
+/// <para>
+/// The rewrite is gated on detecting Docker Desktop (Docker engine on
+/// macOS/Windows) or an explicit config flag, so native Linux Docker —
+/// where <c>localhost</c> in the daemon IS the host — is left unchanged.
+/// </para>
+/// </remarks>
+public static class PushTargetHostResolver
+{
+    /// <summary>
+    /// The hostname Docker Desktop publishes for "the host running the
+    /// daemon", reachable from inside the VM and from containers.
+    /// </summary>
+    public const string DockerDesktopHostAlias = "host.docker.internal";
+
+    /// <summary>
+    /// Loopback host tokens that the Docker Desktop VM cannot route to.
+    /// Only these are rewritten; an already-routable authority
+    /// (a LAN IP, a real hostname, <c>host.docker.internal</c> itself)
+    /// is left untouched.
+    /// </summary>
+    private static readonly string[] LoopbackHosts = ["localhost", "127.0.0.1", "::1", "[::1]"];
+
+    /// <summary>
+    /// Resolve the authority the Docker CLI should tag/push to, given
+    /// the registry's configured authority (the one the HTTP client
+    /// uses) and the chosen rewrite policy.
+    /// </summary>
+    /// <param name="registryAuthority">
+    /// The registry authority as the HTTP client sees it, e.g.
+    /// <c>localhost:5050</c> or <c>127.0.0.1:5050</c>. Must not be
+    /// null/whitespace.
+    /// </param>
+    /// <param name="options">Rewrite policy (mode + alias host).</param>
+    /// <returns>
+    /// The resolution: the target authority for <c>docker push</c> plus
+    /// whether a rewrite happened (so the caller can warn about the
+    /// <c>insecure-registries</c> precondition).
+    /// </returns>
+    public static PushTargetHostResolution Resolve(
+        string registryAuthority,
+        PushTargetHostOptions options)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(registryAuthority);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var (host, portSuffix) = SplitAuthority(registryAuthority);
+
+        var shouldRewrite = options.Mode switch
+        {
+            PushTargetHostRewriteMode.Never => false,
+            PushTargetHostRewriteMode.Always => true,
+            // Auto: rewrite only when the daemon is the Docker Desktop
+            // VM — i.e. Docker engine on a non-Linux host. On Linux the
+            // daemon shares the host's network namespace and localhost
+            // is the host, so a rewrite would break it.
+            PushTargetHostRewriteMode.Auto => IsDockerDesktop(options),
+            _ => false,
+        };
+
+        if (!shouldRewrite || !IsLoopback(host))
+        {
+            return new PushTargetHostResolution(
+                TargetAuthority: registryAuthority,
+                WasRewritten: false,
+                AliasHost: options.DockerDesktopHostAlias);
+        }
+
+        var alias = string.IsNullOrWhiteSpace(options.DockerDesktopHostAlias)
+            ? DockerDesktopHostAlias
+            : options.DockerDesktopHostAlias.Trim();
+
+        return new PushTargetHostResolution(
+            TargetAuthority: $"{alias}{portSuffix}",
+            WasRewritten: true,
+            AliasHost: alias);
+    }
+
+    /// <summary>
+    /// Rewrite a full remote reference (<c>host:port/repo:tag</c>) so
+    /// only the authority segment changes. The repo path and tag are
+    /// preserved verbatim.
+    /// </summary>
+    public static PushTargetHostResolution ResolveRemoteReference(
+        string remoteReference,
+        PushTargetHostOptions options)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(remoteReference);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var slash = remoteReference.IndexOf('/');
+        // No slash means there's no repo path to preserve — treat the
+        // whole thing as the authority.
+        if (slash < 0)
+        {
+            return Resolve(remoteReference, options);
+        }
+
+        var authority = remoteReference[..slash];
+        var rest = remoteReference[slash..]; // includes leading '/'
+
+        var resolution = Resolve(authority, options);
+        if (!resolution.WasRewritten)
+        {
+            return resolution with { TargetAuthority = remoteReference };
+        }
+
+        return resolution with { TargetAuthority = resolution.TargetAuthority + rest };
+    }
+
+    /// <summary>
+    /// True when the configured daemon is the Docker Desktop VM. Docker
+    /// Desktop runs on macOS and Windows; on those hosts the daemon is
+    /// in a VM with the loopback gap. On Linux, Docker runs natively and
+    /// shares the host network namespace, so no rewrite is needed.
+    /// </summary>
+    private static bool IsDockerDesktop(PushTargetHostOptions options)
+    {
+        if (options.IsDockerDesktopOverride is { } forced)
+        {
+            return forced;
+        }
+
+        return !RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+    }
+
+    private static bool IsLoopback(string host)
+        => LoopbackHosts.Contains(host, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Split <c>host:port</c> into the host and the <c>:port</c> suffix
+    /// (empty when no port). Handles bracketed IPv6 literals
+    /// (<c>[::1]:5050</c>).
+    /// </summary>
+    private static (string Host, string PortSuffix) SplitAuthority(string authority)
+    {
+        var trimmed = authority.Trim();
+
+        // Bracketed IPv6: [::1]:5050 → host "[::1]", suffix ":5050".
+        if (trimmed.StartsWith('['))
+        {
+            var close = trimmed.IndexOf(']');
+            if (close >= 0)
+            {
+                var host = trimmed[..(close + 1)];
+                var suffix = close + 1 < trimmed.Length ? trimmed[(close + 1)..] : string.Empty;
+                return (host, suffix);
+            }
+        }
+
+        var colon = trimmed.LastIndexOf(':');
+        if (colon < 0)
+        {
+            return (trimmed, string.Empty);
+        }
+        return (trimmed[..colon], trimmed[colon..]);
+    }
+}
+
+/// <summary>
+/// Policy controlling when <see cref="PushTargetHostResolver"/> rewrites
+/// a loopback registry authority to the Docker Desktop host alias.
+/// </summary>
+public enum PushTargetHostRewriteMode
+{
+    /// <summary>
+    /// Rewrite only when the daemon is Docker Desktop (Docker engine on
+    /// a non-Linux host). The default — safe on Linux, correct on
+    /// macOS/Windows Docker Desktop.
+    /// </summary>
+    Auto = 0,
+
+    /// <summary>Never rewrite; always push to the configured authority.</summary>
+    Never = 1,
+
+    /// <summary>Always rewrite a loopback authority, regardless of OS.</summary>
+    Always = 2,
+}
+
+/// <summary>
+/// Configuration for <see cref="PushTargetHostResolver"/>. Bound from
+/// the <c>ImageManagement:PushTarget</c> configuration section.
+/// </summary>
+public sealed class PushTargetHostOptions
+{
+    public const string SectionName = "ImageManagement:PushTarget";
+
+    /// <summary>When to apply the loopback→alias rewrite.</summary>
+    public PushTargetHostRewriteMode Mode { get; set; } = PushTargetHostRewriteMode.Auto;
+
+    /// <summary>
+    /// The host alias the Docker Desktop daemon can reach the host on.
+    /// Defaults to <c>host.docker.internal</c>.
+    /// </summary>
+    public string DockerDesktopHostAlias { get; set; } = PushTargetHostResolver.DockerDesktopHostAlias;
+
+    /// <summary>
+    /// Test/diagnostic override for Docker Desktop detection. When set,
+    /// <see cref="PushTargetHostRewriteMode.Auto"/> uses this value
+    /// instead of probing the OS platform. Null = probe the OS.
+    /// </summary>
+    public bool? IsDockerDesktopOverride { get; set; }
+}
+
+/// <summary>
+/// Result of resolving the push/tag target authority.
+/// </summary>
+/// <param name="TargetAuthority">
+/// The authority (or full remote ref, for the remote-ref overload) the
+/// Docker CLI should be told to push to.
+/// </param>
+/// <param name="WasRewritten">
+/// True when a loopback authority was rewritten to the Docker Desktop
+/// alias — the signal that the <c>insecure-registries</c> precondition
+/// now applies and a TLS/connection failure should be explained.
+/// </param>
+/// <param name="AliasHost">
+/// The alias host used for the rewrite (e.g. <c>host.docker.internal</c>),
+/// for inclusion in actionable error messages.
+/// </param>
+public readonly record struct PushTargetHostResolution(
+    string TargetAuthority,
+    bool WasRewritten,
+    string AliasHost);

--- a/src/Andy.Containers.Infrastructure/Registries/Local/RegistryPushFailureDiagnostics.cs
+++ b/src/Andy.Containers.Infrastructure/Registries/Local/RegistryPushFailureDiagnostics.cs
@@ -1,0 +1,96 @@
+namespace Andy.Containers.Infrastructure.Registries.Local;
+
+/// <summary>
+/// Turns a raw <c>docker push</c> failure into an actionable, loud
+/// message when the failure signature matches a known Docker Desktop
+/// misconfiguration — the loopback-unreachable timeout or the
+/// HTTP-vs-HTTPS / insecure-registry rejection.
+/// </summary>
+/// <remarks>
+/// The user has been explicit: NO silent push failures. When we've
+/// rewritten the push target to <c>host.docker.internal:5050</c> and
+/// the daemon still can't reach it (because zot binds loopback-only)
+/// or rejects it (because the host isn't in <c>insecure-registries</c>),
+/// the raw Go networking error is useless to a human. This appends the
+/// exact registry address and the exact <c>insecure-registries</c>
+/// entry to add.
+/// </remarks>
+public static class RegistryPushFailureDiagnostics
+{
+    /// <summary>
+    /// Build a hint explaining a Docker Desktop push failure, or null
+    /// when the failure doesn't match a known signature.
+    /// </summary>
+    /// <param name="targetAuthority">
+    /// The authority the push targeted, e.g.
+    /// <c>host.docker.internal:5050</c>.
+    /// </param>
+    /// <param name="dockerOutput">
+    /// Combined stdout/stderr from the failed <c>docker push</c>.
+    /// </param>
+    /// <param name="wasRewritten">
+    /// Whether the target was rewritten to the Docker Desktop alias —
+    /// only then do the Docker Desktop preconditions apply.
+    /// </param>
+    public static string? BuildHint(string targetAuthority, string? dockerOutput, bool wasRewritten)
+    {
+        var output = dockerOutput ?? string.Empty;
+
+        // HTTP-vs-HTTPS / insecure-registry rejection. Docker treats a
+        // non-localhost registry as HTTPS by default; pushing plain HTTP
+        // surfaces one of these signatures.
+        if (LooksLikeTlsRejection(output))
+        {
+            return
+                $"The registry '{targetAuthority}' is served over plain HTTP, but the Docker daemon " +
+                $"requires HTTPS for any registry that isn't 'localhost'. Add '{targetAuthority}' to the " +
+                "Docker daemon's insecure-registries and restart Docker Desktop:\n" +
+                "  Docker Desktop → Settings → Docker Engine, add:\n" +
+                "    \"insecure-registries\": [\"" + targetAuthority + "\"]\n" +
+                "then click Apply & Restart.";
+        }
+
+        // Loopback-unreachable timeout. Either zot binds loopback-only
+        // (so the VM can't reach host.docker.internal) or the host alias
+        // didn't resolve.
+        if (LooksLikeConnectionTimeout(output))
+        {
+            if (wasRewritten)
+            {
+                return
+                    $"The Docker daemon could not reach the registry at '{targetAuthority}'. On Docker " +
+                    "Desktop the daemon runs in a VM, so the embedded registry must bind a VM-reachable " +
+                    "interface (e.g. 0.0.0.0:5050, not 127.0.0.1:5050) and be in insecure-registries. " +
+                    $"Confirm zot is bound to 0.0.0.0 and add '{targetAuthority}' to Docker Desktop's " +
+                    "insecure-registries (Settings → Docker Engine), then Apply & Restart.";
+            }
+
+            return
+                $"The Docker daemon could not reach the registry at '{targetAuthority}'. On Docker Desktop " +
+                "the daemon runs in a VM where 'localhost' is the VM, not the host — it cannot reach a " +
+                "host-loopback registry. The push target must be a VM-reachable address such as " +
+                $"'{PushTargetHostResolver.DockerDesktopHostAlias}:<port>', the registry must bind a " +
+                "VM-reachable interface (0.0.0.0), and that address must be in Docker Desktop's " +
+                "insecure-registries.";
+        }
+
+        return null;
+    }
+
+    private static bool LooksLikeConnectionTimeout(string output)
+        => Contains(output, "Client.Timeout exceeded while awaiting headers")
+        || Contains(output, "request canceled while waiting for connection")
+        || Contains(output, "connection refused")
+        || Contains(output, "no route to host")
+        || Contains(output, "i/o timeout")
+        || Contains(output, "dial tcp");
+
+    private static bool LooksLikeTlsRejection(string output)
+        => Contains(output, "http: server gave HTTP response to HTTPS client")
+        || Contains(output, "tls: first record does not look like a TLS handshake")
+        || (Contains(output, "x509") && Contains(output, "certificate"))
+        || Contains(output, "server gave HTTP response to HTTPS client");
+
+    private static bool Contains(string haystack, string needle)
+        => haystack.Contains(needle, StringComparison.OrdinalIgnoreCase);
+}

--- a/tests/Andy.Containers.Tests/Infrastructure/Images/DockerCliImagePullServiceTests.cs
+++ b/tests/Andy.Containers.Tests/Infrastructure/Images/DockerCliImagePullServiceTests.cs
@@ -1,0 +1,166 @@
+using Andy.Containers.Abstractions.Images;
+using Andy.Containers.Configuration;
+using Andy.Containers.Infrastructure.Images;
+using Andy.Containers.Infrastructure.Registries.Local;
+using Andy.Containers.Models.ImageManagement;
+using Andy.Containers.Tests.TestSupport;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Andy.Containers.Tests.Infrastructure.Images;
+
+// Docker Desktop loopback gap (rivoli-ai/andy-containers). The
+// ensure-pull rehost path (docker pull → tag → push) must rewrite the
+// DESTINATION authority to host.docker.internal on Docker Desktop so
+// the push from inside the VM reaches the host's zot — while the pull
+// SOURCE (ghcr.io) is left untouched.
+//
+// These substitute "docker" with a StubScript recording its args, so
+// no real daemon is needed. macOS / Linux only.
+public class DockerCliImagePullServiceTests
+{
+    public static bool RunsBashStubs => !OperatingSystem.IsWindows();
+
+    [Fact]
+    public async Task EnsurePull_DockerDesktop_RewritesDestinationToHostDockerInternal()
+    {
+        if (!RunsBashStubs) { return; }
+
+        using var docker = new StubScript(exitCode: 0, stderr: "");
+        var service = MakeService(docker, isDockerDesktop: true);
+
+        await service.EnsurePullAsync(new EnsurePullRequest
+        {
+            SourceRegistry = "ghcr.io",
+            SourceRepository = "rivoli-ai/conductor-terminal-claude-code",
+            SourceTag = "v1",
+            DestinationRegistryId = "local-zot",
+        }, CancellationToken.None);
+
+        // pull (source unchanged), tag (source→rewritten dest), push (rewritten dest)
+        docker.Invocations.Should().HaveCount(3);
+        docker.Invocations[0].Should().Equal(
+            ["pull", "ghcr.io/rivoli-ai/conductor-terminal-claude-code:v1"]);
+        docker.Invocations[1].Should().Equal(
+            ["tag",
+             "ghcr.io/rivoli-ai/conductor-terminal-claude-code:v1",
+             "host.docker.internal:5050/conductor-terminal-claude-code:v1"]);
+        docker.Invocations[2].Should().Equal(
+            ["push", "host.docker.internal:5050/conductor-terminal-claude-code:v1"]);
+    }
+
+    [Fact]
+    public async Task EnsurePull_Linux_KeepsLocalhostDestination()
+    {
+        if (!RunsBashStubs) { return; }
+
+        using var docker = new StubScript(exitCode: 0, stderr: "");
+        var service = MakeService(docker, isDockerDesktop: false);
+
+        await service.EnsurePullAsync(new EnsurePullRequest
+        {
+            SourceRegistry = "ghcr.io",
+            SourceRepository = "rivoli-ai/conductor-terminal-claude-code",
+            SourceTag = "v1",
+            DestinationRegistryId = "local-zot",
+        }, CancellationToken.None);
+
+        docker.Invocations[2].Should().Equal(
+            ["push", "localhost:5050/conductor-terminal-claude-code:v1"]);
+    }
+
+    [Fact]
+    public async Task EnsurePull_PushTimeoutOnDockerDesktop_ThrowsActionableHint()
+    {
+        if (!RunsBashStubs) { return; }
+
+        // docker exits non-zero on the push with the loopback-timeout
+        // signature.
+        using var docker = new StubScript(
+            exitCode: 1,
+            stderr: "Get http://host.docker.internal:5050/v2/ : Client.Timeout exceeded while awaiting headers");
+        var service = MakeService(docker, isDockerDesktop: true);
+
+        var act = async () => await service.EnsurePullAsync(new EnsurePullRequest
+        {
+            SourceRegistry = "ghcr.io",
+            SourceRepository = "rivoli-ai/conductor-terminal-claude-code",
+            SourceTag = "v1",
+            DestinationRegistryId = "local-zot",
+        }, CancellationToken.None);
+
+        (await act.Should().ThrowAsync<ImagePullException>())
+            .Which.Message.Should().Contain("insecure-registries");
+    }
+
+    private static DockerCliImagePullService MakeService(StubScript docker, bool isDockerDesktop)
+    {
+        var registryConfig = Options.Create(new RegistryConfigurationOptions
+        {
+            Registries =
+            [
+                new RegistryConfigEntry
+                {
+                    Id = "local-zot",
+                    Kind = "zot",
+                    Url = "http://localhost:5050",
+                    IsPrimary = true,
+                },
+            ],
+        });
+
+        var pullOptions = Options.Create(new DockerCliImagePullOptions
+        {
+            DockerExecutablePath = docker.Path,
+        });
+
+        var pushTargetOptions = Options.Create(new PushTargetHostOptions
+        {
+            Mode = PushTargetHostRewriteMode.Auto,
+            IsDockerDesktopOverride = isDockerDesktop,
+        });
+
+        return new DockerCliImagePullService(
+            registryAdapters: [new NeverPresentAdapter()],
+            registryConfig: registryConfig,
+            logger: NullLogger<DockerCliImagePullService>.Instance,
+            options: pullOptions,
+            pushTargetOptions: pushTargetOptions);
+    }
+
+    /// <summary>
+    /// Registry adapter whose idempotency probe always reports nothing
+    /// present (so the pull always runs), then reports a reference once
+    /// the push has happened (so the post-push lookup succeeds).
+    /// </summary>
+    private sealed class NeverPresentAdapter : IRegistryAdapter
+    {
+        private int _listCalls;
+
+        public string RegistryId => "local-zot";
+
+        public Task<IReadOnlyList<RegistryReference>> ListReferencesAsync(string repoPath, CancellationToken ct)
+        {
+            // First call = pre-push idempotency probe → empty.
+            // Subsequent = post-push lookup → one reference.
+            _listCalls++;
+            IReadOnlyList<RegistryReference> result = _listCalls <= 1
+                ? []
+                : [new RegistryReference(
+                    Id: Guid.NewGuid(), RegistryId: RegistryId, RepoPath: repoPath, Tag: "v1",
+                    Digest: "sha256:pushed", PushedAt: DateTimeOffset.UtcNow, PushedBy: "test")];
+            return Task.FromResult(result);
+        }
+
+        public Task<RegistryReference> PushAsync(BuildArtifact artifact, string repoPath, string tag, CancellationToken ct)
+            => throw new NotSupportedException();
+
+        public Task<bool> ExistsAsync(string repoPath, string digest, CancellationToken ct)
+            => Task.FromResult(false);
+
+        public Task DeleteAsync(RegistryReference reference, CancellationToken ct)
+            => Task.CompletedTask;
+    }
+}

--- a/tests/Andy.Containers.Tests/Infrastructure/Registries/LocalZotAdapterTests.cs
+++ b/tests/Andy.Containers.Tests/Infrastructure/Registries/LocalZotAdapterTests.cs
@@ -41,7 +41,15 @@ public class LocalZotAdapterTests
                 }),
         });
         var uploader = new RecordingUploader();
-        var adapter = NewAdapter(stub, uploader);
+        // Pin the no-rewrite (Linux/native daemon) baseline so this
+        // assertion is OS-independent — the Docker Desktop rewrite is
+        // exercised separately by
+        // PushAsync_DockerDesktop_RewritesRemoteRefToHostDockerInternal.
+        var adapter = NewAdapter(stub, uploader, pushTargetOptions: new PushTargetHostOptions
+        {
+            Mode = PushTargetHostRewriteMode.Auto,
+            IsDockerDesktopOverride = false,
+        });
         var artifact = MakeArtifact(localRef: "andy-build:tmp-123", specHash: "sha256:spec");
 
         var reference = await adapter.PushAsync(artifact, "foo/bar", "v1", CancellationToken.None);
@@ -230,13 +238,101 @@ public class LocalZotAdapterTests
         adapter.RegistryId.Should().Be("team-zot");
     }
 
+    // Docker Desktop loopback gap (rivoli-ai/andy-containers). On Docker
+    // Desktop the push/tag target must be host.docker.internal so the
+    // `docker push` running inside the VM can reach the host's zot. The
+    // HTTP client (post-push HEAD) still uses localhost. This test
+    // proves the adapter rewrites the remote ref it hands the uploader,
+    // while the HEAD it issues stays on localhost (the stub is keyed by
+    // path only, so a wrong-host HEAD wouldn't even be routed).
+    [Fact]
+    public async Task PushAsync_DockerDesktop_RewritesRemoteRefToHostDockerInternal()
+    {
+        var stub = new StubHandler(new Dictionary<string, StubHandler.Response>
+        {
+            ["HEAD /v2/foo/bar/manifests/v1"] = new(
+                HttpStatusCode.OK,
+                Headers: new Dictionary<string, string>
+                {
+                    ["Docker-Content-Digest"] = "sha256:abc123",
+                }),
+        });
+        var uploader = new RecordingUploader();
+        var adapter = NewAdapter(stub, uploader, pushTargetOptions: new PushTargetHostOptions
+        {
+            Mode = PushTargetHostRewriteMode.Auto,
+            IsDockerDesktopOverride = true,
+        });
+
+        await adapter.PushAsync(
+            MakeArtifact(localRef: "andy-build:tmp-123", specHash: "sha256:spec"),
+            "foo/bar", "v1", CancellationToken.None);
+
+        uploader.Pushed.Should().ContainSingle()
+            .Which.Should().Be(("andy-build:tmp-123", "host.docker.internal:5050/foo/bar:v1"));
+    }
+
+    [Fact]
+    public async Task PushAsync_Linux_KeepsLocalhostRemoteRef()
+    {
+        var stub = new StubHandler(new Dictionary<string, StubHandler.Response>
+        {
+            ["HEAD /v2/foo/bar/manifests/v1"] = new(
+                HttpStatusCode.OK,
+                Headers: new Dictionary<string, string>
+                {
+                    ["Docker-Content-Digest"] = "sha256:abc123",
+                }),
+        });
+        var uploader = new RecordingUploader();
+        var adapter = NewAdapter(stub, uploader, pushTargetOptions: new PushTargetHostOptions
+        {
+            Mode = PushTargetHostRewriteMode.Auto,
+            IsDockerDesktopOverride = false,
+        });
+
+        await adapter.PushAsync(
+            MakeArtifact(localRef: "andy-build:tmp-123", specHash: "sha256:spec"),
+            "foo/bar", "v1", CancellationToken.None);
+
+        uploader.Pushed.Should().ContainSingle()
+            .Which.Should().Be(("andy-build:tmp-123", "localhost:5050/foo/bar:v1"));
+    }
+
+    [Fact]
+    public async Task PushAsync_WrapsDockerDesktopUnreachable_WithActionableHint()
+    {
+        var stub = new StubHandler(new Dictionary<string, StubHandler.Response>());
+        var uploader = new ThrowingUploader(new RegistryUploadException(
+            code: "DockerCliUploader.Push.NonZeroExit1",
+            message: "docker exited with code 1",
+            capturedOutput:
+                "Get \"http://host.docker.internal:5050/v2/\": net/http: request canceled " +
+                "while waiting for connection (Client.Timeout exceeded while awaiting headers)"));
+        var adapter = NewAdapter(stub, uploader, pushTargetOptions: new PushTargetHostOptions
+        {
+            Mode = PushTargetHostRewriteMode.Auto,
+            IsDockerDesktopOverride = true,
+        });
+
+        var act = async () => await adapter.PushAsync(
+            MakeArtifact(localRef: "x", specHash: "sha256:y"),
+            "foo/bar", "v1", CancellationToken.None);
+
+        (await act.Should().ThrowAsync<RegistryUploadException>()
+            .Where(e => e.Code == "LocalZotAdapter.Push.DockerDesktopUnreachable"))
+            .Which.Message.Should().Contain("insecure-registries");
+    }
+
     private static LocalZotAdapter NewAdapter(
         StubHandler handler,
         IRegistryUploader uploader,
-        string registryId = "local-zot")
+        string registryId = "local-zot",
+        PushTargetHostOptions? pushTargetOptions = null)
     {
         var http = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:5050") };
-        return new LocalZotAdapter(http, uploader, NullLogger<LocalZotAdapter>.Instance, registryId);
+        return new LocalZotAdapter(
+            http, uploader, NullLogger<LocalZotAdapter>.Instance, registryId, pushTargetOptions);
     }
 
     private static BuildArtifact MakeArtifact(string localRef, string specHash)
@@ -260,6 +356,19 @@ public class LocalZotAdapterTests
             Pushed.Add((localReference, remoteReference));
             return Task.CompletedTask;
         }
+    }
+
+    /// <summary>
+    /// Uploader that always throws a supplied exception — exercises the
+    /// adapter's Docker Desktop failure-wrapping path.
+    /// </summary>
+    private sealed class ThrowingUploader : IRegistryUploader
+    {
+        private readonly RegistryUploadException _ex;
+        public ThrowingUploader(RegistryUploadException ex) { _ex = ex; }
+
+        public Task PushAsync(string localReference, string remoteReference, CancellationToken ct)
+            => throw _ex;
     }
 
     /// <summary>

--- a/tests/Andy.Containers.Tests/Infrastructure/Registries/PushTargetHostResolverTests.cs
+++ b/tests/Andy.Containers.Tests/Infrastructure/Registries/PushTargetHostResolverTests.cs
@@ -1,0 +1,154 @@
+using Andy.Containers.Infrastructure.Registries.Local;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Tests.Infrastructure.Registries;
+
+// Docker Desktop loopback gap (rivoli-ai/andy-containers).
+// `docker push localhost:5050/...` runs inside the Docker Desktop VM,
+// where localhost is the VM — not the host running zot. These tests
+// lock down the rewrite policy:
+//   - Docker Desktop  → loopback authority rewritten to host.docker.internal
+//   - Linux / default → localhost left unchanged (daemon shares host net)
+// The IsDockerDesktopOverride knob makes the OS-platform branch
+// deterministic on any CI host.
+public class PushTargetHostResolverTests
+{
+    private static PushTargetHostOptions Options(
+        PushTargetHostRewriteMode mode = PushTargetHostRewriteMode.Auto,
+        bool? isDockerDesktop = null)
+        => new() { Mode = mode, IsDockerDesktopOverride = isDockerDesktop };
+
+    [Fact]
+    public void Resolve_DockerDesktop_RewritesLocalhostToHostDockerInternal()
+    {
+        var result = PushTargetHostResolver.Resolve(
+            "localhost:5050", Options(isDockerDesktop: true));
+
+        result.WasRewritten.Should().BeTrue();
+        result.TargetAuthority.Should().Be("host.docker.internal:5050");
+    }
+
+    [Fact]
+    public void Resolve_DockerDesktop_RewritesLoopbackIpToHostDockerInternal()
+    {
+        var result = PushTargetHostResolver.Resolve(
+            "127.0.0.1:5050", Options(isDockerDesktop: true));
+
+        result.WasRewritten.Should().BeTrue();
+        result.TargetAuthority.Should().Be("host.docker.internal:5050");
+    }
+
+    [Fact]
+    public void Resolve_Linux_LeavesLocalhostUnchanged()
+    {
+        // Auto mode on a Linux/native daemon: localhost in the daemon IS
+        // the host, so rewriting would break it.
+        var result = PushTargetHostResolver.Resolve(
+            "localhost:5050", Options(isDockerDesktop: false));
+
+        result.WasRewritten.Should().BeFalse();
+        result.TargetAuthority.Should().Be("localhost:5050");
+    }
+
+    [Fact]
+    public void Resolve_NeverMode_NeverRewrites_EvenOnDockerDesktop()
+    {
+        var result = PushTargetHostResolver.Resolve(
+            "localhost:5050",
+            Options(mode: PushTargetHostRewriteMode.Never, isDockerDesktop: true));
+
+        result.WasRewritten.Should().BeFalse();
+        result.TargetAuthority.Should().Be("localhost:5050");
+    }
+
+    [Fact]
+    public void Resolve_AlwaysMode_RewritesEvenOnLinux()
+    {
+        var result = PushTargetHostResolver.Resolve(
+            "localhost:5050",
+            Options(mode: PushTargetHostRewriteMode.Always, isDockerDesktop: false));
+
+        result.WasRewritten.Should().BeTrue();
+        result.TargetAuthority.Should().Be("host.docker.internal:5050");
+    }
+
+    [Fact]
+    public void Resolve_NonLoopbackAuthority_NeverRewritten()
+    {
+        // A real hostname / LAN IP is already daemon-reachable — leave it.
+        var result = PushTargetHostResolver.Resolve(
+            "registry.internal:5050", Options(isDockerDesktop: true));
+
+        result.WasRewritten.Should().BeFalse();
+        result.TargetAuthority.Should().Be("registry.internal:5050");
+    }
+
+    [Fact]
+    public void Resolve_AlreadyHostDockerInternal_NotRewrittenAgain()
+    {
+        var result = PushTargetHostResolver.Resolve(
+            "host.docker.internal:5050", Options(isDockerDesktop: true));
+
+        result.WasRewritten.Should().BeFalse();
+        result.TargetAuthority.Should().Be("host.docker.internal:5050");
+    }
+
+    [Fact]
+    public void Resolve_PreservesPort()
+    {
+        var result = PushTargetHostResolver.Resolve(
+            "localhost:9101", Options(isDockerDesktop: true));
+
+        result.TargetAuthority.Should().Be("host.docker.internal:9101");
+    }
+
+    [Fact]
+    public void Resolve_NoPort_StillRewritesHost()
+    {
+        var result = PushTargetHostResolver.Resolve(
+            "localhost", Options(isDockerDesktop: true));
+
+        result.WasRewritten.Should().BeTrue();
+        result.TargetAuthority.Should().Be("host.docker.internal");
+    }
+
+    [Fact]
+    public void Resolve_CustomAlias_Honored()
+    {
+        var opts = Options(isDockerDesktop: true);
+        opts.DockerDesktopHostAlias = "gateway.docker.internal";
+
+        var result = PushTargetHostResolver.Resolve("localhost:5050", opts);
+
+        result.TargetAuthority.Should().Be("gateway.docker.internal:5050");
+        result.AliasHost.Should().Be("gateway.docker.internal");
+    }
+
+    [Fact]
+    public void ResolveRemoteReference_DockerDesktop_RewritesOnlyAuthority()
+    {
+        var result = PushTargetHostResolver.ResolveRemoteReference(
+            "localhost:5050/foo/bar:v1", Options(isDockerDesktop: true));
+
+        result.WasRewritten.Should().BeTrue();
+        result.TargetAuthority.Should().Be("host.docker.internal:5050/foo/bar:v1");
+    }
+
+    [Fact]
+    public void ResolveRemoteReference_Linux_LeavesRefUnchanged()
+    {
+        var result = PushTargetHostResolver.ResolveRemoteReference(
+            "localhost:5050/foo/bar:v1", Options(isDockerDesktop: false));
+
+        result.WasRewritten.Should().BeFalse();
+        result.TargetAuthority.Should().Be("localhost:5050/foo/bar:v1");
+    }
+
+    [Fact]
+    public void Resolve_RejectsNullOrWhitespaceAuthority()
+    {
+        var act = () => PushTargetHostResolver.Resolve("  ", Options());
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/Andy.Containers.Tests/Infrastructure/Registries/RegistryPushFailureDiagnosticsTests.cs
+++ b/tests/Andy.Containers.Tests/Infrastructure/Registries/RegistryPushFailureDiagnosticsTests.cs
@@ -1,0 +1,81 @@
+using Andy.Containers.Infrastructure.Registries.Local;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Containers.Tests.Infrastructure.Registries;
+
+// NO silent push failures. When a docker push to a rewritten
+// host.docker.internal target fails with a loopback-timeout or an
+// HTTP-vs-HTTPS rejection, the bare Go networking error is useless to
+// a human. These tests lock down the actionable hint that names the
+// exact registry address and the insecure-registries entry to add.
+public class RegistryPushFailureDiagnosticsTests
+{
+    [Fact]
+    public void BuildHint_TlsRejection_ExplainsInsecureRegistries()
+    {
+        const string output =
+            "http: server gave HTTP response to HTTPS client";
+
+        var hint = RegistryPushFailureDiagnostics.BuildHint(
+            "host.docker.internal:5050", output, wasRewritten: true);
+
+        hint.Should().NotBeNull();
+        hint.Should().Contain("insecure-registries");
+        hint.Should().Contain("host.docker.internal:5050");
+        hint.Should().Contain("Apply & Restart");
+    }
+
+    [Fact]
+    public void BuildHint_ConnectionTimeout_AfterRewrite_MentionsBindAndInsecure()
+    {
+        const string output =
+            "Get \"http://host.docker.internal:5050/v2/\": net/http: request canceled " +
+            "while waiting for connection (Client.Timeout exceeded while awaiting headers)";
+
+        var hint = RegistryPushFailureDiagnostics.BuildHint(
+            "host.docker.internal:5050", output, wasRewritten: true);
+
+        hint.Should().NotBeNull();
+        hint.Should().Contain("host.docker.internal:5050");
+        hint.Should().Contain("0.0.0.0", "the registry must bind a VM-reachable interface");
+        hint.Should().Contain("insecure-registries");
+    }
+
+    [Fact]
+    public void BuildHint_ConnectionTimeout_WithoutRewrite_ExplainsLoopbackGap()
+    {
+        // The original failing case: target still localhost, push from
+        // the VM times out.
+        const string output =
+            "Get \"http://localhost:5050/v2/\": net/http: request canceled while " +
+            "waiting for connection (Client.Timeout exceeded while awaiting headers)";
+
+        var hint = RegistryPushFailureDiagnostics.BuildHint(
+            "localhost:5050", output, wasRewritten: false);
+
+        hint.Should().NotBeNull();
+        hint.Should().Contain("host.docker.internal");
+        hint.Should().Contain("VM");
+    }
+
+    [Fact]
+    public void BuildHint_UnrelatedFailure_ReturnsNull()
+    {
+        const string output = "denied: requested access to the resource is denied";
+
+        var hint = RegistryPushFailureDiagnostics.BuildHint(
+            "host.docker.internal:5050", output, wasRewritten: true);
+
+        hint.Should().BeNull("an auth-denied error is not a Docker Desktop misconfig");
+    }
+
+    [Fact]
+    public void BuildHint_NullOutput_ReturnsNull()
+    {
+        var hint = RegistryPushFailureDiagnostics.BuildHint(
+            "host.docker.internal:5050", null, wasRewritten: true);
+
+        hint.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Root cause

Template image builds and `POST /api/images/ensure-pull` rehosts FAIL at the **push** step on macOS Docker Desktop:

```
docker exited with code 1 ...
Get "http://localhost:5050/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```

— even though `curl http://localhost:5050/v2/` returns **200 from the host**.

`docker push localhost:5050/...` runs **inside the Docker Desktop VM**, where `localhost` is the VM, not the host. The embedded zot registry binds the host's loopback (`127.0.0.1:5050`), which the VM cannot route to, so every push times out. Reproduced deterministically: `docker push localhost:5050/<x>` fails with the exact reported error while `curl` from the host returns 200.

Both push paths build the remote ref from the configured registry authority (`localhost:5050`):
- `LocalZotAdapter.PushAsync` (template builds)
- `DockerCliImagePullService.EnsurePullAsync` (ensure-pull rehost)

There was already `host.docker.internal` handling for `Proxy__ContainerFacingBaseUrl` (the proxy URL baked into spawned containers) — but **not** for the registry push target.

## Fix

- **`PushTargetHostResolver`** (pure, unit-tested) rewrites the push/tag **target authority** from a loopback host (`localhost` / `127.0.0.1` / `::1`) to `host.docker.internal` whenever the daemon is Docker Desktop (Docker engine on a non-Linux host). The HTTP API client (`LocalZotAdapter._http`, post-push HEAD) keeps using `localhost`.
- Default `Auto` mode is OS-aware: on **native Linux Docker** the daemon shares the host network namespace, so `localhost` already works and **no rewrite happens** — Linux is unaffected. `Never` / `Always` override the policy.
- Wired into both push paths; the **pull source** (e.g. `ghcr.io`) is left untouched, only the destination is rewritten.
- **`RegistryPushFailureDiagnostics`** turns the two known Docker Desktop failure signatures into a LOUD, actionable error (the user has been explicit: **no silent push failures**):
  - loopback-unreachable timeout
  - HTTP-vs-HTTPS / missing insecure-registries rejection

  The error names the exact registry address and the exact `insecure-registries` entry to add.
- Configurable via `ImageManagement:PushTarget` (`Mode`, `DockerDesktopHostAlias`).

## Required Docker Desktop setting

`host.docker.internal:5050` is plain HTTP, and Docker treats any non-`localhost` registry as HTTPS by default. The host must be in the daemon's **insecure-registries**:

**Docker Desktop → Settings → Docker Engine**, add:

```json
{
  "insecure-registries": ["host.docker.internal:5050"]
}
```

then **Apply & Restart**. (Use the real port if zot is not on 5050; Conductor pins it to 5050.)

## Verification (real push)

Built a one-layer image and pushed it:

- `docker push localhost:5050/zot-push-test:v1` →
  `Get "http://localhost:5050/v2/": ... Client.Timeout exceeded while awaiting headers` — **reproduces the exact reported failure**.
- `docker push host.docker.internal:5050/zot-push-test:v1` (the rewritten target) →
  `Get "https://host.docker.internal:5050/v2/": http: server gave HTTP response to HTTPS client` — the connection now **reaches zot** (no more timeout); the remaining step is the `insecure-registries` Docker Desktop setting, which the new diagnostics detect and explain.

(zot bind was confirmed `127.0.0.1:5050` via `lsof`; on this Docker Desktop 4.50 build `host.docker.internal` is proxied back to the host loopback, so the alias rewrite alone restores reachability — documented, with the optional `0.0.0.0` bind note for future Docker Desktop versions.)

## Tests

All green — `Andy.Containers.Tests` 570 passed (3 consecutive full runs), `Andy.Containers.Api.Tests` ImagesController 59 passed.

- `PushTargetHostResolverTests` — Docker Desktop → rewrite; Linux/default → unchanged; `Never`/`Always` modes; loopback IP, IPv6, port preservation, custom alias, non-loopback untouched, remote-ref rewrite.
- `RegistryPushFailureDiagnosticsTests` — TLS-rejection + loopback-timeout (rewritten & not) produce actionable hints; unrelated/auth-denied/null → null.
- `LocalZotAdapterTests` — remote-ref rewritten on Docker Desktop, `localhost` on Linux, `DockerDesktopUnreachable` wrapping with the `insecure-registries` hint. (Existing `PushAsync_Delegates…` pinned to the Linux baseline so it's OS-independent.)
- `DockerCliImagePullServiceTests` (new) — ensure-pull rewrites the destination (source untouched), Linux baseline keeps `localhost`, push timeout raises the actionable hint.

Pre-existing flake noted: `LocalBuildBackendTests.BuildAsync_NonZeroExit_ThrowsWithCapturedLogs` failed once under parallel load but passes in isolation on both `origin/main` and this branch — unrelated to this change (it's the build backend's bash StubScript, not the registry path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)