### PR TITLE
Secure container lifecycle and log streams

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -19,13 +19,29 @@ All endpoints require authentication (JWT Bearer token) and RBAC permissions via
 | PUT | `/containers/{id}/resources` | container:execute | Live resize CPU/memory |
 | GET | `/containers/{id}/connection` | container:read | Get IDE/VNC/SSH endpoints |
 | GET | `/containers/{id}/screenshot` | container:read | Get terminal thumbnail |
-| GET | `/containers/{id}/events` | container:read | Get lifecycle events |
+| GET | `/containers/events` | container:read | Fleet lifecycle SSE, filtered server-side to visible containers |
+| GET | `/containers/{id}/logs` | container:read | Agent stdout/stderr SSE with replay, follow, and terminal errors |
 | GET | `/containers/{id}/repositories` | container:read | List cloned git repos |
 | POST | `/containers/{id}/repositories` | container:write | Clone a new repository |
 | POST | `/containers/{id}/repositories/{repoId}/pull` | container:execute | Pull latest changes |
 | GET | `/containers/{id}/git/diff` | container:read | Unified git diff of the run branch vs base |
 | GET | `/containers/{id}/ports` | container:read | List the run container's TCP ports (mapped + discovered) for web preview |
 | POST | `/containers/{id}/ports/expose` | container:execute | Publish a container port to a host (loopback) port for preview |
+
+### Container event streams
+
+`GET /api/containers/events` emits fleet lifecycle transitions as SSE
+`event: lifecycle` frames. Event ids are fleet-wide monotonic sequence
+numbers and reconnects resume with `Last-Event-ID`. The server filters both
+buffered replay and live events through the owner/admin/service-account and
+same-organization read policy; clients never receive another tenant's
+container ids or phase data. Idle streams emit `: heartbeat` every 15 seconds.
+
+`GET /api/containers/{id}/logs` emits the selected run's stdout/stderr as SSE
+`event: log` frames. It supports `follow=0|1`, `tail=0..1000`, `since=<ISO-8601>`,
+and `Last-Event-ID`. Idle following connections emit 15-second heartbeats.
+Failed/cancelled runs and stopped containers finish with an
+`event: terminal-error` frame.
 
 ### `GET /api/containers/{id}/git/diff`
 

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -158,6 +158,7 @@ The lifecycle event stream above only surfaces **terminal** observations — not
 
 ```
 GET /api/runs/{id}/output      (text/event-stream, run:read)
+GET /api/containers/{id}/logs  (text/event-stream, container:read)
 ```
 
 Wire format (SSE), one frame per output line, mirroring the build-progress SSE bus (IM9 / `InMemoryBuildEventBus`):
@@ -171,6 +172,11 @@ data: {"stream":"stdout","line":"Iteration 2/4","timestamp":"2026-..."}
 
 - `id:` is a monotonic per-run sequence number. A reconnecting client sends the last id it saw in the `Last-Event-ID` request header; the server replays buffered lines **after** that id (no duplicates, no gaps). If the requested id has aged out of the bounded ring buffer, the stream restarts from the oldest buffered line and the client reconciles via the run status snapshot.
 - `stream` distinguishes `stdout` from `stderr`.
+- The container-scoped route accepts `follow`, `tail`, and `since`; an idle
+  following connection emits an SSE heartbeat comment every 15 seconds.
+- Container-log authorization is enforced before streaming. Fleet lifecycle
+  replay from `GET /api/containers/events` is independently filtered
+  server-side to containers visible to the principal.
 - The stream **closes** once the run reaches a terminal status and the buffer is drained — same terminal-stop contract as `RunEventStream`. A subscriber attaching after the run is already terminal replays the buffer then closes immediately (never hangs). Unknown run id → `404`.
 - Run-scoped tokens (`ANDY_TOKEN`, see *Run-scoped credentials* below) are **redacted** (`RunOutputRedactor`) before any line reaches the wire — both the literal bearer (known to the runner via the idempotent `ITokenIssuer.MintAsync`) and the defensive `ANDY_TOKEN=<value>` / `export` / JSON env-echo shapes.
 

--- a/src/Andy.Containers.Api/Controllers/ContainersController.cs
+++ b/src/Andy.Containers.Api/Controllers/ContainersController.cs
@@ -129,13 +129,35 @@ public class ContainersController : ControllerBase
     /// Resume via <c>Last-Event-ID</c>; the bus replays buffered events
     /// from after the supplied id. On buffer miss (id too old) replay
     /// restarts from the oldest buffered event.
-    /// RBAC: <c>container:read</c>. The bus delivers ALL containers; the
-    /// client filters to the containers it owns.
+    /// RBAC: <c>container:read</c>. The bus delivers fleet-wide events
+    /// internally; this endpoint filters every replayed and live event through
+    /// the same owner/admin/service/same-organisation read policy used by
+    /// <c>GET /api/containers/{id}</c>.
     /// </remarks>
     [HttpGet("events")]
     [RequirePermission("container:read")]
     public Task Events(CancellationToken ct)
-        => ContainerLifecycleSse.StreamAsync(Response, Request, _lifecycleBus, ct);
+        => ContainerLifecycleSse.StreamAsync(
+            Response,
+            Request,
+            _lifecycleBus,
+            ct,
+            IsLifecycleEventVisibleAsync);
+
+    private async ValueTask<bool> IsLifecycleEventVisibleAsync(
+        ContainerLifecycleEnvelope envelope,
+        CancellationToken ct)
+    {
+        // Fail closed when a row no longer exists. Lifecycle publishers emit
+        // destroyed before removing state, so legitimate terminal events are
+        // still visible; an unknown id must never become an authorization
+        // bypass. AsNoTracking avoids retaining an unbounded fleet in the
+        // request-scoped context during a long-lived SSE connection.
+        var container = await _db.Containers
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == envelope.Event.ContainerId, ct);
+        return container is not null && await CanReadAsync(container, ct);
+    }
 
     /// <summary>
     /// SM.2.6 (rivoli-ai/conductor#2008). Classified GET — returns:
@@ -813,11 +835,47 @@ public class ContainersController : ControllerBase
             Response.Headers.ContentType = "text/event-stream";
             Response.Headers.CacheControl = "no-store";
             Response.Headers["X-Accel-Buffering"] = "no";
+            if (container.Status is ContainerStatus.Stopped
+                or ContainerStatus.Stopping
+                or ContainerStatus.Destroying
+                or ContainerStatus.Destroyed
+                or ContainerStatus.Failed)
+            {
+                await RunOutputSse.WriteTerminalErrorAsync(
+                    Response,
+                    "container-stopped",
+                    $"Container {id} is {container.Status}.",
+                    ct);
+                return;
+            }
             await Response.Body.FlushAsync(ct);
             return;
         }
 
-        await RunOutputSse.StreamAsync(Response, Request, _outputBus, run.Id, ct);
+        await RunOutputSse.StreamAsync(
+            Response,
+            Request,
+            _outputBus,
+            run.Id,
+            ct,
+            honorLogQuery: true);
+
+        if (run.Status is RunStatus.Failed or RunStatus.Timeout)
+        {
+            await RunOutputSse.WriteTerminalErrorAsync(
+                Response,
+                "internal-error",
+                $"Run {run.Id} ended with {run.Status}.",
+                ct);
+        }
+        else if (run.Status == RunStatus.Cancelled)
+        {
+            await RunOutputSse.WriteTerminalErrorAsync(
+                Response,
+                "container-stopped",
+                $"Run {run.Id} was cancelled.",
+                ct);
+        }
     }
 
     /// <summary>

--- a/src/Andy.Containers.Api/Services/ContainerLifecycleSse.cs
+++ b/src/Andy.Containers.Api/Services/ContainerLifecycleSse.cs
@@ -42,7 +42,8 @@ public static class ContainerLifecycleSse
         HttpResponse response,
         HttpRequest request,
         IContainerLifecycleBus bus,
-        CancellationToken ct)
+        CancellationToken ct,
+        Func<ContainerLifecycleEnvelope, CancellationToken, ValueTask<bool>>? isVisible = null)
     {
         response.Headers.ContentType = "text/event-stream";
         response.Headers.CacheControl = "no-store";
@@ -58,7 +59,7 @@ public static class ContainerLifecycleSse
 
         // Merge the event stream with a recurring heartbeat timer.
         using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        var eventTask = PumpEventsAsync(response, bus, lastEventId, ct);
+        var eventTask = PumpEventsAsync(response, bus, lastEventId, isVisible, ct);
         var heartbeatTask = PumpHeartbeatsAsync(response, heartbeatCts.Token);
 
         await Task.WhenAny(eventTask, heartbeatTask);
@@ -72,10 +73,19 @@ public static class ContainerLifecycleSse
         HttpResponse response,
         IContainerLifecycleBus bus,
         long? lastEventId,
+        Func<ContainerLifecycleEnvelope, CancellationToken, ValueTask<bool>>? isVisible,
         CancellationToken ct)
     {
         await foreach (var envelope in bus.SubscribeAsync(lastEventId, ct))
         {
+            // The bus is intentionally fleet-wide. Authorization belongs at
+            // the HTTP boundary so every connection receives only containers
+            // visible to its principal while publishers remain non-blocking
+            // and unaware of request identity.
+            if (isVisible is not null && !await isVisible(envelope, ct))
+            {
+                continue;
+            }
             await WriteEventFrameAsync(response, envelope, ct);
         }
     }

--- a/src/Andy.Containers.Api/Services/RunOutputSse.cs
+++ b/src/Andy.Containers.Api/Services/RunOutputSse.cs
@@ -28,6 +28,8 @@ namespace Andy.Containers.Api.Services;
 /// </remarks>
 public static class RunOutputSse
 {
+    public static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(15);
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -39,7 +41,9 @@ public static class RunOutputSse
         HttpRequest request,
         IRunOutputBus bus,
         Guid runId,
-        CancellationToken ct)
+        CancellationToken ct,
+        TimeSpan? heartbeatInterval = null,
+        bool honorLogQuery = false)
     {
         response.Headers.ContentType = "text/event-stream";
         response.Headers.CacheControl = "no-store";
@@ -55,10 +59,71 @@ public static class RunOutputSse
             lastEventId = parsed;
         }
 
-        await foreach (var envelope in bus.SubscribeAsync(runId, lastEventId, ct))
+        int? tail = null;
+        DateTimeOffset? since = null;
+        var follow = true;
+        if (honorLogQuery)
         {
-            await WriteFrameAsync(response, envelope, ct);
+            tail = 200;
+            if (int.TryParse(request.Query["tail"], out var requestedTail))
+            {
+                tail = Math.Clamp(requestedTail, 0, 1000);
+            }
+            if (DateTimeOffset.TryParse(request.Query["since"], out var requestedSince))
+            {
+                since = requestedSince;
+            }
+            follow = int.TryParse(request.Query["follow"], out var requestedFollow)
+                && requestedFollow == 1;
         }
+
+        var interval = heartbeatInterval ?? HeartbeatInterval;
+        await using var enumerator = bus
+            .SubscribeAsync(runId, lastEventId, ct, tail, since, follow)
+            .GetAsyncEnumerator(ct);
+        var moveNext = enumerator.MoveNextAsync().AsTask();
+
+        try
+        {
+            while (true)
+            {
+                var heartbeat = Task.Delay(interval, ct);
+                if (await Task.WhenAny(moveNext, heartbeat) == heartbeat)
+                {
+                    await response.WriteAsync(": heartbeat\n\n", ct);
+                    await response.Body.FlushAsync(ct);
+                    continue;
+                }
+
+                if (!await moveNext)
+                {
+                    break;
+                }
+
+                await WriteFrameAsync(response, enumerator.Current, ct);
+                moveNext = enumerator.MoveNextAsync().AsTask();
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Client disconnected. The request-aborted token is the normal
+            // lifetime boundary for a following SSE connection.
+        }
+    }
+
+    public static async Task WriteTerminalErrorAsync(
+        HttpResponse response,
+        string code,
+        string message,
+        CancellationToken ct)
+    {
+        var json = JsonSerializer.Serialize(
+            new TerminalErrorWire(code, message),
+            JsonOptions);
+        await response.WriteAsync(
+            $"event: terminal-error\ndata: {json}\n\n",
+            ct);
+        await response.Body.FlushAsync(ct);
     }
 
     private static async Task WriteFrameAsync(
@@ -84,4 +149,6 @@ public static class RunOutputSse
         RunOutputStream Stream,
         string Line,
         DateTimeOffset Timestamp);
+
+    private sealed record TerminalErrorWire(string Code, string Message);
 }

--- a/src/Andy.Containers.Infrastructure/Runs/Events/InMemoryRunOutputBus.cs
+++ b/src/Andy.Containers.Infrastructure/Runs/Events/InMemoryRunOutputBus.cs
@@ -45,10 +45,18 @@ public sealed class InMemoryRunOutputBus : IRunOutputBus, IDisposable
     public async IAsyncEnumerable<RunOutputEnvelope> SubscribeAsync(
         Guid runId,
         long? lastEventId,
-        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct,
+        int? tail = null,
+        DateTimeOffset? since = null,
+        bool follow = true)
     {
         var channel = _channels.GetOrAdd(runId, _ => new RunChannel(_options.BufferSize));
-        var subscription = channel.Subscribe(_options.SubscriberQueueSize, lastEventId);
+        var subscription = channel.Subscribe(
+            _options.SubscriberQueueSize,
+            lastEventId,
+            tail,
+            since,
+            follow);
         try
         {
             await foreach (var envelope in subscription.ReadAllAsync(ct))
@@ -153,7 +161,12 @@ public sealed class InMemoryRunOutputBus : IRunOutputBus, IDisposable
             }
         }
 
-        public Subscription Subscribe(int queueSize, long? lastEventId)
+        public Subscription Subscribe(
+            int queueSize,
+            long? lastEventId,
+            int? tail,
+            DateTimeOffset? since,
+            bool follow)
         {
             // BoundedChannelFullMode.DropOldest matches the buffer's
             // ring-replace semantics — slow subscribers drop history
@@ -171,8 +184,19 @@ public sealed class InMemoryRunOutputBus : IRunOutputBus, IDisposable
             bool terminalAlreadySeen;
             lock (_lock)
             {
-                _subscribers.Add(subscription);
-                replay = [.. _buffer.Where(e => lastEventId is null || e.SequenceNumber > lastEventId.Value)];
+                if (follow)
+                {
+                    _subscribers.Add(subscription);
+                }
+
+                IEnumerable<RunOutputEnvelope> replayQuery = _buffer.Where(e =>
+                    (lastEventId is null || e.SequenceNumber > lastEventId.Value)
+                    && (since is null || e.Line.Timestamp >= since.Value));
+                if (tail is { } tailCount)
+                {
+                    replayQuery = replayQuery.TakeLast(Math.Max(0, tailCount));
+                }
+                replay = [.. replayQuery];
                 terminalAlreadySeen = _terminalSeen;
             }
 
@@ -182,7 +206,7 @@ public sealed class InMemoryRunOutputBus : IRunOutputBus, IDisposable
             {
                 subscription.TryWrite(envelope);
             }
-            if (terminalAlreadySeen)
+            if (terminalAlreadySeen || !follow)
             {
                 subscription.Complete();
             }

--- a/src/Andy.Containers/Storage/IRunOutputBus.cs
+++ b/src/Andy.Containers/Storage/IRunOutputBus.cs
@@ -54,10 +54,19 @@ public interface IRunOutputBus
     /// restarts from the oldest buffered line (and the caller can
     /// reconcile gaps via the run status snapshot).
     /// </param>
+    /// <param name="tail">Optional maximum number of buffered lines to replay.</param>
+    /// <param name="since">Optional lower timestamp bound for buffered replay.</param>
+    /// <param name="follow">
+    /// When true, replay then follow live output. When false, replay the
+    /// requested snapshot and close immediately.
+    /// </param>
     IAsyncEnumerable<RunOutputEnvelope> SubscribeAsync(
         Guid runId,
         long? lastEventId,
-        CancellationToken ct);
+        CancellationToken ct,
+        int? tail = null,
+        DateTimeOffset? since = null,
+        bool follow = true);
 
     /// <summary>
     /// Drop all buffered lines for a run. Called by the runner once a

--- a/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerEventsSseTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerEventsSseTests.cs
@@ -1,0 +1,212 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text;
+using Andy.Containers.Abstractions;
+using Andy.Containers.Api.Controllers;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using Andy.Containers.Storage;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Controllers;
+
+/// <summary>
+/// Security regression coverage for #318. The lifecycle bus is fleet-wide,
+/// but the HTTP stream must filter both replay and live events to containers
+/// visible to the current principal.
+/// </summary>
+public sealed class ContainersControllerEventsSseTests : IDisposable
+{
+    private readonly ContainersDbContext _db = InMemoryDbHelper.CreateContext();
+    private readonly Mock<ICurrentUserService> _currentUser = new();
+    private readonly Mock<IOrganizationMembershipService> _orgMembership = new();
+
+    public ContainersControllerEventsSseTests()
+    {
+        _currentUser.Setup(u => u.GetUserId()).Returns("viewer");
+        _currentUser.Setup(u => u.GetEmail()).Returns((string?)null);
+        _currentUser.Setup(u => u.IsAdmin()).Returns(false);
+        _currentUser.Setup(u => u.IsServiceAccount()).Returns(false);
+        _orgMembership
+            .Setup(o => o.IsMemberAsync(
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task Events_NonAdmin_EmitsOnlyOwnedContainer()
+    {
+        var owned = SeedContainer("viewer");
+        var foreign = SeedContainer("another-user");
+        var controller = CreateController(
+            Envelope(1, foreign, "running"),
+            Envelope(2, owned, "running"));
+        var bodyStream = SetupResponse(controller);
+
+        await controller.Events(CancellationToken.None);
+
+        var body = ReadBody(bodyStream);
+        body.Should().Contain($"\"containerId\":\"{owned.Id}\"");
+        body.Should().NotContain(foreign.Id.ToString());
+        body.Should().Contain("id: 2\n",
+            "global sequence ids remain stable even when an earlier event is filtered");
+    }
+
+    [Fact]
+    public async Task Events_SameOrganizationMember_CanReadLifecycle()
+    {
+        var organizationId = Guid.NewGuid();
+        var container = SeedContainer("another-user", organizationId);
+        _orgMembership
+            .Setup(o => o.IsMemberAsync(
+                "viewer", organizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        var controller = CreateController(Envelope(1, container, "creating"));
+        var bodyStream = SetupResponse(controller);
+
+        await controller.Events(CancellationToken.None);
+
+        ReadBody(bodyStream).Should().Contain(container.Id.ToString());
+    }
+
+    [Fact]
+    public async Task Events_Admin_EmitsAllContainers()
+    {
+        _currentUser.Setup(u => u.IsAdmin()).Returns(true);
+        var first = SeedContainer("first-user");
+        var second = SeedContainer("second-user");
+        var controller = CreateController(
+            Envelope(1, first, "creating"),
+            Envelope(2, second, "running"));
+        var bodyStream = SetupResponse(controller);
+
+        await controller.Events(CancellationToken.None);
+
+        var body = ReadBody(bodyStream);
+        body.Should().Contain(first.Id.ToString());
+        body.Should().Contain(second.Id.ToString());
+    }
+
+    [Fact]
+    public async Task Events_UnknownContainerId_FailsClosed()
+    {
+        var unknown = Guid.NewGuid();
+        var controller = CreateController(new ContainerLifecycleEnvelope(
+            1,
+            new ContainerLifecycleEvent(
+                unknown,
+                "running",
+                new ContainerLifecyclePhaseData(),
+                unknown,
+                DateTimeOffset.UtcNow)));
+        var bodyStream = SetupResponse(controller);
+
+        await controller.Events(CancellationToken.None);
+
+        ReadBody(bodyStream).Should().BeEmpty();
+    }
+
+    private ContainersController CreateController(params ContainerLifecycleEnvelope[] events)
+        => new(
+            Mock.Of<IContainerService>(),
+            _currentUser.Object,
+            _db,
+            Mock.Of<IGitCloneService>(),
+            Mock.Of<IGitCredentialService>(),
+            Mock.Of<IGitRepositoryProbeService>(),
+            _orgMembership.Object,
+            Mock.Of<IGitDiffService>(),
+            Mock.Of<IPortDiscoveryService>(),
+            new FiniteLifecycleBus(events),
+            Mock.Of<IRunOutputBus>());
+
+    private static MemoryStream SetupResponse(ContainersController controller)
+    {
+        var stream = new MemoryStream();
+        var context = new DefaultHttpContext();
+        context.Response.Body = stream;
+        controller.ControllerContext = new ControllerContext { HttpContext = context };
+        return stream;
+    }
+
+    private static string ReadBody(MemoryStream stream)
+    {
+        stream.Position = 0;
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private Container SeedContainer(string ownerId, Guid? organizationId = null)
+    {
+        var template = new ContainerTemplate
+        {
+            Code = $"events-{Guid.NewGuid():N}",
+            Name = "Events test",
+            Version = "1",
+            BaseImage = "ubuntu:24.04",
+        };
+        var provider = new InfrastructureProvider
+        {
+            Code = $"events-{Guid.NewGuid():N}",
+            Name = "Events test",
+            Type = ProviderType.Docker,
+            IsEnabled = true,
+        };
+        var container = new Container
+        {
+            Id = Guid.NewGuid(),
+            Name = $"events-{Guid.NewGuid():N}",
+            OwnerId = ownerId,
+            OrganizationId = organizationId,
+            Status = ContainerStatus.Running,
+            Template = template,
+            Provider = provider,
+        };
+        _db.Containers.Add(container);
+        _db.SaveChanges();
+        return container;
+    }
+
+    private static ContainerLifecycleEnvelope Envelope(
+        long sequence,
+        Container container,
+        string phase)
+        => new(
+            sequence,
+            new ContainerLifecycleEvent(
+                container.Id,
+                phase,
+                new ContainerLifecyclePhaseData(),
+                container.Id,
+                DateTimeOffset.UtcNow));
+
+    private sealed class FiniteLifecycleBus(
+        IReadOnlyList<ContainerLifecycleEnvelope> events) : IContainerLifecycleBus
+    {
+        public void Publish(ContainerLifecycleEvent @event)
+            => throw new NotSupportedException();
+
+        public async IAsyncEnumerable<ContainerLifecycleEnvelope> SubscribeAsync(
+            long? lastEventId,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            foreach (var envelope in events)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (lastEventId is null || envelope.SequenceNumber > lastEventId.Value)
+                {
+                    yield return envelope;
+                }
+            }
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerLogsSseTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerLogsSseTests.cs
@@ -112,6 +112,24 @@ public class ContainersControllerLogsSseTests : IDisposable
     }
 
     [Fact]
+    public async Task Logs_FollowZeroAndTail_ReturnsBoundedSnapshotWithoutTerminalMarker()
+    {
+        var container = CreateContainer();
+        var run = SeedRun(container.Id, RunStatus.Running);
+        _bus.Publish(run.Id, new RunOutputLine(
+            RunOutputStream.Stdout, "old", DateTimeOffset.UtcNow));
+        _bus.Publish(run.Id, new RunOutputLine(
+            RunOutputStream.Stdout, "latest", DateTimeOffset.UtcNow));
+        var responseStream = SetupResponse(queryString: "?follow=0&tail=1");
+
+        await _controller.Logs(container.Id, CancellationToken.None);
+
+        var body = ReadBody(responseStream);
+        body.Should().Contain("\"line\":\"latest\"");
+        body.Should().NotContain("\"line\":\"old\"");
+    }
+
+    [Fact]
     public async Task Logs_NoRunYet_EmptySseStreamNot404()
     {
         var container = CreateContainer();
@@ -124,6 +142,42 @@ public class ContainersControllerLogsSseTests : IDisposable
         _controller.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
         _controller.Response.Headers.ContentType.ToString().Should().Be("text/event-stream");
         ReadBody(responseStream).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Logs_StoppedContainerWithoutRun_EmitsTerminalError()
+    {
+        var container = CreateContainer();
+        container.Status = ContainerStatus.Stopped;
+        var responseStream = SetupResponse();
+
+        await _controller.Logs(container.Id, CancellationToken.None);
+
+        var body = ReadBody(responseStream);
+        body.Should().Contain("event: terminal-error");
+        body.Should().Contain("\"code\":\"container-stopped\"");
+    }
+
+    [Fact]
+    public async Task Logs_FailedRun_ReplaysOutputThenEmitsTerminalError()
+    {
+        var container = CreateContainer();
+        var run = SeedRun(container.Id, RunStatus.Failed);
+        _bus.Publish(
+            run.Id,
+            new RunOutputLine(
+                RunOutputStream.Stderr,
+                "agent failed",
+                DateTimeOffset.UtcNow));
+        _bus.Complete(run.Id);
+        var responseStream = SetupResponse();
+
+        await _controller.Logs(container.Id, CancellationToken.None);
+
+        var body = ReadBody(responseStream);
+        body.Should().Contain("\"line\":\"agent failed\"");
+        body.Should().Contain("event: terminal-error");
+        body.Should().Contain("\"code\":\"internal-error\"");
     }
 
     [Fact]
@@ -153,10 +207,16 @@ public class ContainersControllerLogsSseTests : IDisposable
         _controller.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
     }
 
-    private MemoryStream SetupResponse(string? lastEventId = null)
+    private MemoryStream SetupResponse(
+        string? lastEventId = null,
+        string? queryString = null)
     {
         var responseStream = new MemoryStream();
         var context = new DefaultHttpContext { Response = { Body = responseStream } };
+        if (queryString is not null)
+        {
+            context.Request.QueryString = new QueryString(queryString);
+        }
         if (lastEventId is not null)
         {
             context.Request.Headers["Last-Event-ID"] = lastEventId;

--- a/tests/Andy.Containers.Api.Tests/Services/RunOutputSseHeartbeatTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/RunOutputSseHeartbeatTests.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Infrastructure.Runs.Events;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+public sealed class RunOutputSseHeartbeatTests
+{
+    [Fact]
+    public async Task Stream_IdleFollowingConnection_EmitsHeartbeatComments()
+    {
+        using var bus = new InMemoryRunOutputBus();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(80));
+        var context = new DefaultHttpContext();
+        var responseBody = new MemoryStream();
+        context.Response.Body = responseBody;
+
+        await RunOutputSse.StreamAsync(
+            context.Response,
+            context.Request,
+            bus,
+            Guid.NewGuid(),
+            cts.Token,
+            heartbeatInterval: TimeSpan.FromMilliseconds(10));
+
+        responseBody.Position = 0;
+        var body = Encoding.UTF8.GetString(responseBody.ToArray());
+        body.Should().Contain(": heartbeat\n\n");
+        context.Response.Headers.ContentType.ToString().Should().Be("text/event-stream");
+    }
+}

--- a/tests/Andy.Containers.Tests/Infrastructure/Runs/Events/InMemoryRunOutputBusTests.cs
+++ b/tests/Andy.Containers.Tests/Infrastructure/Runs/Events/InMemoryRunOutputBusTests.cs
@@ -230,6 +230,63 @@ public class InMemoryRunOutputBusTests
         lines.Select(e => e.SequenceNumber).Should().Equal(3, 4);
     }
 
+    [Fact]
+    public async Task Subscribe_TailAndSince_FilterReplay()
+    {
+        using var bus = new InMemoryRunOutputBus();
+        var runId = Guid.NewGuid();
+        var cutoff = DateTimeOffset.UtcNow;
+
+        bus.Publish(runId, new RunOutputLine(
+            RunOutputStream.Stdout,
+            "too-old",
+            cutoff.AddMinutes(-1)));
+        bus.Publish(runId, new RunOutputLine(
+            RunOutputStream.Stdout,
+            "first-current",
+            cutoff));
+        bus.Publish(runId, new RunOutputLine(
+            RunOutputStream.Stdout,
+            "last-current",
+            cutoff.AddSeconds(1)));
+
+        var lines = new List<RunOutputEnvelope>();
+        await foreach (var envelope in bus.SubscribeAsync(
+            runId,
+            lastEventId: null,
+            CancellationToken.None,
+            tail: 1,
+            since: cutoff,
+            follow: false))
+        {
+            lines.Add(envelope);
+        }
+
+        lines.Should().ContainSingle();
+        lines[0].Line.Line.Should().Be("last-current");
+    }
+
+    [Fact]
+    public async Task Subscribe_FollowFalse_ReplaysAndClosesWithoutTerminalMarker()
+    {
+        using var bus = new InMemoryRunOutputBus();
+        var runId = Guid.NewGuid();
+        bus.Publish(runId, Line(RunOutputStream.Stdout, "snapshot"));
+
+        var lines = new List<RunOutputEnvelope>();
+        await foreach (var envelope in bus.SubscribeAsync(
+            runId,
+            lastEventId: null,
+            CancellationToken.None,
+            follow: false))
+        {
+            lines.Add(envelope);
+        }
+
+        lines.Should().ContainSingle();
+        lines[0].Line.Line.Should().Be("snapshot");
+    }
+
     private static async Task<List<RunOutputEnvelope>> ConsumeAsync(
         IRunOutputBus bus, Guid runId, long? lastEventId, int take)
     {


### PR DESCRIPTION
Closes #318

## Summary
- filter fleet lifecycle replay and live SSE events server-side through container RBAC
- add Last-Event-ID-compatible log snapshots with tail/since/follow controls and heartbeats
- emit stable terminal errors for failed/cancelled runs and stopped containers
- document the current agent-output streaming contract and add security/reconnect tests

## Validation
- `dotnet test Andy.Containers.sln --no-build --no-restore --disable-build-servers -m:1 /nr:false --blame-hang-timeout 60s`
- 2,160 passed; 9 environment-gated skipped; 0 failed