### PR TITLE
Register real commit-derived deliverable artifacts

### DIFF
--- a/docs/runs.md
+++ b/docs/runs.md
@@ -103,6 +103,37 @@ The run's changes are then retrievable as a unified patch via
 (`git diff <base>` of the run branch + working tree), aggregated across repos or
 scoped to one via `repoId`.
 
+### Commit-derived deliverable artifacts
+
+After a successful headless run, each cloned repository with staged changes is
+checkpointed on `andy/run/{runId}`. The same guarded shell transaction then
+writes a bundle under:
+
+```
+/workspace/.andy/outputs/deliverables/{runId}/{repositoryId}/
+  checkpoint.patch
+  changed-files.tsv
+  manifest.json
+```
+
+`checkpoint.patch` is a binary-capable `git show` of the exact checkpoint
+commit; `changed-files.tsv` records Git status plus every changed source, test,
+documentation, and asset path; `manifest.json` binds the bundle to the run,
+repository, branch, and commit SHA. Deleted files remain represented by the
+patch and manifest. A no-change run does not fabricate a bundle.
+During collection, older run-scoped bundles are excluded so a later no-change
+task cannot inherit stale deliverables merely because they remain on the
+shared container filesystem.
+
+The normal recursive output collector discovers these files alongside
+`run-summary.md`, hashes them, assigns MIME types (`text/x-diff`,
+`text/tab-separated-values`, `application/json`), uploads their bytes to
+andy-docs, and writes their typed `DocsRef`s into `Run.OutputArtifacts` and the
+terminal event. The document link targets the concrete run id—not the hosting
+container id—so downstream `output_doc_refs` and `prior_context.artifact_refs`
+refer to the correct attempt. `.andy/inputs`, pre-existing `.andy/outputs`, and
+untracked backup-shaped files remain excluded from the Git commit itself.
+
 ## Cancellation
 
 ```

--- a/src/Andy.Containers.Api/Services/FilesystemOutputArtifactCollector.cs
+++ b/src/Andy.Containers.Api/Services/FilesystemOutputArtifactCollector.cs
@@ -152,6 +152,27 @@ public sealed class FilesystemOutputArtifactCollector : IOutputArtifactCollector
     public async Task<IReadOnlyList<RunOutputArtifact>> CollectAsync(
         Container container,
         CancellationToken ct = default)
+        => await CollectCoreAsync(
+            container,
+            docsTargetId: container.Id,
+            deliverableRunId: null,
+            ct);
+
+    public async Task<IReadOnlyList<RunOutputArtifact>> CollectRunAsync(
+        Container container,
+        Guid runId,
+        CancellationToken ct = default)
+        => await CollectCoreAsync(
+            container,
+            docsTargetId: runId,
+            deliverableRunId: runId,
+            ct);
+
+    private async Task<IReadOnlyList<RunOutputArtifact>> CollectCoreAsync(
+        Container container,
+        Guid docsTargetId,
+        Guid? deliverableRunId,
+        CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(container);
 
@@ -171,8 +192,17 @@ public sealed class FilesystemOutputArtifactCollector : IOutputArtifactCollector
             // permission-denied / vanished-file noise that would
             // otherwise show up on stderr without changing the
             // semantically-empty success case.
+            // Run collection includes generic/agent-declared outputs plus
+            // only this attempt's commit-derived bundle. Older bundles stay
+            // on disk for filesystem continuity but must not be re-registered
+            // as outputs of a later task.
+            var find = deliverableRunId is { } runId
+                ? "find " + OutputsRoot + " -type f " +
+                    "\\( ! -path '" + OutputsRoot + "/deliverables/*' -o " +
+                    "-path '" + OutputsRoot + "/deliverables/" + runId + "/*' \\)"
+                : "find " + OutputsRoot + " -type f";
             var script = $"if [ -d {OutputsRoot} ]; then " +
-                "find " + OutputsRoot + " -type f -print0 2>/dev/null | " +
+                find + " -print0 2>/dev/null | " +
                 "xargs -0 -I{} sh -c 'sz=$(stat -c %s \"{}\" 2>/dev/null); " +
                 "h=$(sha256sum \"{}\" 2>/dev/null | awk \"{print \\$1}\"); " +
                 "[ -n \"$sz\" ] && [ -n \"$h\" ] && printf \"%s\\t%s\\t%s\\n\" \"$sz\" \"$h\" \"{}\"'; " +
@@ -204,7 +234,11 @@ public sealed class FilesystemOutputArtifactCollector : IOutputArtifactCollector
                 return parsed;
             }
 
-            return await UploadAndAttachDocsRefsAsync(container, parsed, ct);
+            return await UploadAndAttachDocsRefsAsync(
+                container,
+                docsTargetId,
+                parsed,
+                ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -227,6 +261,7 @@ public sealed class FilesystemOutputArtifactCollector : IOutputArtifactCollector
     // or upload error just leaves that one artifact metadata-only.
     private async Task<IReadOnlyList<RunOutputArtifact>> UploadAndAttachDocsRefsAsync(
         Container container,
+        Guid docsTargetId,
         IReadOnlyList<RunOutputArtifact> parsed,
         CancellationToken ct)
     {
@@ -256,7 +291,7 @@ public sealed class FilesystemOutputArtifactCollector : IOutputArtifactCollector
                             {
                                 new DocumentLinkDescriptor(
                                     TargetType: "Run",
-                                    TargetId: container.Id.ToString(),
+                                    TargetId: docsTargetId.ToString(),
                                     Role: "Output"),
                             });
                         docsRef = await _andyDocs!.UploadAsync(request, ct);
@@ -445,6 +480,7 @@ public sealed class FilesystemOutputArtifactCollector : IOutputArtifactCollector
         return ext switch
         {
             ".txt" or ".log" => "text/plain",
+            ".patch" or ".diff" => "text/x-diff",
             ".md" => "text/markdown",
             ".json" => "application/json",
             ".yaml" or ".yml" => "application/yaml",

--- a/src/Andy.Containers.Api/Services/HeadlessRunner.cs
+++ b/src/Andy.Containers.Api/Services/HeadlessRunner.cs
@@ -86,6 +86,7 @@ public sealed class HeadlessRunner : IHeadlessRunner
     private const string NoChangesMarker = "__ANDY_NO_CHANGES_TO_COMMIT__";
     private const string ExcludedArtifactsMarker = "__ANDY_CHECKPOINT_EXCLUDED__=";
     private const string ExcludedRuntimeArtifactsMarker = "__ANDY_CHECKPOINT_RUNTIME_ARTIFACTS_EXCLUDED__";
+    private const string DeliverablesRegisteredMarker = "__ANDY_DELIVERABLES_REGISTERED__=";
 
     public HeadlessRunner(
         IContainerService containers,
@@ -610,7 +611,10 @@ public sealed class HeadlessRunner : IHeadlessRunner
                 var container = await _db.Containers.FindAsync(new object[] { containerId }, ct);
                 if (container is not null)
                 {
-                    artifacts = await _artifactCollector.CollectAsync(container, ct);
+                    artifacts = await _artifactCollector.CollectRunAsync(
+                        container,
+                        run.Id,
+                        ct);
                 }
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -1120,7 +1124,10 @@ public sealed class HeadlessRunner : IHeadlessRunner
         {
             try
             {
-                var command = BuildCheckpointCommand(run, repo);
+                var command = BuildCheckpointCommand(
+                    run,
+                    repo,
+                    FilesystemOutputArtifactCollector.OutputsRoot);
 
                 var result = await _containers.ExecAsync(containerId, command, CommitTimeout, ct);
 
@@ -1158,9 +1165,18 @@ public sealed class HeadlessRunner : IHeadlessRunner
                 }
                 else
                 {
+                    var deliverableDiagnostic = result.StdOut?
+                        .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                        .FirstOrDefault(line => line.StartsWith(
+                            DeliverablesRegisteredMarker,
+                            StringComparison.Ordinal));
                     _logger.LogInformation(
-                        "Run {RunId}: committed task work to per-run branch in repo {RepoPath} (container {ContainerId}).",
-                        run.Id, repo.TargetPath, containerId);
+                        "Run {RunId}: committed task work to per-run branch in repo {RepoPath} (container {ContainerId}); deliverable bundle {DeliverablePath}.",
+                        run.Id,
+                        repo.TargetPath,
+                        containerId,
+                        deliverableDiagnostic?[DeliverablesRegisteredMarker.Length..]
+                            ?? "was not reported");
                 }
             }
             catch (Exception ex)
@@ -1180,7 +1196,10 @@ public sealed class HeadlessRunner : IHeadlessRunner
     /// in the working tree. Tracked files with the same names are ordinary
     /// repository content and are never deleted or implicitly excluded.
     /// </summary>
-    internal static string BuildCheckpointCommand(Run run, ContainerGitRepository repo)
+    internal static string BuildCheckpointCommand(
+        Run run,
+        ContainerGitRepository repo,
+        string? outputsRoot = null)
     {
         var q = GitCloneService.ShellQuote(repo.TargetPath);
         var expectedBranch = IRunBranchService.BranchNameFor(run.Id);
@@ -1188,6 +1207,16 @@ public sealed class HeadlessRunner : IHeadlessRunner
         var excludedTemplate = ShellEscape(
             $"/tmp/andy-checkpoint-excluded-{run.Id}-{repo.Id}.XXXXXX");
         var message = $"andy run {run.Id}: task work checkpoint";
+        // Production explicitly supplies the service-wide outputs root. The
+        // repo-local fallback makes the pure shell contract safely testable in
+        // a temporary repository without touching /workspace.
+        outputsRoot ??= repo.TargetPath.TrimEnd('/') + "/.andy/outputs";
+        var deliverableRelativePath = $"deliverables/{run.Id}/{repo.Id}";
+        var deliverableRoot = outputsRoot.TrimEnd('/') + "/" + deliverableRelativePath;
+        var deliverableRootQuoted = ShellEscape(deliverableRoot);
+        var manifestJson = ShellEscape(
+            $"{{\"schema_version\":1,\"run_id\":\"{run.Id}\",\"repository_id\":\"{repo.Id}\","
+            + $"\"branch\":\"{expectedBranch}\",\"commit\":\"%s\"}}\\n");
 
         return
             $"actual_branch=$(git -C {q} symbolic-ref --quiet --short HEAD) || "
@@ -1213,7 +1242,13 @@ public sealed class HeadlessRunner : IHeadlessRunner
             + "rm -f \"$excluded\" && trap - EXIT && "
             + $"(git -C {q} diff --cached --quiet "
             + $"&& echo {ShellEscape(NoChangesMarker)} "
-            + $"|| git -C {q} -c user.email='agent@andy.rivoli.ai' -c user.name='Andy Agent' commit -m {ShellEscape(message)} --no-verify)";
+            + $"|| (git -C {q} -c user.email='agent@andy.rivoli.ai' -c user.name='Andy Agent' commit -m {ShellEscape(message)} --no-verify && "
+            + $"deliverable_root={deliverableRootQuoted} && mkdir -p \"$deliverable_root\" && "
+            + $"commit_sha=$(git -C {q} rev-parse HEAD) && "
+            + $"git -C {q} show --binary --format=fuller --stat --patch HEAD > \"$deliverable_root/checkpoint.patch\" && "
+            + $"git -C {q} diff-tree --root --no-commit-id --name-status -r HEAD > \"$deliverable_root/changed-files.tsv\" && "
+            + $"printf {manifestJson} \"$commit_sha\" > \"$deliverable_root/manifest.json\" && "
+            + $"echo {DeliverablesRegisteredMarker}{deliverableRelativePath}))";
     }
 
     // POSIX single-quote escape — safe for /bin/sh -c "...". Single quotes

--- a/src/Andy.Containers/Abstractions/IOutputArtifactCollector.cs
+++ b/src/Andy.Containers/Abstractions/IOutputArtifactCollector.cs
@@ -9,6 +9,9 @@ namespace Andy.Containers.Abstractions;
 /// Walks the well-known outputs directory inside a container and
 /// produces a structured manifest of artifacts to publish on the
 /// terminal run event.
+/// Successful agent runs may first materialize commit-derived deliverables
+/// beneath the same root; the recursive walk treats those patch/manifest
+/// files exactly like agent-declared outputs.
 ///
 /// Issue rivoli-ai/andy-containers#316. The default contract:
 ///
@@ -36,4 +39,15 @@ public interface IOutputArtifactCollector
     Task<IReadOnlyList<RunOutputArtifact>> CollectAsync(
         Container container,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Collect artifacts for a concrete agent run. Implementations that upload
+    /// bytes can attach document links to <paramref name="runId"/> instead of
+    /// incorrectly treating the hosting container id as the run identity.
+    /// </summary>
+    Task<IReadOnlyList<RunOutputArtifact>> CollectRunAsync(
+        Container container,
+        Guid runId,
+        CancellationToken ct = default)
+        => CollectAsync(container, ct);
 }

--- a/tests/Andy.Containers.Api.Tests/Services/FilesystemOutputArtifactCollectorTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/FilesystemOutputArtifactCollectorTests.cs
@@ -176,6 +176,8 @@ public class FilesystemOutputArtifactCollectorTests
 
     [Theory]
     [InlineData("foo.txt", "text/plain")]
+    [InlineData("checkpoint.patch", "text/x-diff")]
+    [InlineData("changes.diff", "text/x-diff")]
     [InlineData("foo.json", "application/json")]
     [InlineData("foo.pdf", "application/pdf")]
     [InlineData("foo.png", "image/png")]
@@ -291,6 +293,39 @@ public class FilesystemOutputArtifactCollectorTests
     }
 
     [Fact]
+    public async Task CollectRun_ProbeIncludesOnlyCurrentRunDeliverableBundle()
+    {
+        string? command = null;
+        var containers = new Mock<IContainerService>();
+        containers
+            .Setup(c => c.ExecAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<string>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, TimeSpan, CancellationToken>(
+                (_, cmd, _, _) => command = cmd)
+            .ReturnsAsync(new ExecResult { ExitCode = 0, StdOut = "" });
+        var collector = new FilesystemOutputArtifactCollector(
+            containers.Object,
+            NullLogger<FilesystemOutputArtifactCollector>.Instance);
+        var container = new Container
+        {
+            Id = Guid.NewGuid(), Name = "c", OwnerId = "u", ExternalId = "ext-1",
+        };
+        var runId = Guid.NewGuid();
+
+        await collector.CollectRunAsync(container, runId);
+
+        command.Should().Contain(
+            $"{Root}/deliverables/{runId}/*");
+        command.Should().Contain("! -path");
+        command.Should().Contain(
+            $"{Root}/deliverables/*",
+            "older attempts must not be attributed to this run");
+    }
+
+    [Fact]
     public async Task Collect_PropagatesCallerCancellation()
     {
         var containers = new Mock<IContainerService>();
@@ -385,7 +420,7 @@ public class FilesystemOutputArtifactCollectorTests
     {
         // Capture the UploadRequest and assert it carries the
         // expected MimeType / Name / Digest / Links shape (Run target,
-        // container id, Output role).
+        // concrete run id, Output role).
         var sha = new string('a', 64);
         var probe = $"3\t{sha}\t{Root}/report.pdf";
         var b64 = Convert.ToBase64String(new byte[] { 1, 2, 3 });
@@ -399,6 +434,7 @@ public class FilesystemOutputArtifactCollectorTests
             .ReturnsAsync(new DocsRef(Guid.NewGuid(), Guid.NewGuid()));
 
         var containerId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
         var collector = new FilesystemOutputArtifactCollector(
             containers.Object,
             NullLogger<FilesystemOutputArtifactCollector>.Instance,
@@ -408,7 +444,7 @@ public class FilesystemOutputArtifactCollectorTests
             Id = containerId, Name = "c", OwnerId = "u", ExternalId = "ext-1",
         };
 
-        var artifacts = await collector.CollectAsync(container);
+        var artifacts = await collector.CollectRunAsync(container, runId);
 
         artifacts.Should().HaveCount(1);
         captured.Should().NotBeNull();
@@ -418,7 +454,7 @@ public class FilesystemOutputArtifactCollectorTests
         captured.Content.ToArray().Should().BeEquivalentTo(new byte[] { 1, 2, 3 });
         captured.Links.Should().HaveCount(1);
         captured.Links[0].TargetType.Should().Be("Run");
-        captured.Links[0].TargetId.Should().Be(containerId.ToString());
+        captured.Links[0].TargetId.Should().Be(runId.ToString());
         captured.Links[0].Role.Should().Be("Output");
     }
 

--- a/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/HeadlessRunnerTests.cs
@@ -928,7 +928,10 @@ public class HeadlessRunnerTests : IDisposable
         };
         var collector = new Mock<IOutputArtifactCollector>();
         collector
-            .Setup(c => c.CollectAsync(It.IsAny<Container>(), It.IsAny<CancellationToken>()))
+            .Setup(c => c.CollectRunAsync(
+                It.IsAny<Container>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(artifacts);
 
         // Seed a real container row so the runner can FindAsync it.
@@ -953,7 +956,9 @@ public class HeadlessRunnerTests : IDisposable
         arr[0].GetProperty("relative_path").GetString().Should().Be("report.pdf");
 
         collector.Verify(
-            c => c.CollectAsync(It.Is<Container>(ct => ct.Id == run.ContainerId.Value),
+            c => c.CollectRunAsync(
+                It.Is<Container>(ct => ct.Id == run.ContainerId.Value),
+                run.Id,
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -966,7 +971,10 @@ public class HeadlessRunnerTests : IDisposable
         // output_artifacts field on the payload).
         var collector = new Mock<IOutputArtifactCollector>();
         collector
-            .Setup(c => c.CollectAsync(It.IsAny<Container>(), It.IsAny<CancellationToken>()))
+            .Setup(c => c.CollectRunAsync(
+                It.IsAny<Container>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("probe exec died"));
 
         var run = SeedRun();
@@ -1028,7 +1036,10 @@ public class HeadlessRunnerTests : IDisposable
         await runner.StartAsync(run, _configPath);
 
         collector.Verify(
-            c => c.CollectAsync(It.IsAny<Container>(), It.IsAny<CancellationToken>()),
+            c => c.CollectRunAsync(
+                It.IsAny<Container>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -1195,6 +1206,11 @@ public class HeadlessRunnerTests : IDisposable
             .ContainSingle(c => c.Contains("git -C") && c.Contains("commit")).Subject;
         commit.Should().Contain("add -A");
         commit.Should().Contain("/workspace");
+        commit.Should().Contain("/workspace/.andy/outputs/deliverables/");
+        commit.Should().Contain($"/deliverables/{run.Id}/");
+        commit.Should().Contain("checkpoint.patch");
+        commit.Should().Contain("changed-files.tsv");
+        commit.Should().Contain("manifest.json");
         commit.Should().Contain($"andy run {run.Id}", "the commit message must identify the run");
         commit.Should().Contain($"andy/run/{run.Id}",
             "the branch invariant must be checked in the same exec as staging");
@@ -1285,6 +1301,8 @@ public class HeadlessRunnerTests : IDisposable
             result.ExitCode.Should().Be(0, result.StdErr);
             result.StdOut.Should().Contain("__ANDY_CHECKPOINT_EXCLUDED__=1");
             result.StdOut.Should().Contain("__ANDY_CHECKPOINT_RUNTIME_ARTIFACTS_EXCLUDED__");
+            result.StdOut.Should().Contain(
+                $"__ANDY_DELIVERABLES_REGISTERED__=deliverables/{run.Id}/{repo.Id}");
             File.Exists(Path.Combine(root, "fixture.orig")).Should().BeTrue();
             File.Exists(Path.Combine(root, "notes.bak")).Should().BeTrue();
             File.Exists(Path.Combine(root, ".andy", "inputs", "sensitive.bin")).Should().BeTrue();
@@ -1298,6 +1316,36 @@ public class HeadlessRunnerTests : IDisposable
             RunGit(root, "status", "--porcelain").StdOut.Should().Contain("?? notes.bak");
             RunGit(root, "status", "--porcelain").StdOut.Should().Contain("?? .andy/");
             RunGit(root, "branch", "--show-current").StdOut.Trim().Should().Be(expectedBranch);
+
+            var deliverables = Path.Combine(
+                root,
+                ".andy",
+                "outputs",
+                "deliverables",
+                run.Id.ToString(),
+                repo.Id.ToString());
+            var patch = File.ReadAllText(Path.Combine(deliverables, "checkpoint.patch"));
+            patch.Should().Contain("ordinary changed");
+            patch.Should().Contain("fixture.orig");
+            patch.Should().NotContain("notes.bak");
+            patch.Should().NotContain("sensitive.bin");
+
+            var changedFiles = File.ReadAllText(
+                Path.Combine(deliverables, "changed-files.tsv"));
+            changedFiles.Should().Contain("fixture.orig");
+            changedFiles.Should().Contain("ordinary.txt");
+            changedFiles.Should().NotContain(".andy/");
+
+            using var manifest = JsonDocument.Parse(
+                File.ReadAllText(Path.Combine(deliverables, "manifest.json")));
+            manifest.RootElement.GetProperty("run_id").GetString()
+                .Should().Be(run.Id.ToString());
+            manifest.RootElement.GetProperty("repository_id").GetString()
+                .Should().Be(repo.Id.ToString());
+            manifest.RootElement.GetProperty("branch").GetString()
+                .Should().Be(expectedBranch);
+            manifest.RootElement.GetProperty("commit").GetString()
+                .Should().Be(RunGit(root, "rev-parse", "HEAD").StdOut.Trim());
         }
         finally
         {


### PR DESCRIPTION
Closes #365

## Summary
- materialize a binary-capable checkpoint patch, changed-file TSV, and commit manifest after each successful repository checkpoint
- scope bundles by run and repository and exclude older bundles from later run collection
- collect/upload the generated bundle through the existing andy-docs artifact pipeline
- link uploaded documents to the concrete run id instead of the hosting container id
- classify patch artifacts as `text/x-diff` and document the handoff contract

## Validation
- full solution: 2,177 passed; 9 environment-gated skipped; 0 failed
- real temporary-Git test verifies exact commit SHA, patch content, changed files, branch guard, and sensitive/service-owned exclusions
- `git diff --check` passed