### PR TITLE
Fix hanging and parallel test regressions

### DIFF
--- a/src/Andy.Containers.Api/Services/AndyModelsProxyTokenService.cs
+++ b/src/Andy.Containers.Api/Services/AndyModelsProxyTokenService.cs
@@ -241,7 +241,17 @@ public sealed class AndyModelsProxyTokenService : IProxyTokenService
                         + "sub=andy-containers-api instead of the originating user. Likely cause: the inbound "
                         + "user token is expired or not exchange-eligible. Underlying: {Reason}",
                     AndyModelsApiAudience, ex.Message);
-                return await GetBearerAsync(ct).ConfigureAwait(false);
+                try
+                {
+                    return await GetBearerAsync(ct).ConfigureAwait(false);
+                }
+                catch (ProxyTokenException fallbackEx)
+                {
+                    throw new ProxyTokenException(
+                        "OBO exchange for andy-models failed and the M2M bearer fallback could not be obtained. " +
+                        "Check token-exchange policy, ServiceAuth:* configuration, and the andy-models API scope.",
+                        new AggregateException(ex, fallbackEx));
+                }
             }
         }
 

--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -634,7 +634,8 @@ public class ContainerOrchestrationService : IContainerService
                 // codeAssistant routing block above only runs for a configured
                 // assistant; an assistant-less headless run lands here, so
                 // point the OpenAI dialect at the andy-models proxy.
-                if (!string.IsNullOrWhiteSpace(containerFacingProxyUrl))
+                if (!string.IsNullOrWhiteSpace(containerFacingProxyUrl)
+                    && string.IsNullOrWhiteSpace(codeAssistant?.ApiBaseUrl))
                 {
                     // andy-models exposes the OpenAI-compatible chat surface at
                     // `/models/v1/chat/completions` (the OpenAI SDK appends

--- a/tests/Andy.Containers.Api.Tests/Mcp/RunsMcpToolsTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Mcp/RunsMcpToolsTests.cs
@@ -22,6 +22,7 @@ namespace Andy.Containers.Api.Tests.Mcp;
 // what AP7 wired into the HTTP layer.
 public class RunsMcpToolsTests : IDisposable
 {
+    private readonly string _databaseName = Guid.NewGuid().ToString();
     private readonly ContainersDbContext _db;
     private readonly Mock<IRunConfigurator> _configurator;
     private readonly Mock<IRunModeDispatcher> _dispatcher;
@@ -33,7 +34,7 @@ public class RunsMcpToolsTests : IDisposable
 
     public RunsMcpToolsTests()
     {
-        _db = InMemoryDbHelper.CreateContext();
+        _db = InMemoryDbHelper.CreateContext(_databaseName);
 
         _configurator = new Mock<IRunConfigurator>();
         _configurator
@@ -333,9 +334,16 @@ public class RunsMcpToolsTests : IDisposable
         // Wait one poll cycle so the consumer is in the loop.
         await Task.Delay(50);
 
-        run.TransitionTo(RunStatus.Cancelled);
-        _db.AppendAgentRunEvent(run, RunEventKind.Cancelled);
-        await _db.SaveChangesAsync();
+        // The live enumerator is polling through _db. EF DbContext is not
+        // thread-safe, so model the real producer with its own request scope
+        // instead of racing a write through the consumer's context.
+        await using (var writerDb = InMemoryDbHelper.CreateContext(_databaseName))
+        {
+            var writerRun = await writerDb.Runs.SingleAsync(r => r.Id == run.Id);
+            writerRun.TransitionTo(RunStatus.Cancelled);
+            writerDb.AppendAgentRunEvent(writerRun, RunEventKind.Cancelled);
+            await writerDb.SaveChangesAsync();
+        }
 
         var collected = await streamTask;
 

--- a/tests/Andy.Containers.Api.Tests/Services/HeadlessRunLauncherTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/HeadlessRunLauncherTests.cs
@@ -61,14 +61,31 @@ public class HeadlessRunLauncherTests
         var dbName = Guid.NewGuid().ToString();
         var db = InMemoryDbHelper.CreateContext(dbName);
 
-        var workspace = new Workspace
+        var template = new ContainerTemplate
+        {
+            Code = "headless-launcher-test",
+            Name = "Headless launcher test",
+            Version = "1",
+            BaseImage = "ubuntu:24.04",
+        };
+        var provider = new InfrastructureProvider
+        {
+            Code = "headless-launcher-test",
+            Name = "Headless launcher test",
+            Type = ProviderType.Docker,
+            IsEnabled = true,
+        };
+        var container = new Container
         {
             Id = Guid.NewGuid(),
-            Name = "ws",
+            Name = "headless-launcher-test",
             OwnerId = "u",
-            DefaultContainerId = Guid.NewGuid(),
+            Template = template,
+            Provider = provider,
+            Status = ContainerStatus.Running,
+            ExternalId = "headless-launcher-test",
         };
-        db.Workspaces.Add(workspace);
+        db.Containers.Add(container);
         var run = new Run
         {
             Id = Guid.NewGuid(),
@@ -77,7 +94,7 @@ public class HeadlessRunLauncherTests
             EnvironmentProfileId = Guid.NewGuid(),
             CorrelationId = Guid.NewGuid(),
             Status = RunStatus.Pending,
-            WorkspaceRef = new WorkspaceRef { WorkspaceId = workspace.Id },
+            WorkspaceRef = new WorkspaceRef { WorkspaceId = container.Id },
         };
         db.Runs.Add(run);
         db.SaveChanges();

--- a/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerOutputStreamTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerOutputStreamTests.cs
@@ -29,9 +29,15 @@ public class HeadlessRunnerOutputStreamTests : IDisposable
     private readonly Mock<ITokenIssuer> _tokens = new();
     private readonly InMemoryRunOutputBus _bus = new();
     private readonly HeadlessRunner _runner;
+    private readonly string _configPath;
 
     public HeadlessRunnerOutputStreamTests()
     {
+        _configPath = Path.Combine(
+            Path.GetTempPath(),
+            $"andy-containers-output-stream-{Guid.NewGuid():N}.json");
+        File.WriteAllText(_configPath, "{}");
+
         _db = InMemoryDbHelper.CreateContext();
         _tokens
             .Setup(t => t.RevokeAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
@@ -51,6 +57,7 @@ public class HeadlessRunnerOutputStreamTests : IDisposable
     {
         _db.Dispose();
         _bus.Dispose();
+        File.Delete(_configPath);
     }
 
     [Fact]
@@ -68,7 +75,7 @@ public class HeadlessRunnerOutputStreamTests : IDisposable
         // Subscribe BEFORE running is racy in a unit test; instead drive
         // the run, then drain the bus (which replays the buffered lines
         // and closes because the run is terminal).
-        var outcome = await _runner.StartAsync(run, "/tmp/x/config.json");
+        var outcome = await _runner.StartAsync(run, _configPath);
         outcome.Status.Should().Be(RunStatus.Succeeded);
 
         var lines = await DrainAsync(run.Id);
@@ -93,7 +100,7 @@ public class HeadlessRunnerOutputStreamTests : IDisposable
             (ExecStreamKind.Stdout, "curl -H 'Authorization: Bearer sk-run-secret-0123456789abcdef'"),
         ]);
 
-        await _runner.StartAsync(run, "/tmp/x/config.json");
+        await _runner.StartAsync(run, _configPath);
 
         var lines = await DrainAsync(run.Id);
 
@@ -108,7 +115,7 @@ public class HeadlessRunnerOutputStreamTests : IDisposable
         var run = SeedRun();
         SetupStreamingExec(run.ContainerId!.Value, exitCode: 0, lines: []);
 
-        await _runner.StartAsync(run, "/tmp/x/config.json");
+        await _runner.StartAsync(run, _configPath);
 
         // An immediate drain must close (terminal marker present) with no
         // frames — never hang.
@@ -123,8 +130,10 @@ public class HeadlessRunnerOutputStreamTests : IDisposable
         // the exec open until a subscriber has consumed the first batch,
         // then let it finish.
         var run = SeedRun();
-        var firstBatchPublished = new TaskCompletionSource<bool>();
-        var releaseExec = new TaskCompletionSource<bool>();
+        var firstBatchPublished = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseExec = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
 
         _containers
             .Setup(c => c.ExecStreamingAsync(
@@ -141,7 +150,7 @@ public class HeadlessRunnerOutputStreamTests : IDisposable
                     return new ExecResult { ExitCode = 0 };
                 });
 
-        var startTask = _runner.StartAsync(run, "/tmp/x/config.json");
+        var startTask = _runner.StartAsync(run, _configPath);
 
         // Subscribe live and read the first two lines while exec is still
         // running (releaseExec not yet completed → run not terminal).

--- a/tests/Andy.Containers.Api.Tests/Telemetry/AndyTelemetryAdoptionTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Telemetry/AndyTelemetryAdoptionTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using Andy.Containers.Api.Telemetry;
 using FluentAssertions;
@@ -25,24 +26,33 @@ public class AndyTelemetryAdoptionTests
     [Fact]
     public void Provisioning_ActivitySource_IsListenedTo()
     {
-        var captured = new List<Activity>();
+        var operationName = $"ProvisionContainer-{Guid.NewGuid():N}";
+        var captured = new ConcurrentQueue<Activity>();
+        // Materialize the static source before installing the listener.
+        // Referencing ActivitySources.Provisioning from ShouldListenTo while
+        // the ActivitySources type initializer is constructing that same
+        // source recursively observes a null field in standalone test runs.
+        var provisioningSource = ActivitySources.Provisioning;
         using var listener = new ActivityListener
         {
-            ShouldListenTo = source => source.Name == ActivitySources.Provisioning.Name,
+            ShouldListenTo = source => source.Name == provisioningSource.Name,
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
-            ActivityStopped = activity => captured.Add(activity),
+            ActivityStopped = captured.Enqueue,
         };
         ActivitySource.AddActivityListener(listener);
 
-        using (var activity = ActivitySources.Provisioning.StartActivity("ProvisionContainer"))
+        using (var activity = provisioningSource.StartActivity(operationName))
         {
             activity.Should().NotBeNull("an active listener must materialise the activity");
             activity!.SetTag("container.id", "test-container");
         }
 
-        captured.Should().ContainSingle();
-        captured[0].OperationName.Should().Be("ProvisionContainer");
-        captured[0].GetTagItem("container.id").Should().Be("test-container");
+        // Activity listeners are process-global and other parallel tests may
+        // emit on this source. Snapshot the thread-safe queue and select only
+        // the uniquely named activity created above.
+        var matching = captured.Where(a => a.OperationName == operationName).ToArray();
+        matching.Should().ContainSingle();
+        matching[0].GetTagItem("container.id").Should().Be("test-container");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- repair the headless output-stream test fixture and force asynchronous continuations
- preserve explicit custom model endpoints and improve OBO fallback diagnostics
- update launcher coverage for direct container resolution
- remove concurrent DbContext and process-global ActivityListener test races

## Validation
- dotnet test Andy.Containers.sln --no-build --no-restore --disable-build-servers -m:1 /nr:false --blame-hang-timeout 60s
- 2,150 passed, 9 environment-gated tests skipped, 0 failed
- git diff --check

Closes #355