### PR TITLE
Publish complete attempt-correlated run lifecycle

### DIFF
--- a/docs/presentation.md
+++ b/docs/presentation.md
@@ -211,20 +211,26 @@ andy.containers.events.run.{runId}.{kind}
 
 **Kinds** (`Messaging/Events/RunEvents.cs`):
 
+- `.queued` / `.provisioning` / `.ready` / `.running` — durable attempt lifecycle
+- `.progress` — durable structured progress
+- `.output` — live stdout/stderr (ephemeral direct publish)
 - `.finished` — graceful stop
 - `.failed` — provisioning or runtime error
 - `.cancelled` — explicit destroy
+- `.timeout` — watchdog timeout
 
 **Payload** (`RunEventPayload`, snake_case):
 
 ```json
-{ "run_id": "…", "story_id": "…|null",
+{ "run_id": "…", "attempt_id": "…", "sequence": 639204260290755790,
+  "occurred_at": "2026-07-23T17:53:49Z", "story_id": "…|null",
   "status": "Finished|Failed|Cancelled",
   "exit_code": 0, "duration_seconds": 125.5,
-  "schema_version": 1 }
+  "schema_version": 5 }
 ```
 
-Published via an **outbox** → `OutboxDispatcher` → NATS. Andy Issues subscribes via its Story 15.6 consumer.
+Lifecycle events publish via an **outbox** → `OutboxDispatcher` → NATS;
+live `.output` events publish directly and share the attempt sequence.
 
 ---
 

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -123,38 +123,62 @@ Either way, exactly one terminal subject lands in the outbox. The 30 s grace is 
 
 ## Event stream
 
-Every terminal observation appends a row to the `OutboxEntries` table in the same EF transaction as the state-machine transition. The `OutboxDispatcher` background service drains pending rows to NATS at-least-once (per ADR 0001). Subjects:
+Every lifecycle observation appends a row to `OutboxEntries` in the same EF
+transaction as its state change. The `OutboxDispatcher` drains rows to NATS
+at-least-once (ADR 0001). Subjects cover the whole attempt:
 
 ```
+andy.containers.events.run.{runId}.queued
+andy.containers.events.run.{runId}.provisioning
+andy.containers.events.run.{runId}.ready
+andy.containers.events.run.{runId}.running
+andy.containers.events.run.{runId}.progress
 andy.containers.events.run.{runId}.finished
 andy.containers.events.run.{runId}.failed
 andy.containers.events.run.{runId}.cancelled
 andy.containers.events.run.{runId}.timeout
 ```
 
+Live stdout/stderr is also published directly (ephemeral, not through the
+transactional outbox) on
+`andy.containers.events.run.{runId}.output`. Its payload uses the same
+`attempt_id` and monotonic `sequence` as the lifecycle and SSE streams; NATS
+durable consumers provide transport replay while the SSE ring provides
+attach-before/after and `Last-Event-ID` replay for HTTP clients.
+
 Payload (`RunEventPayload`):
 
 ```json
 {
   "run_id":           "<uuid>",
+  "attempt_id":       "<uuid>",
+  "sequence":         639204260290755790,
+  "occurred_at":      "2026-07-23T17:53:49Z",
   "story_id":         "<uuid|null>",
   "status":           "Succeeded|Failed|Cancelled|Timeout",
   "exit_code":        12,
-  "duration_seconds": 2.5
+  "duration_seconds": 2.5,
+  "progress":         { "message": "Agent execution started.", "percent": 0 },
+  "output":           { "stream": "stdout", "line": "Iteration 2/4" },
+  "schema_version":   5
 }
 ```
 
 For HTTP / MCP / CLI consumers that want a per-run filtered view of the same stream:
 
-- **HTTP**: `GET /api/runs/{id}/events` returns NDJSON (one `RunEvent` per line, flushed). Closes when the run hits terminal (with a final drain pass).
+- **HTTP**: `GET /api/runs/{id}/events` returns NDJSON (one `RunEvent` per line, flushed). Send `Last-Event-ID: <sequence>` to resume after the last observation. It closes when the run hits terminal (with a final drain pass).
 - **MCP**: `run.events` tool — `IAsyncEnumerable<RunEventDto>`, identical semantics.
 - **CLI**: `andy-containers-cli runs events <id>` colour-codes each line.
 
-The shared implementation lives in `RunEventStream.AsyncEnumerate` so all three surfaces have one polling loop and one terminal-stop policy.
+The shared implementation lives in `RunEventStream.AsyncEnumerate`. Its cursor
+uses the payload sequence, not timestamps, so two events created in one
+transaction cannot hide each other. `attempt_id` identifies a concrete retry;
+`correlation_id` remains the root that groups related attempts.
 
 ### Mid-run output stream (F4.1, rivoli-ai/conductor#1934)
 
-The lifecycle event stream above only surfaces **terminal** observations — nothing arrives until the run is over. For a **live** view of the agent's progress while a headless run is in flight, andy-containers also exposes the agent's stdout/stderr line-by-line as it is produced:
+For a live line-by-line view in addition to the lifecycle/progress stream,
+andy-containers exposes the agent's stdout/stderr as it is produced:
 
 ```
 GET /api/runs/{id}/output      (text/event-stream, run:read)
@@ -166,11 +190,11 @@ Wire format (SSE), one frame per output line, mirroring the build-progress SSE b
 ```
 id: <sequence>
 event: log
-data: {"stream":"stdout","line":"Iteration 2/4","timestamp":"2026-..."}
+data: {"runId":"...","attemptId":"...","sequence":639204260290755800,"stream":"stdout","line":"Iteration 2/4","timestamp":"2026-..."}
 
 ```
 
-- `id:` is a monotonic per-run sequence number. A reconnecting client sends the last id it saw in the `Last-Event-ID` request header; the server replays buffered lines **after** that id (no duplicates, no gaps). If the requested id has aged out of the bounded ring buffer, the stream restarts from the oldest buffered line and the client reconciles via the run status snapshot.
+- `id:` and `data.sequence` are the shared monotonic per-run sequence; `data.attemptId` matches lifecycle NATS/NDJSON events. A reconnecting client sends the last id it saw in `Last-Event-ID`; the server replays buffered lines **after** that id. Sequence gaps are expected when lifecycle events occupy ids. If the requested id has aged out of the bounded ring buffer, replay restarts from the oldest buffered line and the client reconciles via the run snapshot.
 - `stream` distinguishes `stdout` from `stderr`.
 - The container-scoped route accepts `follow`, `tail`, and `since`; an idle
   following connection emits an SSE heartbeat comment every 15 seconds.

--- a/openapi/containers-api.yaml
+++ b/openapi/containers-api.yaml
@@ -554,6 +554,11 @@ paths:
           in: path
           required: true
           schema: { type: string, format: uuid }
+        - name: Last-Event-ID
+          in: header
+          required: false
+          description: Resume after this lifecycle sequence number.
+          schema: { type: integer, format: int64 }
       responses:
         '200':
           description: NDJSON event stream
@@ -570,18 +575,19 @@ paths:
       description: |
         F4.1 (rivoli-ai/conductor#1934). A live feed of the headless
         agent's stdout/stderr while the run is in flight — distinct from
-        `/events`, which only surfaces terminal lifecycle events. Each SSE
+        `/events`, which surfaces the complete lifecycle. Each SSE
         frame is:
 
         ```
         id: <sequence>
         event: log
-        data: {"stream":"stdout","line":"...","timestamp":"2026-..."}
+        data: {"runId":"...","attemptId":"...","sequence":123,"stream":"stdout","line":"...","timestamp":"2026-..."}
         ```
 
         `id:` is a monotonic per-run sequence number; reconnect via the
         `Last-Event-ID` request header to resume after the last line seen
-        (no duplicates, no gaps; restarts from the oldest buffered line if
+        (no duplicate output lines; sequence gaps may represent lifecycle
+        observations; replay restarts from the oldest buffered line if
         the id has aged out of the ring buffer). `stream` distinguishes
         stdout from stderr. The stream closes after the run reaches a
         terminal status and a final drain pass (matching the `/events`
@@ -608,7 +614,7 @@ paths:
                 example: |
                   id: 1
                   event: log
-                  data: {"stream":"stdout","line":"Iteration 1/4","timestamp":"2026-05-31T12:00:00Z"}
+                  data: {"runId":"7c5d3f5e-3b2a-4d2a-9e9f-2c8d1e0f3a4b","attemptId":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","sequence":639204260290755790,"stream":"stdout","line":"Iteration 1/4","timestamp":"2026-05-31T12:00:00Z"}
         '404':
           description: No run with that id
 
@@ -1518,6 +1524,11 @@ components:
             Optional ADR-0001 root causation id. When omitted the controller
             mints one so every run carries a chain anchor.
           nullable: true
+        attemptId:
+          type: string
+          format: uuid
+          description: Concrete retry-attempt identity; defaults to the generated run id.
+          nullable: true
 
     Run:
       type: object
@@ -1525,7 +1536,7 @@ components:
         Wire shape for agent-run responses (AP2). `links.cancel` is null once
         the run is in a terminal state, signalling to clients that the row
         is observation-only.
-      required: [id, agentId, mode, environmentProfileId, workspaceRef, status, correlationId, createdAt, updatedAt, links]
+      required: [id, agentId, mode, environmentProfileId, workspaceRef, status, correlationId, attemptId, createdAt, updatedAt, links]
       properties:
         id: { type: string, format: uuid }
         agentId: { type: string }
@@ -1555,6 +1566,7 @@ components:
           type: string
           nullable: true
         correlationId: { type: string, format: uuid }
+        attemptId: { type: string, format: uuid }
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }
         links: { $ref: '#/components/schemas/RunLinks' }
@@ -1597,18 +1609,19 @@ components:
         One outbox row, surfaced as a single line in the
         `GET /api/runs/{id}/events` NDJSON stream and as a single
         `IAsyncEnumerable<RunEventDto>` element via the matching MCP /
-        CLI consumers. Subject suffix (`.finished` / `.failed` /
-        `.cancelled` / `.timeout`) repeats in the `kind` field for
-        consumers that want the discriminator without parsing.
-      required: [runId, subject, kind, status, timestamp, correlationId]
+        CLI consumers. The subject suffix repeats in `kind`; `sequence`
+        provides an authoritative reconnect cursor across an attempt.
+      required: [runId, attemptId, sequence, subject, kind, status, timestamp, correlationId]
       properties:
         runId: { type: string, format: uuid }
+        attemptId: { type: string, format: uuid }
+        sequence: { type: integer, format: int64 }
         subject:
           type: string
           example: andy.containers.events.run.7c5d3f5e-3b2a-4d2a-9e9f-2c8d1e0f3a4b.finished
         kind:
           type: string
-          enum: [finished, failed, cancelled, timeout]
+          enum: [queued, provisioning, ready, running, progress, output, finished, failed, cancelled, timeout]
         status: { $ref: '#/components/schemas/RunStatus' }
         exitCode:
           type: integer
@@ -1619,6 +1632,20 @@ components:
           nullable: true
         timestamp: { type: string, format: date-time }
         correlationId: { type: string, format: uuid }
+        progress:
+          type: object
+          nullable: true
+          properties:
+            message: { type: string }
+            percent: { type: number, format: double, nullable: true }
+        output:
+          type: object
+          nullable: true
+          properties:
+            stream:
+              type: string
+              enum: [stdout, stderr]
+            line: { type: string }
 
     # --- Environment-profile catalog (Epic X) ---
 

--- a/src/Andy.Containers.Api/Controllers/RunsController.cs
+++ b/src/Andy.Containers.Api/Controllers/RunsController.cs
@@ -77,10 +77,16 @@ public class RunsController : ControllerBase
             return BadRequest(new { error = "workspaceRef.workspaceId must be a non-empty Guid when workspaceRef is provided." });
         }
 
+        if (request.AttemptId == Guid.Empty)
+        {
+            return BadRequest(new { error = "attemptId must be a non-empty Guid when provided." });
+        }
+
         var now = DateTimeOffset.UtcNow;
+        var runId = Guid.NewGuid();
         var run = new Run
         {
-            Id = Guid.NewGuid(),
+            Id = runId,
             AgentId = request.AgentId,
             AgentRevision = request.AgentRevision,
             Mode = request.Mode,
@@ -94,6 +100,7 @@ public class RunsController : ControllerBase
                 },
             PolicyId = request.PolicyId,
             CorrelationId = request.CorrelationId ?? Guid.NewGuid(),
+            AttemptId = request.AttemptId ?? runId,
             // Transient (NotMapped): consumed by the configurator at create-time
             // to bake the task into the headless agent's system prompt.
             Objective = request.Objective,
@@ -108,6 +115,7 @@ public class RunsController : ControllerBase
         };
 
         _db.Runs.Add(run);
+        _db.AppendAgentRunEvent(run, RunEventKind.Queued);
         await _db.SaveChangesAsync(ct);
 
         // AP3 (rivoli-ai/andy-containers#105). Build + write the andy-cli
@@ -275,7 +283,18 @@ public class RunsController : ControllerBase
         Response.Headers.Append("Cache-Control", "no-cache");
         Response.Headers.Append("X-Accel-Buffering", "no");
 
-        await foreach (var evt in RunEventStream.AsyncEnumerate(_db, id, ct: ct))
+        long? afterSequence = null;
+        if (Request.Headers.TryGetValue("Last-Event-ID", out var lastEventId)
+            && long.TryParse(lastEventId.FirstOrDefault(), out var parsed))
+        {
+            afterSequence = parsed;
+        }
+
+        await foreach (var evt in RunEventStream.AsyncEnumerate(
+            _db,
+            id,
+            ct: ct,
+            afterSequence: afterSequence))
         {
             var json = JsonSerializer.Serialize(evt, EventJson.Options);
             await Response.WriteAsync(json, ct);
@@ -287,9 +306,10 @@ public class RunsController : ControllerBase
     /// <summary>
     /// F4.1 (rivoli-ai/conductor#1934). Server-Sent Events stream of the
     /// run's MID-RUN agent output. Each <c>event: log</c> frame carries a
-    /// <c>{stream, line, timestamp}</c> JSON payload; the <c>id:</c> line
-    /// is the per-run sequence number so a reconnecting client resumes via
-    /// <c>Last-Event-ID</c> with no duplicates and no gaps. The stream
+    /// <c>{runId, attemptId, sequence, stream, line, timestamp}</c> JSON
+    /// payload; the <c>id:</c> line is the shared per-run sequence so a
+    /// reconnecting client resumes via <c>Last-Event-ID</c> without duplicate
+    /// output. Lifecycle observations may occupy sequence gaps. The stream
     /// closes after the run reaches a terminal status and the buffer is
     /// drained (matching <see cref="RunEventStream"/> semantics). Run-scoped
     /// tokens are redacted upstream by the runner before publish.

--- a/src/Andy.Containers.Api/Mcp/RunsMcpTools.cs
+++ b/src/Andy.Containers.Api/Mcp/RunsMcpTools.cs
@@ -80,6 +80,7 @@ public class RunsMcpTools
         [Description("Optional branch name.")] string? branch = null,
         [Description("Optional policy id (GUID).")] string? policyId = null,
         [Description("Optional ADR-0001 root causation id (GUID); minted if omitted.")] string? correlationId = null,
+        [Description("Optional concrete attempt id (GUID); defaults to the generated run id.")] string? attemptId = null,
         CancellationToken ct = default)
     {
         if (!await EnsurePermission(Permissions.RunWrite, ct)) return null;
@@ -121,10 +122,18 @@ public class RunsMcpTools
             parsedCorrelationId = cid;
         }
 
+        Guid? parsedAttemptId = null;
+        if (!string.IsNullOrWhiteSpace(attemptId))
+        {
+            if (!Guid.TryParse(attemptId, out var aid) || aid == Guid.Empty) return null;
+            parsedAttemptId = aid;
+        }
+
         var now = DateTimeOffset.UtcNow;
+        var runId = Guid.NewGuid();
         var run = new Run
         {
-            Id = Guid.NewGuid(),
+            Id = runId,
             AgentId = agentId,
             AgentRevision = agentRevision,
             Mode = parsedMode,
@@ -132,12 +141,14 @@ public class RunsMcpTools
             WorkspaceRef = workspaceRef,
             PolicyId = parsedPolicyId,
             CorrelationId = parsedCorrelationId ?? Guid.NewGuid(),
+            AttemptId = parsedAttemptId ?? runId,
             Status = RunStatus.Pending,
             CreatedAt = now,
             UpdatedAt = now,
         };
 
         _db.Runs.Add(run);
+        _db.AppendAgentRunEvent(run, RunEventKind.Queued);
         await _db.SaveChangesAsync(ct);
 
         // Same handoff sequence as RunsController.Create: configurator
@@ -222,12 +233,13 @@ public class RunsMcpTools
     }
 
     [McpServerTool(Name = "run.events"), Description(
-        "Stream lifecycle events for a run on andy.containers.events.run.{id}.* — finished, failed, cancelled, timeout. " +
+        "Stream the complete attempt-correlated lifecycle for a run on andy.containers.events.run.{id}.*. " +
         "Yields any backfill (events that already landed in the outbox) then live events as they commit. " +
-        "Stops when the run reaches a terminal state or the caller cancels. Requires run:read.")]
+        "Optionally resumes after a monotonic sequence. Stops at terminal or cancellation. Requires run:read.")]
     public async IAsyncEnumerable<RunEventDto> Events(
         [Description("Run id (GUID).")] string runId,
-        [EnumeratorCancellation] CancellationToken ct = default)
+        [EnumeratorCancellation] CancellationToken ct = default,
+        [Description("Optional last sequence already observed; only newer events are yielded.")] long? afterSequence = null)
     {
         if (!await EnsurePermission(Permissions.RunRead, ct)) yield break;
         if (!Guid.TryParse(runId, out var id)) yield break;
@@ -235,7 +247,12 @@ public class RunsMcpTools
         // AP9 (rivoli-ai/andy-containers#111). Shared outbox-poll loop —
         // identical semantics to the HTTP NDJSON endpoint and the CLI
         // events command.
-        await foreach (var evt in RunEventStream.AsyncEnumerate(_db, id, EventsPollInterval, ct))
+        await foreach (var evt in RunEventStream.AsyncEnumerate(
+            _db,
+            id,
+            EventsPollInterval,
+            ct,
+            afterSequence))
         {
             yield return evt;
         }
@@ -269,4 +286,3 @@ public class RunsMcpTools
         _db.AppendAgentRunEvent(run, RunEventKind.Cancelled);
     }
 }
-

--- a/src/Andy.Containers.Api/Services/HeadlessRunner.cs
+++ b/src/Andy.Containers.Api/Services/HeadlessRunner.cs
@@ -5,6 +5,7 @@ using Andy.Containers.Abstractions;
 using Andy.Containers.Configurator;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Infrastructure.Messaging;
+using Andy.Containers.Messaging;
 using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
 using Andy.Containers.Storage;
@@ -36,6 +37,7 @@ public sealed class HeadlessRunner : IHeadlessRunner
     // stderr line is published (token-redacted) as it lands, and the
     // run's output stream is marked terminal on every exit path.
     private readonly IRunOutputBus? _outputBus;
+    private readonly IMessageBus? _messageBus;
 
     // #2231. Optional per-run model-scoped proxy-token mint. The container's
     // create-time OPENAI_API_KEY is scoped only to the container-default
@@ -97,7 +99,8 @@ public sealed class HeadlessRunner : IHeadlessRunner
         IProxyTokenService? proxyTokenService = null,
         Microsoft.Extensions.Configuration.IConfiguration? configuration = null,
         IGitCredentialMaterializer? gitCredentialMaterializer = null,
-        IContainerToolProvisioner? toolProvisioner = null)
+        IContainerToolProvisioner? toolProvisioner = null,
+        IMessageBus? messageBus = null)
     {
         _containers = containers;
         _db = db;
@@ -107,6 +110,7 @@ public sealed class HeadlessRunner : IHeadlessRunner
         _artifactCollector = artifactCollector;
         _inputStager = inputStager;
         _outputBus = outputBus;
+        _messageBus = messageBus;
         _proxyTokenService = proxyTokenService;
         _configuration = configuration;
         _gitCredentialMaterializer = gitCredentialMaterializer;
@@ -143,8 +147,20 @@ public sealed class HeadlessRunner : IHeadlessRunner
         // is a no-op if the run isn't actually in Provisioning (e.g. a test
         // hands us a Pending run directly), which keeps the runner usable
         // standalone without forcing every caller through the dispatcher.
-        SafeTransition(run, RunStatus.Provisioning);
-        SafeTransition(run, RunStatus.Running);
+        if (SafeTransition(run, RunStatus.Provisioning)
+            && run.AttemptId != Guid.Empty)
+        {
+            _db.AppendAgentRunEvent(run, RunEventKind.Provisioning);
+        }
+        if (SafeTransition(run, RunStatus.Running)
+            && run.AttemptId != Guid.Empty)
+        {
+            _db.AppendAgentRunEvent(run, RunEventKind.Running);
+            _db.AppendAgentRunEvent(
+                run,
+                RunEventKind.Progress,
+                progress: new RunProgress("Agent execution started.", 0));
+        }
         await _db.SaveChangesAsync(ct);
 
         // AP7 (rivoli-ai/andy-containers#109). Register so the cancel
@@ -361,7 +377,7 @@ public sealed class HeadlessRunner : IHeadlessRunner
                 // redacted, tagged with its stream kind.
                 result = await _containers.ExecStreamingAsync(
                     containerId, command, execTimeout,
-                    chunk => PublishOutputLine(run.Id, chunk, knownToken),
+                    chunk => PublishOutputLine(run, chunk, knownToken),
                     execToken);
             }
             else
@@ -682,22 +698,24 @@ public sealed class HeadlessRunner : IHeadlessRunner
         };
     }
 
-    private void SafeTransition(Run run, RunStatus next)
+    private bool SafeTransition(Run run, RunStatus next)
     {
         if (!RunStatusTransitions.CanTransition(run.Status, next))
         {
-            return;
+            return false;
         }
 
         try
         {
             run.TransitionTo(next);
+            return true;
         }
         catch (InvalidOperationException ex)
         {
             _logger.LogWarning(ex,
                 "Run {RunId} could not transition {From} → {To}: {Message}",
                 run.Id, run.Status, next, ex.Message);
+            return false;
         }
     }
 
@@ -885,7 +903,7 @@ public sealed class HeadlessRunner : IHeadlessRunner
     // F4.1 (#1934). Publish one streamed exec line to the run-output bus,
     // redacted. Never throws — a publish failure must not interrupt the
     // exec drain loop.
-    private void PublishOutputLine(Guid runId, ExecOutputChunk chunk, string? knownToken)
+    private void PublishOutputLine(Run run, ExecOutputChunk chunk, string? knownToken)
     {
         try
         {
@@ -893,13 +911,59 @@ public sealed class HeadlessRunner : IHeadlessRunner
             var stream = chunk.Stream == ExecStreamKind.Stderr
                 ? RunOutputStream.Stderr
                 : RunOutputStream.Stdout;
-            _outputBus!.Publish(runId, new RunOutputLine(stream, redacted, DateTimeOffset.UtcNow));
+            var timestamp = DateTimeOffset.UtcNow;
+            var envelope = _outputBus!.Publish(
+                run.Id,
+                new RunOutputLine(stream, redacted, timestamp),
+                run.AttemptId == Guid.Empty ? null : run.AttemptId);
+
+            if (_messageBus is not null && run.AttemptId != Guid.Empty)
+            {
+                _ = PublishOutputEventAsync(run, envelope, stream, redacted, timestamp);
+            }
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex,
                 "F4.1: failed to publish run-output line for Run {RunId}: {Message}",
-                runId, ex.Message);
+                run.Id, ex.Message);
+        }
+    }
+
+    private async Task PublishOutputEventAsync(
+        Run run,
+        RunOutputEnvelope envelope,
+        RunOutputStream stream,
+        string line,
+        DateTimeOffset occurredAt)
+    {
+        try
+        {
+            var payload = new RunEventPayload(
+                RunId: run.Id,
+                StoryId: null,
+                Status: run.Status.ToString(),
+                ExitCode: null,
+                DurationSeconds: null,
+                AttemptId: envelope.AttemptId,
+                Sequence: envelope.SequenceNumber,
+                OccurredAt: occurredAt,
+                Output: new RunEventOutput(stream.ToString().ToLowerInvariant(), line));
+            var headers = MessageHeaders.NewRoot(
+                run.CorrelationId == Guid.Empty ? run.Id : run.CorrelationId);
+            await _messageBus!.PublishAsync(
+                $"andy.containers.events.run.{run.Id}.output",
+                payload,
+                headers,
+                CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to publish ephemeral output event for Run {RunId}: {Message}",
+                run.Id,
+                ex.Message);
         }
     }
 

--- a/src/Andy.Containers.Api/Services/RunEventStream.cs
+++ b/src/Andy.Containers.Api/Services/RunEventStream.cs
@@ -33,43 +33,41 @@ public static class RunEventStream
         ContainersDbContext db,
         Guid runId,
         TimeSpan? pollInterval = null,
-        [EnumeratorCancellation] CancellationToken ct = default)
+        [EnumeratorCancellation] CancellationToken ct = default,
+        long? afterSequence = null)
     {
         ArgumentNullException.ThrowIfNull(db);
 
         var interval = pollInterval ?? DefaultPollInterval;
         var subjectPrefix = $"andy.containers.events.run.{runId}.";
-        DateTimeOffset? cursor = null;
+        var cursor = afterSequence;
         var sawTerminal = false;
 
         while (!ct.IsCancellationRequested)
         {
-            // Fetch any new outbox rows for this run, ordered by creation.
-            // SQLite's EF provider can't translate DateTimeOffset operations:
-            // NEITHER the cursor comparison (`CreatedAt > x`) NOR ORDER BY.
-            // The subject-prefix filter IS translatable (→ LIKE), so scope
-            // server-side by prefix, then apply the cursor + ordering + batch
-            // bound CLIENT-side. A single run's outbox event count is small,
-            // so the client-eval is bounded. (Doing the cursor `Where` in the
-            // query throws "could not be translated" once cursor is set, which
-            // silently dropped every post-cursor event — including the
-            // terminal Succeeded/Failed — so the run never completed upstream.)
+            // SQLite cannot order DateTimeOffset reliably, and timestamps are
+            // not unique when several lifecycle rows share one transaction.
+            // Scope by translatable subject prefix, then parse/filter/order by
+            // the authoritative payload sequence on the client. One run's
+            // lifecycle history is small, so this remains bounded.
             var rows = await db.OutboxEntries
                 .AsNoTracking()
                 .Where(e => e.Subject.StartsWith(subjectPrefix))
                 .ToListAsync(ct);
 
             var batch = rows
-                .Where(e => cursor is null || e.CreatedAt > cursor.Value)
-                .OrderBy(e => e.CreatedAt)
+                .Select(e => (Entry: e, Event: RunEventDto.FromOutbox(e)))
+                .Where(x => x.Event is not null
+                    && (cursor is null || x.Event.Sequence > cursor.Value))
+                .OrderBy(x => x.Event!.Sequence)
+                .ThenBy(x => x.Entry.CreatedAt)
                 .Take(BatchSize)
                 .ToList();
 
-            foreach (var entry in batch)
+            foreach (var item in batch)
             {
-                var dto = RunEventDto.FromOutbox(entry);
-                if (dto is null) continue;
-                cursor = entry.CreatedAt;
+                var dto = item.Event!;
+                cursor = dto.Sequence;
                 yield return dto;
             }
 

--- a/src/Andy.Containers.Api/Services/RunModeDispatcher.cs
+++ b/src/Andy.Containers.Api/Services/RunModeDispatcher.cs
@@ -74,6 +74,7 @@ public sealed class RunModeDispatcher : IRunModeDispatcher
         try
         {
             run.TransitionTo(RunStatus.Provisioning);
+            _db.AppendAgentRunEvent(run, RunEventKind.Provisioning);
         }
         catch (InvalidOperationException ex)
         {
@@ -104,6 +105,12 @@ public sealed class RunModeDispatcher : IRunModeDispatcher
                 "Run {RunId}: per-run branch preparation failed for container {ContainerId}; continuing dispatch.",
                 run.Id, containerId);
         }
+
+        // The container and run branch are now prepared. Ready is a distinct
+        // observation from Running: consumers can show that dispatch finished
+        // even while the detached launcher has not started the agent process.
+        _db.AppendAgentRunEvent(run, RunEventKind.Ready);
+        await _db.SaveChangesAsync(ct);
 
         return run.Mode switch
         {

--- a/src/Andy.Containers.Api/Services/RunOutputSse.cs
+++ b/src/Andy.Containers.Api/Services/RunOutputSse.cs
@@ -130,6 +130,9 @@ public static class RunOutputSse
         HttpResponse response, RunOutputEnvelope envelope, CancellationToken ct)
     {
         var payload = new RunOutputWire(
+            envelope.RunId,
+            envelope.AttemptId,
+            envelope.SequenceNumber,
             envelope.Line.Stream,
             envelope.Line.Line,
             envelope.Line.Timestamp);
@@ -144,8 +147,11 @@ public static class RunOutputSse
     }
 
     // Wire shape consumed by Conductor's LogEventPayload decoder:
-    // { stream: "stdout"|"stderr", line: string, timestamp: ISO-8601 }.
+    // { runId, attemptId, sequence, stream, line, timestamp }.
     private sealed record RunOutputWire(
+        Guid RunId,
+        Guid AttemptId,
+        long Sequence,
         RunOutputStream Stream,
         string Line,
         DateTimeOffset Timestamp);

--- a/src/Andy.Containers.Cli/Commands/RunCommands.cs
+++ b/src/Andy.Containers.Cli/Commands/RunCommands.cs
@@ -151,6 +151,9 @@ public static class RunCommands
             {
                 var color = evt.Kind switch
                 {
+                    "queued" or "provisioning" => "cyan",
+                    "ready" => "blue",
+                    "running" or "progress" or "output" => "deepskyblue1",
                     "finished" => "green",
                     "failed" => "red",
                     "cancelled" => "yellow",
@@ -161,7 +164,7 @@ public static class RunCommands
                 var exit = evt.ExitCode is { } ec ? $" exit={ec}" : "";
                 var dur = evt.DurationSeconds is { } d ? $" dur={d:F1}s" : "";
                 AnsiConsole.MarkupLine(
-                    $"[dim]{ts}[/] [{color}]{evt.Kind}[/] status={Markup.Escape(evt.Status)}{exit}{dur}");
+                    $"[dim]{ts} #{evt.Sequence}[/] [{color}]{evt.Kind}[/] status={Markup.Escape(evt.Status)}{exit}{dur}");
             }
 
             AnsiConsole.MarkupLine("[dim]Stream closed (run reached terminal state).[/]");

--- a/src/Andy.Containers.Client/ContainersClient.cs
+++ b/src/Andy.Containers.Client/ContainersClient.cs
@@ -290,11 +290,29 @@ public sealed class ContainersClient
         string id,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
+        await foreach (var evt in StreamRunEventsAsync(id, null, ct))
+        {
+            yield return evt;
+        }
+    }
+
+    /// <summary>
+    /// Resume a run lifecycle stream after an already-observed sequence.
+    /// </summary>
+    public async IAsyncEnumerable<RunEventDto> StreamRunEventsAsync(
+        string id,
+        long? afterSequence,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
         // HttpCompletionOption.ResponseHeadersRead unblocks Send before
         // the body arrives so we can iterate as bytes land — without it
         // HttpClient buffers the whole response and the streaming UX
         // collapses to one batch at terminal.
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/runs/{id}/events");
+        if (afterSequence is { } cursor)
+        {
+            request.Headers.TryAddWithoutValidation("Last-Event-ID", cursor.ToString());
+        }
         using var response = await _http.SendAsync(
             request, HttpCompletionOption.ResponseHeadersRead, ct);
         await EnsureSuccessAsync(response, ct);

--- a/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
+++ b/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
@@ -355,6 +355,7 @@ public class ContainersDbContext : DbContext, IDataProtectionKeyContext
             e.Property(r => r.Status).HasConversion<string>().HasMaxLength(16);
             e.HasIndex(r => r.Status);
             e.HasIndex(r => r.CorrelationId);
+            e.HasIndex(r => new { r.CorrelationId, r.AttemptId });
             e.HasIndex(r => r.AgentId);
             // WorkspaceRef as an owned value object — inlined columns prefixed
             // `WorkspaceRef_*` (EF default). Keeps Run self-contained without

--- a/src/Andy.Containers.Infrastructure/Messaging/RunEventOutbox.cs
+++ b/src/Andy.Containers.Infrastructure/Messaging/RunEventOutbox.cs
@@ -35,13 +35,17 @@ public static class RunEventOutbox
         double? durationSeconds = null,
         IReadOnlyList<RunOutputArtifact>? outputArtifacts = null)
     {
+        var occurredAt = DateTimeOffset.UtcNow;
         var payload = new RunEventPayload(
             RunId: container.Id,
             StoryId: container.StoryId,
             Status: container.Status.ToString(),
             ExitCode: exitCode,
             DurationSeconds: durationSeconds,
-            OutputArtifacts: outputArtifacts);
+            OutputArtifacts: outputArtifacts,
+            AttemptId: container.Id,
+            Sequence: RunEventSequence.Next(container.Id),
+            OccurredAt: occurredAt);
 
         var subject = $"andy.containers.events.run.{container.Id}.{kind.ToSubjectKind()}";
 
@@ -56,7 +60,7 @@ public static class RunEventOutbox
             CorrelationId = correlationId,
             CausationId = null,
             Generation = 0,
-            CreatedAt = DateTimeOffset.UtcNow
+            CreatedAt = occurredAt
         });
     }
 
@@ -111,7 +115,9 @@ public static class RunEventOutbox
         RunEventKind kind,
         int? exitCode = null,
         double? durationSeconds = null,
-        IReadOnlyList<RunOutputArtifact>? outputArtifacts = null)
+        IReadOnlyList<RunOutputArtifact>? outputArtifacts = null,
+        RunProgress? progress = null,
+        RunEventOutput? output = null)
     {
         // Persist onto the Run row first so the payload and the entity
         // agree byte-for-byte (the payload reads `run.OutputArtifacts`
@@ -127,6 +133,9 @@ public static class RunEventOutbox
         // code + stderr tail) instead of a synthesised "ended with Failed."
         // Run.Error is set by the runner before this append on every
         // non-success terminal path; null for a clean success.
+        var occurredAt = DateTimeOffset.UtcNow;
+        var sequence = RunEventSequence.Next(run.Id);
+        var attemptId = run.AttemptId == Guid.Empty ? run.Id : run.AttemptId;
         var payload = new RunEventPayload(
             RunId: run.Id,
             StoryId: null,
@@ -134,7 +143,12 @@ public static class RunEventOutbox
             ExitCode: exitCode,
             DurationSeconds: durationSeconds,
             OutputArtifacts: outputArtifacts,
-            Error: run.Error);
+            Error: run.Error,
+            AttemptId: attemptId,
+            Sequence: sequence,
+            OccurredAt: occurredAt,
+            Progress: progress,
+            Output: output);
 
         var subject = $"andy.containers.events.run.{run.Id}.{kind.ToSubjectKind()}";
 
@@ -149,7 +163,7 @@ public static class RunEventOutbox
             CorrelationId = correlationId,
             CausationId = null,
             Generation = 0,
-            CreatedAt = DateTimeOffset.UtcNow
+            CreatedAt = occurredAt
         });
     }
 }

--- a/src/Andy.Containers.Infrastructure/Migrations/20260723180000_AddRunAttemptCorrelation.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260723180000_AddRunAttemptCorrelation.cs
@@ -1,0 +1,38 @@
+using Andy.Containers.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Containers.Infrastructure.Migrations;
+
+[DbContext(typeof(ContainersDbContext))]
+[Migration("20260723180000_AddRunAttemptCorrelation")]
+public partial class AddRunAttemptCorrelation : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<Guid>(
+            name: "AttemptId",
+            table: "Runs",
+            type: "uuid",
+            nullable: false,
+            defaultValue: Guid.Empty);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Runs_CorrelationId_AttemptId",
+            table: "Runs",
+            columns: new[] { "CorrelationId", "AttemptId" });
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_Runs_CorrelationId_AttemptId",
+            table: "Runs");
+
+        migrationBuilder.DropColumn(
+            name: "AttemptId",
+            table: "Runs");
+    }
+}

--- a/src/Andy.Containers.Infrastructure/Migrations/ContainersDbContextModelSnapshot.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/ContainersDbContextModelSnapshot.cs
@@ -999,6 +999,9 @@ namespace Andy.Containers.Infrastructure.Migrations
                     b.Property<int?>("AgentRevision")
                         .HasColumnType("integer");
 
+                    b.Property<Guid>("AttemptId")
+                        .HasColumnType("uuid");
+
                     b.Property<Guid?>("ContainerId")
                         .HasColumnType("uuid");
 
@@ -1051,6 +1054,8 @@ namespace Andy.Containers.Infrastructure.Migrations
                     b.HasIndex("AgentId");
 
                     b.HasIndex("CorrelationId");
+
+                    b.HasIndex("CorrelationId", "AttemptId");
 
                     b.HasIndex("Status");
 

--- a/src/Andy.Containers.Infrastructure/Runs/Events/InMemoryRunOutputBus.cs
+++ b/src/Andy.Containers.Infrastructure/Runs/Events/InMemoryRunOutputBus.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Threading.Channels;
+using Andy.Containers.Messaging.Events;
 using Andy.Containers.Storage;
 
 namespace Andy.Containers.Infrastructure.Runs.Events;
@@ -29,16 +30,19 @@ public sealed class InMemoryRunOutputBus : IRunOutputBus, IDisposable
         _options = options ?? new RunOutputBusOptions();
     }
 
-    public void Publish(Guid runId, RunOutputLine line)
+    public RunOutputEnvelope Publish(
+        Guid runId,
+        RunOutputLine line,
+        Guid? attemptId = null)
     {
         ArgumentNullException.ThrowIfNull(line);
-        var channel = _channels.GetOrAdd(runId, _ => new RunChannel(_options.BufferSize));
-        channel.Publish(line);
+        var channel = _channels.GetOrAdd(runId, _ => new RunChannel(runId, _options.BufferSize));
+        return channel.Publish(line, attemptId);
     }
 
     public void Complete(Guid runId)
     {
-        var channel = _channels.GetOrAdd(runId, _ => new RunChannel(_options.BufferSize));
+        var channel = _channels.GetOrAdd(runId, _ => new RunChannel(runId, _options.BufferSize));
         channel.MarkTerminal();
     }
 
@@ -50,7 +54,7 @@ public sealed class InMemoryRunOutputBus : IRunOutputBus, IDisposable
         DateTimeOffset? since = null,
         bool follow = true)
     {
-        var channel = _channels.GetOrAdd(runId, _ => new RunChannel(_options.BufferSize));
+        var channel = _channels.GetOrAdd(runId, _ => new RunChannel(runId, _options.BufferSize));
         var subscription = channel.Subscribe(
             _options.SubscriberQueueSize,
             lastEventId,
@@ -96,19 +100,21 @@ public sealed class InMemoryRunOutputBus : IRunOutputBus, IDisposable
     private sealed class RunChannel : IDisposable
     {
         private readonly object _lock = new();
+        private readonly Guid _runId;
         private readonly int _bufferSize;
         private readonly Queue<RunOutputEnvelope> _buffer;
         private readonly List<Subscription> _subscribers = [];
-        private long _nextSequence = 1;
+        private long _nextLegacySequence = 1;
         private bool _terminalSeen;
 
-        public RunChannel(int bufferSize)
+        public RunChannel(Guid runId, int bufferSize)
         {
+            _runId = runId;
             _bufferSize = bufferSize;
             _buffer = new Queue<RunOutputEnvelope>(bufferSize);
         }
 
-        public void Publish(RunOutputLine line)
+        public RunOutputEnvelope Publish(RunOutputLine line, Guid? attemptId)
         {
             RunOutputEnvelope envelope;
             List<Subscription> snapshot;
@@ -120,10 +126,22 @@ public sealed class InMemoryRunOutputBus : IRunOutputBus, IDisposable
                 // BuildCompletedEvent.
                 if (_terminalSeen)
                 {
-                    return;
+                    return new RunOutputEnvelope(
+                        attemptId is null
+                            ? _nextLegacySequence++
+                            : RunEventSequence.Next(_runId),
+                        _runId,
+                        attemptId ?? _runId,
+                        line);
                 }
 
-                envelope = new RunOutputEnvelope(_nextSequence++, line);
+                envelope = new RunOutputEnvelope(
+                    attemptId is null
+                        ? _nextLegacySequence++
+                        : RunEventSequence.Next(_runId),
+                    _runId,
+                    attemptId ?? _runId,
+                    line);
                 if (_buffer.Count >= _bufferSize)
                 {
                     _buffer.Dequeue();
@@ -136,6 +154,7 @@ public sealed class InMemoryRunOutputBus : IRunOutputBus, IDisposable
             {
                 sub.TryWrite(envelope);
             }
+            return envelope;
         }
 
         public void MarkTerminal()

--- a/src/Andy.Containers/Messaging/Events/RunEventSequence.cs
+++ b/src/Andy.Containers/Messaging/Events/RunEventSequence.cs
@@ -1,0 +1,27 @@
+using System.Collections.Concurrent;
+
+namespace Andy.Containers.Messaging.Events;
+
+/// <summary>
+/// Allocates a monotonic sequence shared by lifecycle and output events for
+/// one run. The wall-clock floor keeps a restarted process ahead of sequences
+/// emitted before restart; the atomic update orders concurrent publishers.
+/// </summary>
+public static class RunEventSequence
+{
+    private static readonly ConcurrentDictionary<Guid, long> LastByRun = new();
+
+    public static long Next(Guid runId)
+    {
+        if (runId == Guid.Empty)
+        {
+            throw new ArgumentException("Run id must be non-empty.", nameof(runId));
+        }
+
+        var clockFloor = DateTimeOffset.UtcNow.UtcTicks;
+        return LastByRun.AddOrUpdate(
+            runId,
+            clockFloor,
+            (_, current) => Math.Max(clockFloor, checked(current + 1)));
+    }
+}

--- a/src/Andy.Containers/Messaging/Events/RunEvents.cs
+++ b/src/Andy.Containers/Messaging/Events/RunEvents.cs
@@ -37,6 +37,10 @@ namespace Andy.Containers.Messaging.Events;
 // Nullable + omitted-when-null so pre-v4 consumers deserialise unchanged;
 // consumers that opt in surface it as the task-failure reason instead of
 // the synthesised placeholder.
+//
+// v5 (#380) adds AttemptId, Sequence, OccurredAt, Progress, and Output.
+// Agent lifecycle rows use the transactional outbox; live output uses the
+// same payload on the `.output` subject and the same sequence on SSE frames.
 public sealed record RunEventPayload(
     Guid RunId,
     Guid? StoryId,
@@ -44,13 +48,16 @@ public sealed record RunEventPayload(
     int? ExitCode,
     double? DurationSeconds,
     IReadOnlyList<RunOutputArtifact>? OutputArtifacts = null,
-    string? Error = null)
+    string? Error = null,
+    Guid? AttemptId = null,
+    long? Sequence = null,
+    DateTimeOffset? OccurredAt = null,
+    RunProgress? Progress = null,
+    RunEventOutput? Output = null)
 {
-    // Bumped to 4 when Error landed on the payload (conductor#2204).
-    // Pre-v4 consumers ignore Error cleanly (tolerant-read); v4+ consumers
-    // can gate on schema_version >= 4 to know the actionable reason is
-    // present on a non-success terminal event.
-    public const int SchemaVersion = 4;
+    // v5 adds attempt-correlated monotonic lifecycle/output metadata.
+    // Nullable additions preserve tolerant reads of legacy v1-v4 events.
+    public const int SchemaVersion = 5;
 
     public int Schema_Version => SchemaVersion;
 }
@@ -62,6 +69,12 @@ public sealed record RunEventPayload(
 // already has a Timeout member) don't lose the watchdog signal.
 public enum RunEventKind
 {
+    Queued,
+    Provisioning,
+    Ready,
+    Running,
+    Progress,
+    Output,
     Finished,
     Failed,
     Cancelled,
@@ -72,6 +85,12 @@ public static class RunEventKindExtensions
 {
     public static string ToSubjectKind(this RunEventKind kind) => kind switch
     {
+        RunEventKind.Queued => "queued",
+        RunEventKind.Provisioning => "provisioning",
+        RunEventKind.Ready => "ready",
+        RunEventKind.Running => "running",
+        RunEventKind.Progress => "progress",
+        RunEventKind.Output => "output",
         RunEventKind.Finished => "finished",
         RunEventKind.Failed => "failed",
         RunEventKind.Cancelled => "cancelled",
@@ -79,3 +98,11 @@ public static class RunEventKindExtensions
         _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
     };
 }
+
+public sealed record RunProgress(
+    string Message,
+    double? Percent = null);
+
+public sealed record RunEventOutput(
+    string Stream,
+    string Line);

--- a/src/Andy.Containers/Models/Run.cs
+++ b/src/Andy.Containers/Models/Run.cs
@@ -49,6 +49,12 @@ public class Run
     /// <summary>Root causation id per ADR-0001 header semantics.</summary>
     public Guid CorrelationId { get; set; }
 
+    /// <summary>
+    /// Identity of this concrete execution attempt. Defaults to the run id
+    /// when the caller does not provide one.
+    /// </summary>
+    public Guid AttemptId { get; set; }
+
     public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
 
     public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;

--- a/src/Andy.Containers/Models/RunDtos.cs
+++ b/src/Andy.Containers/Models/RunDtos.cs
@@ -32,6 +32,12 @@ public class CreateRunRequest
     public Guid? CorrelationId { get; set; }
 
     /// <summary>
+    /// Optional identity for this concrete attempt. Defaults to the generated
+    /// run id when omitted.
+    /// </summary>
+    public Guid? AttemptId { get; set; }
+
+    /// <summary>
     /// The concrete task objective (the andy-tasks TaskNode's
     /// delegation-contract objective). The configurator bakes it into the
     /// headless agent's system prompt so the in-container agent acts on the
@@ -91,6 +97,7 @@ public class RunDto
     public int? ExitCode { get; set; }
     public string? Error { get; set; }
     public Guid CorrelationId { get; set; }
+    public Guid AttemptId { get; set; }
     public DateTimeOffset CreatedAt { get; set; }
     public DateTimeOffset UpdatedAt { get; set; }
     public RunLinks Links { get; set; } = new();
@@ -118,6 +125,7 @@ public class RunDto
             ExitCode = run.ExitCode,
             Error = run.Error,
             CorrelationId = run.CorrelationId,
+            AttemptId = run.AttemptId == Guid.Empty ? run.Id : run.AttemptId,
             CreatedAt = run.CreatedAt,
             UpdatedAt = run.UpdatedAt,
             Links = new RunLinks

--- a/src/Andy.Containers/Models/RunEventDto.cs
+++ b/src/Andy.Containers/Models/RunEventDto.cs
@@ -15,8 +15,12 @@ namespace Andy.Containers.Models;
 public sealed record RunEventDto
 {
     public required Guid RunId { get; init; }
+    // Non-required CLR members preserve tolerant deserialization of v1-v4
+    // NDJSON. New v5 producers always populate both.
+    public Guid AttemptId { get; init; }
+    public long Sequence { get; init; }
     public required string Subject { get; init; }
-    /// <summary>One of <c>finished</c>, <c>failed</c>, <c>cancelled</c>, <c>timeout</c>.</summary>
+    /// <summary>Lifecycle kind encoded by the final NATS subject token.</summary>
     public required string Kind { get; init; }
     /// <summary>Mirrors the run's status at emission (e.g. <c>Cancelled</c>, <c>Succeeded</c>).</summary>
     public required string Status { get; init; }
@@ -24,6 +28,8 @@ public sealed record RunEventDto
     public double? DurationSeconds { get; init; }
     public required DateTimeOffset Timestamp { get; init; }
     public required Guid CorrelationId { get; init; }
+    public RunProgress? Progress { get; init; }
+    public RunEventOutput? Output { get; init; }
 
     /// <summary>
     /// Parse an <see cref="OutboxEntry"/> into a <see cref="RunEventDto"/>.
@@ -54,13 +60,17 @@ public sealed record RunEventDto
         return new RunEventDto
         {
             RunId = payload.RunId,
+            AttemptId = payload.AttemptId ?? payload.RunId,
+            Sequence = payload.Sequence ?? entry.CreatedAt.UtcTicks,
             Subject = entry.Subject,
             Kind = kind,
             Status = payload.Status,
             ExitCode = payload.ExitCode,
             DurationSeconds = payload.DurationSeconds,
-            Timestamp = entry.CreatedAt,
+            Timestamp = payload.OccurredAt ?? entry.CreatedAt,
             CorrelationId = entry.CorrelationId,
+            Progress = payload.Progress,
+            Output = payload.Output,
         };
     }
 }

--- a/src/Andy.Containers/Storage/IRunOutputBus.cs
+++ b/src/Andy.Containers/Storage/IRunOutputBus.cs
@@ -32,7 +32,10 @@ public interface IRunOutputBus
     /// subscribers don't backpressure the runner; bounded queues drop
     /// old lines when a subscriber falls behind.
     /// </summary>
-    void Publish(Guid runId, RunOutputLine line);
+    RunOutputEnvelope Publish(
+        Guid runId,
+        RunOutputLine line,
+        Guid? attemptId = null);
 
     /// <summary>
     /// Mark a run's output stream terminal. Subscribers drain any
@@ -99,4 +102,6 @@ public sealed record RunOutputLine(
 /// </summary>
 public sealed record RunOutputEnvelope(
     long SequenceNumber,
+    Guid RunId,
+    Guid AttemptId,
     RunOutputLine Line);

--- a/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/RunsControllerTests.cs
@@ -10,6 +10,7 @@ using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -98,6 +99,34 @@ public class RunsControllerTests : IDisposable
         persisted.Should().NotBeNull();
         persisted!.Status.Should().Be(RunStatus.Pending);
         persisted.AgentRevision.Should().Be(3);
+        persisted.AttemptId.Should().Be(dto.Id);
+
+        var queued = await _db.OutboxEntries.SingleAsync();
+        queued.Subject.Should().Be(
+            $"andy.containers.events.run.{dto.Id}.queued");
+        RunEventDto.FromOutbox(queued)!.AttemptId.Should().Be(dto.Id);
+    }
+
+    [Fact]
+    public async Task Create_CallerAttemptId_IsPersistedAndPublished()
+    {
+        var attemptId = Guid.NewGuid();
+        var result = await _controller.Create(
+            new CreateRunRequest
+            {
+                AgentId = "retry-agent",
+                Mode = RunMode.Headless,
+                EnvironmentProfileId = Guid.NewGuid(),
+                AttemptId = attemptId,
+            },
+            CancellationToken.None);
+
+        var dto = result.Should().BeOfType<CreatedAtActionResult>()
+            .Subject.Value.Should().BeOfType<RunDto>().Subject;
+        dto.AttemptId.Should().Be(attemptId);
+
+        var queued = await _db.OutboxEntries.SingleAsync();
+        RunEventDto.FromOutbox(queued)!.AttemptId.Should().Be(attemptId);
     }
 
     [Fact]
@@ -476,6 +505,43 @@ public class RunsControllerTests : IDisposable
         evt!.RunId.Should().Be(run.Id);
         evt.Kind.Should().Be("finished");
         evt.ExitCode.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Events_LastEventId_ReplaysOnlyNewerSequences()
+    {
+        var run = SeedRun(RunStatus.Succeeded);
+        _db.AppendAgentRunEvent(run, RunEventKind.Queued);
+        _db.AppendAgentRunEvent(run, RunEventKind.Running);
+        _db.AppendAgentRunEvent(run, RunEventKind.Finished);
+        await _db.SaveChangesAsync();
+        var ordered = (await _db.OutboxEntries.ToListAsync())
+            .Select(RunEventDto.FromOutbox)
+            .Where(e => e is not null)
+            .Cast<RunEventDto>()
+            .OrderBy(e => e.Sequence)
+            .ToList();
+
+        var responseStream = new MemoryStream();
+        var context = new Microsoft.AspNetCore.Http.DefaultHttpContext();
+        context.Request.Headers["Last-Event-ID"] = ordered[0].Sequence.ToString();
+        context.Response.Body = responseStream;
+        _controller.ControllerContext = new Microsoft.AspNetCore.Mvc.ControllerContext
+        {
+            HttpContext = context,
+        };
+
+        await _controller.Events(run.Id, CancellationToken.None);
+
+        responseStream.Position = 0;
+        var body = await new StreamReader(responseStream).ReadToEndAsync();
+        var events = body
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => System.Text.Json.JsonSerializer.Deserialize<RunEventDto>(
+                line,
+                EventJson.Options)!)
+            .ToList();
+        events.Select(e => e.Kind).Should().Equal("running", "finished");
     }
 
     private Run SeedRun(RunStatus status)

--- a/tests/Andy.Containers.Api.Tests/Messaging/RunEventOutboxTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Messaging/RunEventOutboxTests.cs
@@ -77,6 +77,12 @@ public class RunEventOutboxTests
     }
 
     [Theory]
+    [InlineData(RunEventKind.Queued, "queued")]
+    [InlineData(RunEventKind.Provisioning, "provisioning")]
+    [InlineData(RunEventKind.Ready, "ready")]
+    [InlineData(RunEventKind.Running, "running")]
+    [InlineData(RunEventKind.Progress, "progress")]
+    [InlineData(RunEventKind.Output, "output")]
     [InlineData(RunEventKind.Finished, "finished")]
     [InlineData(RunEventKind.Failed, "failed")]
     [InlineData(RunEventKind.Cancelled, "cancelled")]
@@ -132,6 +138,46 @@ public class RunEventOutboxTests
         root.GetProperty("status").GetString().Should().Be("Succeeded");
         root.GetProperty("exit_code").GetInt32().Should().Be(0);
         root.GetProperty("duration_seconds").GetDouble().Should().Be(12.3);
+    }
+
+    [Fact]
+    public async Task AppendAgentRunEvent_CarriesAttemptAndStrictlyIncreasingSequence()
+    {
+        using var db = InMemoryDbHelper.CreateContext();
+        var run = new Run
+        {
+            Id = Guid.NewGuid(),
+            AttemptId = Guid.NewGuid(),
+            AgentId = "activity-agent",
+            Mode = RunMode.Headless,
+            EnvironmentProfileId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid(),
+            Status = RunStatus.Provisioning,
+        };
+        db.Runs.Add(run);
+
+        db.AppendAgentRunEvent(run, RunEventKind.Queued);
+        db.AppendAgentRunEvent(run, RunEventKind.Provisioning);
+        db.AppendAgentRunEvent(
+            run,
+            RunEventKind.Progress,
+            progress: new RunProgress("Preparing agent.", 0.25));
+        await db.SaveChangesAsync();
+
+        var events = (await db.OutboxEntries
+                .Where(e => e.Subject.StartsWith($"andy.containers.events.run.{run.Id}."))
+                .ToListAsync())
+            .Select(RunEventDto.FromOutbox)
+            .Where(e => e is not null)
+            .Cast<RunEventDto>()
+            .OrderBy(e => e.Sequence)
+            .ToList();
+
+        events.Should().HaveCount(3);
+        events.Select(e => e.AttemptId).Should().OnlyContain(id => id == run.AttemptId);
+        events.Select(e => e.Sequence).Should().BeInAscendingOrder();
+        events.Select(e => e.Sequence).Should().OnlyHaveUniqueItems();
+        events[^1].Progress.Should().Be(new RunProgress("Preparing agent.", 0.25));
     }
 
     [Fact]
@@ -196,8 +242,8 @@ public class RunEventOutboxTests
         using var doc = JsonDocument.Parse(entry.PayloadJson);
         var root = doc.RootElement;
         root.GetProperty("schema_version").GetInt32().Should().Be(RunEventPayload.SchemaVersion);
-        root.GetProperty("schema_version").GetInt32().Should().Be(4,
-            "the Error field on RunEventPayload bumped the wire shape to v4 (conductor#2204)");
+        root.GetProperty("schema_version").GetInt32().Should().Be(5,
+            "attempt correlation and monotonic sequence metadata use the v5 wire shape");
 
         var arr = root.GetProperty("output_artifacts");
         arr.GetArrayLength().Should().Be(2);
@@ -455,7 +501,7 @@ public class RunEventOutboxTests
 
         // Schema version reflects the latest bump (v4 added the Error
         // field per conductor#2204; DocsRef still rides on the artifact).
-        doc.RootElement.GetProperty("schema_version").GetInt32().Should().Be(4);
+        doc.RootElement.GetProperty("schema_version").GetInt32().Should().Be(5);
 
         // Persisted Run row also carries the DocsRef (through the
         // EF JSON converter on Run.OutputArtifacts).

--- a/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerOutputStreamTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerOutputStreamTests.cs
@@ -4,6 +4,8 @@ using Andy.Containers.Api.Tests.Helpers;
 using Andy.Containers.Configurator;
 using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Infrastructure.Runs.Events;
+using Andy.Containers.Messaging;
+using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
 using Andy.Containers.Storage;
 using FluentAssertions;
@@ -28,6 +30,7 @@ public class HeadlessRunnerOutputStreamTests : IDisposable
     private readonly RunCancellationRegistry _cancellation = new();
     private readonly Mock<ITokenIssuer> _tokens = new();
     private readonly InMemoryRunOutputBus _bus = new();
+    private readonly Mock<IMessageBus> _messageBus = new();
     private readonly HeadlessRunner _runner;
     private readonly string _configPath;
 
@@ -46,11 +49,18 @@ public class HeadlessRunnerOutputStreamTests : IDisposable
         _tokens
             .Setup(t => t.MintAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new RunToken("sk-run-secret-0123456789abcdef", DateTimeOffset.UtcNow.AddHours(1)));
+        _messageBus
+            .Setup(b => b.PublishAsync(
+                It.IsAny<string>(),
+                It.IsAny<object>(),
+                It.IsAny<MessageHeaders>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
         _runner = new HeadlessRunner(
             _containers.Object, _db, _cancellation, _tokens.Object,
             NullLogger<HeadlessRunner>.Instance, artifactCollector: null,
-            inputStager: null, outputBus: _bus);
+            inputStager: null, outputBus: _bus, messageBus: _messageBus.Object);
     }
 
     public void Dispose()
@@ -86,6 +96,36 @@ public class HeadlessRunnerOutputStreamTests : IDisposable
             "Iteration 1/4", "Iteration 2/4", "transient retry", "done");
         lines[2].Line.Stream.Should().Be(RunOutputStream.Stderr,
             "stderr lines stay distinguishable from stdout on the bus.");
+    }
+
+    [Fact]
+    public async Task StartAsync_AttemptOutput_PublishesCorrelatedNatsOutputSubjects()
+    {
+        var run = SeedRun();
+        run.AttemptId = Guid.NewGuid();
+        await _db.SaveChangesAsync();
+        SetupStreamingExec(run.ContainerId!.Value, exitCode: 0, lines:
+        [
+            (ExecStreamKind.Stdout, "working"),
+            (ExecStreamKind.Stderr, "retrying"),
+        ]);
+        var published = new List<RunEventPayload>();
+        _messageBus
+            .Setup(b => b.PublishAsync(
+                $"andy.containers.events.run.{run.Id}.output",
+                It.IsAny<object>(),
+                It.IsAny<MessageHeaders>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, object, MessageHeaders, CancellationToken>(
+                (_, payload, _, _) => published.Add((RunEventPayload)payload))
+            .Returns(Task.CompletedTask);
+
+        await _runner.StartAsync(run, _configPath);
+
+        published.Should().HaveCount(2);
+        published.Select(p => p.AttemptId).Should().OnlyContain(id => id == run.AttemptId);
+        published.Select(p => p.Sequence).Should().BeInAscendingOrder();
+        published.Select(p => p.Output!.Line).Should().Equal("working", "retrying");
     }
 
     [Fact]

--- a/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
@@ -87,6 +87,32 @@ public class HeadlessRunnerTests : IDisposable
         doc.RootElement.GetProperty("exit_code").GetInt32().Should().Be(0);
     }
 
+    [Fact]
+    public async Task StartAsync_AttemptCorrelatedRun_EmitsRunningProgressAndTerminalInOrder()
+    {
+        var run = SeedRun();
+        run.AttemptId = Guid.NewGuid();
+        await _db.SaveChangesAsync();
+        SetupExec(run.ContainerId!.Value, exitCode: 0, stdOut: "ok");
+
+        await _runner.StartAsync(run, _configPath);
+
+        var events = (await _db.OutboxEntries.ToListAsync())
+            .Select(RunEventDto.FromOutbox)
+            .Where(e => e is not null)
+            .Cast<RunEventDto>()
+            .OrderBy(e => e.Sequence)
+            .ToList();
+
+        events.Select(e => e.Kind)
+            .Should().Equal("provisioning", "running", "progress", "finished");
+        events.Select(e => e.AttemptId)
+            .Should().OnlyContain(id => id == run.AttemptId);
+        events.Select(e => e.Sequence).Should().BeInAscendingOrder();
+        events.Single(e => e.Kind == "progress").Progress
+            .Should().Be(new RunProgress("Agent execution started.", 0));
+    }
+
     [Theory]
     [InlineData(1, RunEventKind.Failed, RunStatus.Failed, "failed")]
     [InlineData(2, RunEventKind.Failed, RunStatus.Failed, "failed")]

--- a/tests/Andy.Containers.Api.Tests/Services/RunEventStreamTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/RunEventStreamTests.cs
@@ -114,6 +114,36 @@ public class RunEventStreamTests : IDisposable
     }
 
     [Fact]
+    public async Task AfterSequence_ReplaysOnlyNewerLifecycleEvents()
+    {
+        var run = SeedRun(RunStatus.Succeeded);
+        _db.AppendAgentRunEvent(run, RunEventKind.Queued);
+        _db.AppendAgentRunEvent(run, RunEventKind.Running);
+        _db.AppendAgentRunEvent(run, RunEventKind.Finished);
+        await _db.SaveChangesAsync();
+
+        var all = (await _db.OutboxEntries.ToListAsync())
+            .Select(RunEventDto.FromOutbox)
+            .Where(e => e is not null)
+            .Cast<RunEventDto>()
+            .OrderBy(e => e.Sequence)
+            .ToList();
+
+        var collected = new List<RunEventDto>();
+        await foreach (var evt in RunEventStream.AsyncEnumerate(
+            _db,
+            run.Id,
+            FastPoll,
+            afterSequence: all[0].Sequence))
+        {
+            collected.Add(evt);
+        }
+
+        collected.Select(e => e.Kind).Should().Equal("running", "finished");
+        collected.Select(e => e.Sequence).Should().BeInAscendingOrder();
+    }
+
+    [Fact]
     public async Task UnknownRun_TerminatesImmediately()
     {
         // Run row not in DB → helper exits cleanly without yielding.

--- a/tests/Andy.Containers.Api.Tests/Services/RunModeDispatcherTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/RunModeDispatcherTests.cs
@@ -4,6 +4,7 @@ using Andy.Containers.Infrastructure.Data;
 using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -81,6 +82,15 @@ public class RunModeDispatcherTests : IDisposable
         // container assignment.
         run.Status.Should().Be(RunStatus.Provisioning);
         _launcher.Verify(l => l.Launch(run.Id, ConfigPath), Times.Once);
+
+        var activity = (await _db.OutboxEntries.ToListAsync())
+            .Select(RunEventDto.FromOutbox)
+            .Where(e => e is not null)
+            .Cast<RunEventDto>()
+            .OrderBy(e => e.Sequence)
+            .ToList();
+        activity.Select(e => e.Kind).Should().Equal("provisioning", "ready");
+        activity.Select(e => e.Sequence).Should().BeInAscendingOrder();
     }
 
     [Fact]

--- a/tests/Andy.Containers.Client.Tests/ContainersClientTests.cs
+++ b/tests/Andy.Containers.Client.Tests/ContainersClientTests.cs
@@ -134,6 +134,25 @@ public class ContainersClientTests
     }
 
     [Fact]
+    public async Task StreamRunEventsAsync_AfterSequence_SendsLastEventId()
+    {
+        var handler = new CannedHandler("", "application/x-ndjson");
+        var http = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://example.local/"),
+        };
+        var client = new ContainersClient(http);
+
+        await foreach (var _ in client.StreamRunEventsAsync(
+            Guid.NewGuid().ToString(),
+            12345))
+        {
+        }
+
+        handler.LastEventId.Should().Be("12345");
+    }
+
+    [Fact]
     public async Task StreamRunEventsAsync_404Response_ThrowsContainersApiException()
     {
         var http = new HttpClient(new CannedHandler("not found", "text/plain", HttpStatusCode.NotFound))
@@ -211,6 +230,7 @@ public class ContainersClientTests
 
         public Uri? LastRequestUri { get; private set; }
         public HttpMethod? LastMethod { get; private set; }
+        public string? LastEventId { get; private set; }
 
         public CannedHandler(string body, string contentType, HttpStatusCode status = HttpStatusCode.OK)
         {
@@ -223,6 +243,9 @@ public class ContainersClientTests
         {
             LastRequestUri = request.RequestUri;
             LastMethod = request.Method;
+            LastEventId = request.Headers.TryGetValues("Last-Event-ID", out var values)
+                ? values.Single()
+                : null;
             var content = new ByteArrayContent(_body);
             content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(_contentType);
             return Task.FromResult(new HttpResponseMessage(_status) { Content = content });

--- a/tests/Andy.Containers.Tests/Infrastructure/Runs/Events/InMemoryRunOutputBusTests.cs
+++ b/tests/Andy.Containers.Tests/Infrastructure/Runs/Events/InMemoryRunOutputBusTests.cs
@@ -303,6 +303,34 @@ public class InMemoryRunOutputBusTests
         return lines;
     }
 
+    [Fact]
+    public async Task AttemptCorrelatedOutput_UsesSharedMonotonicSequenceAndReconnectCursor()
+    {
+        using var bus = new InMemoryRunOutputBus();
+        var runId = Guid.NewGuid();
+        var attemptId = Guid.NewGuid();
+
+        var first = bus.Publish(runId, Line(RunOutputStream.Stdout, "one"), attemptId);
+        var second = bus.Publish(runId, Line(RunOutputStream.Stdout, "two"), attemptId);
+        bus.Complete(runId);
+
+        second.SequenceNumber.Should().BeGreaterThan(first.SequenceNumber);
+        second.AttemptId.Should().Be(attemptId);
+        second.RunId.Should().Be(runId);
+
+        var replay = new List<RunOutputEnvelope>();
+        await foreach (var envelope in bus.SubscribeAsync(
+            runId,
+            first.SequenceNumber,
+            CancellationToken.None))
+        {
+            replay.Add(envelope);
+        }
+
+        replay.Should().ContainSingle()
+            .Which.Line.Line.Should().Be("two");
+    }
+
     private static RunOutputLine Line(RunOutputStream stream, string text)
         => new(stream, text, DateTimeOffset.UtcNow);
 }


### PR DESCRIPTION
Closes #380

## Summary
- persist an attempt ID and publish queued, provisioning, ready, running, progress, and terminal lifecycle subjects
- add schema-v5 attempt, monotonic sequence, occurrence time, progress, and output fields while retaining tolerant v1-v4 reads
- publish live output on the run-scoped `.output` NATS subject and carry the same identity in SSE frames
- resume NDJSON and SSE streams from `Last-Event-ID`; order lifecycle replay by sequence rather than non-unique timestamps
- update REST, MCP, client, CLI, OpenAPI, migration, and operational docs

## Validation
- full solution: 2,173 passed; 9 environment-gated skipped; 0 failed
- updated client reconnect test: 32 passed; 0 failed
- empty SQLite database applied `20260723180000_AddRunAttemptCorrelation` successfully
- OpenAPI YAML parsed and `git diff --check` passed