### PR TITLE
feat: stream container exec output over SSE

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -494,7 +494,7 @@ Container operations are protected by RBAC permissions in the format `andy-conta
 | `container:start` | Start a stopped container |
 | `container:stop` | Stop a running container |
 | `container:destroy` | Destroy a container |
-| `container:exec` | Execute commands in a container |
+| `container:execute` | Execute commands in a container |
 | `container:connect` | Open IDE/VNC/SSH session |
 | `workspace:create` | Create workspaces |
 | `workspace:read` | View workspaces |

--- a/docs/api-mcp-cli-parity.md
+++ b/docs/api-mcp-cli-parity.md
@@ -33,6 +33,7 @@ Numbers exclude health checks, Swagger, and WebSocket attach surfaces (which don
 | `POST /api/containers/{id}/stop` | ✅ | `andy-containers-cli stop {id}` ✅ |
 | `DELETE /api/containers/{id}` | ✅ | `andy-containers-cli destroy {id}` ✅ |
 | `POST /api/containers/{id}/exec` | ✅ | `andy-containers-cli exec {id} ...` ✅ |
+| `POST /api/containers/{id}/exec/stream` | HTTP-only streaming transport | HTTP-only streaming transport |
 | `GET /api/containers/{id}/connection` | ❌ | ❌ |
 | `PUT /api/containers/{id}/resources` | ❌ | ❌ |
 | `GET /api/containers/{id}/screenshot` | — | — |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -14,7 +14,8 @@ All endpoints require authentication (JWT Bearer token) and RBAC permissions via
 | POST | `/containers/{id}/start` | container:execute | Start a stopped container |
 | POST | `/containers/{id}/stop` | container:execute | Stop a running container |
 | DELETE | `/containers/{id}` | container:delete | Destroy a container |
-| POST | `/containers/{id}/exec` | container:exec | Execute a command |
+| POST | `/containers/{id}/exec` | container:execute | Execute a command |
+| POST | `/containers/{id}/exec/stream` | container:execute | Execute a command and stream stdout/stderr lines over SSE |
 | GET | `/containers/{id}/stats` | container:read | Get CPU/RAM/disk usage |
 | PUT | `/containers/{id}/resources` | container:execute | Live resize CPU/memory |
 | GET | `/containers/{id}/connection` | container:read | Get IDE/VNC/SSH endpoints |

--- a/openapi/containers-api.yaml
+++ b/openapi/containers-api.yaml
@@ -161,6 +161,75 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/ExecResult' }
 
+  /api/containers/{id}/exec/stream:
+    post:
+      tags: [Containers]
+      summary: Execute a command and stream its output
+      description: |
+        Runs a command through the same provider exec surface as the buffered
+        `/exec` endpoint, but returns each complete stdout/stderr line as a
+        Server-Sent Event as soon as it is produced. The final `done` event
+        carries the process exit code and closes the stream.
+
+        Wire format:
+
+        ```
+        event: stdout
+        data: {"line":"first line"}
+
+        event: stderr
+        data: {"line":"warning"}
+
+        event: done
+        data: {"exitCode":0}
+        ```
+
+        JSON payloads keep structured JSONL output unambiguous. Closing the
+        HTTP connection cancels the underlying provider exec. Requires
+        `container:execute` and ownership, service-account, or admin access
+        to the container.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [command]
+              properties:
+                command: { type: string, minLength: 1 }
+                timeoutSeconds:
+                  type: integer
+                  default: 30
+                  minimum: 1
+                  maximum: 86400
+      responses:
+        '200':
+          description: SSE stream of stdout/stderr lines followed by a done event
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                example: |
+                  event: stdout
+                  data: {"line":"first line"}
+
+                  event: stderr
+                  data: {"line":"warning"}
+
+                  event: done
+                  data: {"exitCode":0}
+        '400':
+          description: Command or timeout validation failed
+        '404':
+          description: Container not found
+        '409':
+          description: Container is not executable in its current state
+
   /api/containers/{id}/connection:
     get:
       tags: [Containers]

--- a/src/Andy.Containers.Api/Controllers/ContainersController.cs
+++ b/src/Andy.Containers.Api/Controllers/ContainersController.cs
@@ -367,6 +367,61 @@ public class ContainersController : ControllerBase
     }
 
     /// <summary>
+    /// Streams a command's stdout and stderr as line-framed Server-Sent
+    /// Events, followed by one terminal <c>done</c> event containing the
+    /// process exit code. Disconnecting the HTTP client cancels the
+    /// underlying provider exec.
+    /// </summary>
+    [HttpPost("{id:guid}/exec/stream")]
+    [RequirePermission("container:execute")]
+    [Produces("text/event-stream")]
+    public async Task<IActionResult> ExecStream(
+        Guid id,
+        [FromBody] ExecRequest request,
+        CancellationToken ct)
+    {
+        var container = await FindContainerAsync(id, ct);
+        if (container is null) return ContainerNotFound(id);
+        if (!CanAccess(container)) return Forbid();
+
+        if (string.IsNullOrWhiteSpace(request.Command))
+        {
+            return BadRequest(new { message = "Command is required." });
+        }
+
+        if (request.TimeoutSeconds is < 1 or > 86_400)
+        {
+            return BadRequest(new
+            {
+                message = "TimeoutSeconds must be between 1 and 86400.",
+            });
+        }
+
+        if (container.Status is not (ContainerStatus.Running or ContainerStatus.Creating))
+        {
+            return Conflict(new
+            {
+                message = $"Container is {container.Status}, cannot exec.",
+            });
+        }
+
+        if (string.IsNullOrEmpty(container.ExternalId))
+        {
+            return Conflict(new { message = "Container has no external ID yet." });
+        }
+
+        await ContainerExecSse.StreamAsync(
+            Response,
+            _containerService,
+            id,
+            request.Command,
+            TimeSpan.FromSeconds(request.TimeoutSeconds),
+            ct);
+
+        return new EmptyResult();
+    }
+
+    /// <summary>
     /// rivoli-ai/conductor#945 (M1.5.3). Re-run the code-assistant
     /// install for a container that surfaced a Failed or Skipped
     /// status. The container must be Running (the install script

--- a/src/Andy.Containers.Api/Services/ContainerExecSse.cs
+++ b/src/Andy.Containers.Api/Services/ContainerExecSse.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using Andy.Containers.Abstractions;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// Writes one container exec as an SSE stream. Each stdout/stderr callback is
+/// awaited so the provider cannot outrun a slow HTTP client indefinitely.
+/// </summary>
+public static class ContainerExecSse
+{
+    public static async Task StreamAsync(
+        HttpResponse response,
+        IContainerService containerService,
+        Guid containerId,
+        string command,
+        TimeSpan timeout,
+        CancellationToken ct)
+    {
+        response.StatusCode = StatusCodes.Status200OK;
+        response.Headers.ContentType = "text/event-stream";
+        response.Headers.CacheControl = "no-store";
+        response.Headers["X-Accel-Buffering"] = "no";
+        response.HttpContext.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
+
+        try
+        {
+            var result = await containerService.ExecStreamingAsync(
+                containerId,
+                command,
+                timeout,
+                async (chunk, writeCt) =>
+                {
+                    var eventName = chunk.Stream == ExecStreamKind.Stderr
+                        ? "stderr"
+                        : "stdout";
+                    await WriteEventAsync(
+                        response,
+                        eventName,
+                        new ExecLineEvent(chunk.Line),
+                        writeCt);
+                },
+                ct);
+
+            await WriteEventAsync(
+                response,
+                "done",
+                new ExecDoneEvent(result.ExitCode),
+                ct);
+        }
+        catch (OperationCanceledException) when (
+            ct.IsCancellationRequested ||
+            response.HttpContext.RequestAborted.IsCancellationRequested)
+        {
+            // A disconnected SSE client cancels RequestAborted. The same
+            // token is passed through the orchestration and provider layers,
+            // terminating the attached exec instead of leaving this request
+            // draining output nobody can consume.
+        }
+    }
+
+    private static async ValueTask WriteEventAsync<T>(
+        HttpResponse response,
+        string eventName,
+        T payload,
+        CancellationToken ct)
+    {
+        var json = JsonSerializer.Serialize(payload, SseJsonOptions);
+        await response.WriteAsync($"event: {eventName}\ndata: {json}\n\n", ct);
+        await response.Body.FlushAsync(ct);
+    }
+
+    private sealed record ExecLineEvent(string Line);
+    private sealed record ExecDoneEvent(int ExitCode);
+
+    private static readonly JsonSerializerOptions SseJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+}

--- a/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
+++ b/src/Andy.Containers.Api/Services/ContainerOrchestrationService.cs
@@ -1061,6 +1061,25 @@ public class ContainerOrchestrationService : IContainerService
         return await infra.ExecStreamingAsync(container.ExternalId!, command, timeout, onLine, ct);
     }
 
+    public async Task<ExecResult> ExecStreamingAsync(
+        Guid containerId, string command, TimeSpan timeout,
+        Func<ExecOutputChunk, CancellationToken, ValueTask> onLine, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(onLine);
+        using var activity = ActivitySources.Provisioning.StartActivity("ExecCommandStreaming");
+        activity?.SetTag("andy.containers.id", containerId.ToString());
+        activity?.SetTag("andy.containers.timeout_seconds", timeout.TotalSeconds);
+
+        var container = await GetContainerAsync(containerId, ct);
+        if (container.Status is not (ContainerStatus.Running or ContainerStatus.Creating))
+            throw new InvalidOperationException($"Container is {container.Status}, cannot exec");
+        if (string.IsNullOrEmpty(container.ExternalId))
+            throw new InvalidOperationException("Container has no external ID yet");
+
+        var infra = _providerFactory.GetProvider(container.Provider!);
+        return await infra.ExecStreamingAsync(container.ExternalId!, command, timeout, onLine, ct);
+    }
+
     public async Task<ConnectionInfo> GetConnectionInfoAsync(Guid containerId, CancellationToken ct)
     {
         var container = await GetContainerAsync(containerId, ct);

--- a/src/Andy.Containers.Infrastructure/Providers/Apple/AppleContainerProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Apple/AppleContainerProvider.cs
@@ -196,6 +196,120 @@ public class AppleContainerProvider : IInfrastructureProvider
         };
     }
 
+    public Task<ExecResult> ExecStreamingAsync(
+        string externalId,
+        string command,
+        TimeSpan timeout,
+        Action<ExecOutputChunk> onLine,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(onLine);
+        return ExecStreamingAsync(
+            externalId,
+            command,
+            timeout,
+            (chunk, _) =>
+            {
+                onLine(chunk);
+                return ValueTask.CompletedTask;
+            },
+            ct);
+    }
+
+    public async Task<ExecResult> ExecStreamingAsync(
+        string externalId,
+        string command,
+        TimeSpan timeout,
+        Func<ExecOutputChunk, CancellationToken, ValueTask> onLine,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(onLine);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = _cliPath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var arg in new[] { "exec", externalId, "sh", "-c", command })
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        using var process = Process.Start(psi);
+        if (process is null)
+        {
+            throw new InvalidOperationException($"Failed to start {_cliPath}");
+        }
+
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+        using var callbackGate = new SemaphoreSlim(1, 1);
+        var token = linked.Token;
+        var stdout = new System.Text.StringBuilder();
+        var stderr = new System.Text.StringBuilder();
+
+        async Task PumpAsync(
+            StreamReader reader,
+            System.Text.StringBuilder all,
+            ExecStreamKind kind)
+        {
+            while (await reader.ReadLineAsync(token) is { } line)
+            {
+                if (all.Length > 0)
+                {
+                    all.Append('\n');
+                }
+                all.Append(line);
+
+                // stdout and stderr are drained concurrently to prevent
+                // process-pipe deadlocks. Serialise callbacks because an
+                // HttpResponse body does not support concurrent writes.
+                await callbackGate.WaitAsync(token);
+                try
+                {
+                    await onLine(new ExecOutputChunk(kind, line), token);
+                }
+                finally
+                {
+                    callbackGate.Release();
+                }
+            }
+        }
+
+        try
+        {
+            await Task.WhenAll(
+                PumpAsync(process.StandardOutput, stdout, ExecStreamKind.Stdout),
+                PumpAsync(process.StandardError, stderr, ExecStreamKind.Stderr),
+                process.WaitForExitAsync(token));
+        }
+        catch (OperationCanceledException)
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // The process exited between HasExited and Kill.
+            }
+            throw;
+        }
+
+        return new ExecResult
+        {
+            ExitCode = process.ExitCode,
+            StdOut = stdout.ToString(),
+            StdErr = stderr.ToString(),
+        };
+    }
+
     /// <summary>
     /// Lists every externalId currently known to the Apple `container`
     /// runtime via <c>container ls -a</c>. Used by the startup

--- a/src/Andy.Containers.Infrastructure/Providers/Local/DockerInfrastructureProvider.cs
+++ b/src/Andy.Containers.Infrastructure/Providers/Local/DockerInfrastructureProvider.cs
@@ -492,9 +492,26 @@ public class DockerInfrastructureProvider : IInfrastructureProvider
     /// with its stream kind. The full stdout/stderr is also accumulated so
     /// the returned <see cref="ExecResult"/> matches the buffered shape.
     /// </summary>
-    public async Task<ExecResult> ExecStreamingAsync(
+    public Task<ExecResult> ExecStreamingAsync(
         string externalId, string command, TimeSpan timeout,
         Action<ExecOutputChunk> onLine, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(onLine);
+        return ExecStreamingAsync(
+            externalId,
+            command,
+            timeout,
+            (chunk, _) =>
+            {
+                onLine(chunk);
+                return ValueTask.CompletedTask;
+            },
+            ct);
+    }
+
+    public async Task<ExecResult> ExecStreamingAsync(
+        string externalId, string command, TimeSpan timeout,
+        Func<ExecOutputChunk, CancellationToken, ValueTask> onLine, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(onLine);
 
@@ -531,21 +548,21 @@ public class DockerInfrastructureProvider : IInfrastructureProvider
             if (read.Target == MultiplexedStream.TargetStream.StandardError)
             {
                 stderrAll.Append(text);
-                EmitLines(stderrCarry, text, ExecStreamKind.Stderr, onLine);
+                await EmitLinesAsync(stderrCarry, text, ExecStreamKind.Stderr, onLine, token);
             }
             else
             {
                 stdoutAll.Append(text);
-                EmitLines(stdoutCarry, text, ExecStreamKind.Stdout, onLine);
+                await EmitLinesAsync(stdoutCarry, text, ExecStreamKind.Stdout, onLine, token);
             }
         }
 
         // Flush any unterminated trailing line (output that never ended in
         // a newline still reaches the live stream).
-        FlushCarry(stdoutCarry, ExecStreamKind.Stdout, onLine);
-        FlushCarry(stderrCarry, ExecStreamKind.Stderr, onLine);
+        await FlushCarryAsync(stdoutCarry, ExecStreamKind.Stdout, onLine, token);
+        await FlushCarryAsync(stderrCarry, ExecStreamKind.Stderr, onLine, token);
 
-        var inspect = await _client.Exec.InspectContainerExecAsync(exec.ID, ct);
+        var inspect = await _client.Exec.InspectContainerExecAsync(exec.ID, token);
         return new ExecResult
         {
             ExitCode = (int)inspect.ExitCode,
@@ -557,9 +574,11 @@ public class DockerInfrastructureProvider : IInfrastructureProvider
     // Append `text` to the carry buffer, then emit one callback per
     // complete (newline-terminated) line, leaving any partial tail in the
     // carry for the next read.
-    private static void EmitLines(
+    private static async ValueTask EmitLinesAsync(
         System.Text.StringBuilder carry, string text,
-        ExecStreamKind kind, Action<ExecOutputChunk> onLine)
+        ExecStreamKind kind,
+        Func<ExecOutputChunk, CancellationToken, ValueTask> onLine,
+        CancellationToken ct)
     {
         carry.Append(text);
         var combined = carry.ToString();
@@ -570,7 +589,7 @@ public class DockerInfrastructureProvider : IInfrastructureProvider
         while ((idx = normalized.IndexOf('\n', start)) >= 0)
         {
             var line = normalized.Substring(start, idx - start);
-            onLine(new ExecOutputChunk(kind, line));
+            await onLine(new ExecOutputChunk(kind, line), ct);
             start = idx + 1;
         }
 
@@ -581,12 +600,15 @@ public class DockerInfrastructureProvider : IInfrastructureProvider
         }
     }
 
-    private static void FlushCarry(
-        System.Text.StringBuilder carry, ExecStreamKind kind, Action<ExecOutputChunk> onLine)
+    private static async ValueTask FlushCarryAsync(
+        System.Text.StringBuilder carry,
+        ExecStreamKind kind,
+        Func<ExecOutputChunk, CancellationToken, ValueTask> onLine,
+        CancellationToken ct)
     {
         if (carry.Length > 0)
         {
-            onLine(new ExecOutputChunk(kind, carry.ToString()));
+            await onLine(new ExecOutputChunk(kind, carry.ToString()), ct);
             carry.Clear();
         }
     }

--- a/src/Andy.Containers/Abstractions/IContainerService.cs
+++ b/src/Andy.Containers/Abstractions/IContainerService.cs
@@ -73,6 +73,26 @@ public interface IContainerService
         }
     }
 
+    /// <summary>
+    /// Asynchronous-callback variant used by streaming transports that need
+    /// to await each output write and apply backpressure.
+    /// </summary>
+    Task<ExecResult> ExecStreamingAsync(
+        Guid containerId,
+        string command,
+        TimeSpan timeout,
+        Func<ExecOutputChunk, CancellationToken, ValueTask> onLine,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(onLine);
+        return ExecStreamingAsync(
+            containerId,
+            command,
+            timeout,
+            chunk => onLine(chunk, ct).AsTask().GetAwaiter().GetResult(),
+            ct);
+    }
+
     Task<ConnectionInfo> GetConnectionInfoAsync(Guid containerId, CancellationToken ct = default);
     Task<ContainerStats> GetContainerStatsAsync(Guid containerId, CancellationToken ct = default);
     Task ResizeContainerAsync(Guid containerId, ResourceSpec resources, CancellationToken ct = default);

--- a/src/Andy.Containers/Abstractions/IInfrastructureProvider.cs
+++ b/src/Andy.Containers/Abstractions/IInfrastructureProvider.cs
@@ -89,6 +89,29 @@ public interface IInfrastructureProvider
     }
 
     /// <summary>
+    /// Asynchronous-callback variant of streaming exec. This keeps the
+    /// existing callback contract source-compatible while allowing HTTP
+    /// transports to await each write and apply backpressure.
+    /// Providers with a native streaming implementation should override
+    /// this overload; the default adapts the synchronous callback.
+    /// </summary>
+    Task<ExecResult> ExecStreamingAsync(
+        string externalId,
+        string command,
+        TimeSpan timeout,
+        Func<ExecOutputChunk, CancellationToken, ValueTask> onLine,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(onLine);
+        return ExecStreamingAsync(
+            externalId,
+            command,
+            timeout,
+            chunk => onLine(chunk, ct).AsTask().GetAwaiter().GetResult(),
+            ct);
+    }
+
+    /// <summary>
     /// Returns the set of container externalIds currently known to the
     /// provider, or <c>null</c> if this provider does not support bulk
     /// enumeration. Used by the startup reconciler (conductor #840) to

--- a/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerExecStreamTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ContainersControllerExecStreamTests.cs
@@ -1,0 +1,202 @@
+using System.Text;
+using Andy.Containers.Abstractions;
+using Andy.Containers.Api.Controllers;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using Andy.Containers.Storage;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Controllers;
+
+/// <summary>
+/// Contract coverage for #279. These tests pin the public SSE framing used by
+/// andy-agents and verify that disconnect cancellation reaches the exec layer.
+/// </summary>
+public sealed class ContainersControllerExecStreamTests : IDisposable
+{
+    private readonly ContainersDbContext _db = InMemoryDbHelper.CreateContext();
+    private readonly Mock<IContainerService> _containers = new();
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task ExecStream_WritesStdoutStderrAndDoneWireContract()
+    {
+        var id = Guid.NewGuid();
+        var controller = CreateController(id);
+        var bodyStream = SetupResponse(controller);
+
+        _containers
+            .Setup(c => c.ExecStreamingAsync(
+                id,
+                "agent-runner",
+                TimeSpan.FromSeconds(42),
+                It.IsAny<Func<ExecOutputChunk, CancellationToken, ValueTask>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<Guid, string, TimeSpan, Func<ExecOutputChunk, CancellationToken, ValueTask>, CancellationToken>(
+                async (_, _, _, onLine, ct) =>
+                {
+                    await onLine(new ExecOutputChunk(ExecStreamKind.Stdout, "first"), ct);
+                    await onLine(new ExecOutputChunk(ExecStreamKind.Stderr, "warning"), ct);
+                    await onLine(new ExecOutputChunk(
+                        ExecStreamKind.Stdout,
+                        """{"type":"token","value":"hello"}"""), ct);
+                    return new ExecResult { ExitCode = 7 };
+                });
+
+        var result = await controller.ExecStream(
+            id,
+            new ExecRequest { Command = "agent-runner", TimeoutSeconds = 42 },
+            CancellationToken.None);
+
+        result.Should().BeOfType<EmptyResult>();
+        controller.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        controller.Response.ContentType.Should().Be("text/event-stream");
+        controller.Response.Headers.CacheControl.ToString().Should().Be("no-store");
+        controller.Response.Headers["X-Accel-Buffering"].ToString().Should().Be("no");
+
+        ReadBody(bodyStream).Should().Be(
+            """
+            event: stdout
+            data: {"line":"first"}
+
+            event: stderr
+            data: {"line":"warning"}
+
+            event: stdout
+            data: {"line":"{\u0022type\u0022:\u0022token\u0022,\u0022value\u0022:\u0022hello\u0022}"}
+
+            event: done
+            data: {"exitCode":7}
+
+
+            """.ReplaceLineEndings("\n"));
+    }
+
+    [Fact]
+    public async Task ExecStream_DisconnectCancelsUnderlyingExecAndOmitsDone()
+    {
+        var id = Guid.NewGuid();
+        var controller = CreateController(id);
+        var bodyStream = SetupResponse(controller);
+        var execStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = false;
+
+        _containers
+            .Setup(c => c.ExecStreamingAsync(
+                id,
+                It.IsAny<string>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<Func<ExecOutputChunk, CancellationToken, ValueTask>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<Guid, string, TimeSpan, Func<ExecOutputChunk, CancellationToken, ValueTask>, CancellationToken>(
+                async (_, _, _, onLine, ct) =>
+                {
+                    await onLine(new ExecOutputChunk(ExecStreamKind.Stdout, "started"), ct);
+                    execStarted.TrySetResult();
+                    try
+                    {
+                        await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        cancellationObserved = true;
+                        throw;
+                    }
+
+                    return new ExecResult();
+                });
+
+        using var disconnect = new CancellationTokenSource();
+        var streamTask = controller.ExecStream(
+            id,
+            new ExecRequest { Command = "long-running" },
+            disconnect.Token);
+
+        await execStarted.Task.WaitAsync(TimeSpan.FromSeconds(3));
+        disconnect.Cancel();
+
+        (await streamTask).Should().BeOfType<EmptyResult>();
+        cancellationObserved.Should().BeTrue();
+        var body = ReadBody(bodyStream);
+        body.Should().Contain("event: stdout");
+        body.Should().NotContain("event: done");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(86_401)]
+    public async Task ExecStream_RejectsUnsafeTimeoutBeforeStartingResponse(int timeoutSeconds)
+    {
+        var id = Guid.NewGuid();
+        var controller = CreateController(id);
+        SetupResponse(controller);
+
+        var result = await controller.ExecStream(
+            id,
+            new ExecRequest { Command = "echo ok", TimeoutSeconds = timeoutSeconds },
+            CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+        _containers.Verify(c => c.ExecStreamingAsync(
+            It.IsAny<Guid>(),
+            It.IsAny<string>(),
+            It.IsAny<TimeSpan>(),
+            It.IsAny<Func<ExecOutputChunk, CancellationToken, ValueTask>>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private ContainersController CreateController(Guid id)
+    {
+        _containers
+            .Setup(c => c.GetContainerAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Container
+            {
+                Id = id,
+                Name = "stream-target",
+                OwnerId = "owner",
+                Status = ContainerStatus.Running,
+                ExternalId = "docker-stream-target",
+            });
+
+        var currentUser = new Mock<ICurrentUserService>();
+        currentUser.Setup(u => u.IsAdmin()).Returns(true);
+        currentUser.Setup(u => u.GetUserId()).Returns("admin");
+        currentUser.Setup(u => u.IsAuthenticated()).Returns(true);
+
+        return new ContainersController(
+            _containers.Object,
+            currentUser.Object,
+            _db,
+            Mock.Of<IGitCloneService>(),
+            Mock.Of<IGitCredentialService>(),
+            Mock.Of<IGitRepositoryProbeService>(),
+            Mock.Of<IOrganizationMembershipService>(),
+            Mock.Of<IGitDiffService>(),
+            Mock.Of<IPortDiscoveryService>(),
+            Mock.Of<IContainerLifecycleBus>(),
+            Mock.Of<IRunOutputBus>());
+    }
+
+    private static MemoryStream SetupResponse(ContainersController controller)
+    {
+        var stream = new MemoryStream();
+        var context = new DefaultHttpContext();
+        context.Response.Body = stream;
+        controller.ControllerContext = new ControllerContext { HttpContext = context };
+        return stream;
+    }
+
+    private static string ReadBody(MemoryStream stream)
+    {
+        stream.Position = 0;
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+}

--- a/tests/Andy.Containers.Api.Tests/Providers/AppleContainerProviderStreamingTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Providers/AppleContainerProviderStreamingTests.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using Andy.Containers.Abstractions;
+using Andy.Containers.Infrastructure.Providers.Apple;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Providers;
+
+public sealed class AppleContainerProviderStreamingTests : IDisposable
+{
+    private readonly string _tempDirectory =
+        Path.Combine(Path.GetTempPath(), $"andy-apple-stream-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecStreamingAsync_EmitsCliLinesBeforeProcessExit()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(_tempDirectory);
+        var cliPath = Path.Combine(_tempDirectory, "container-stub");
+        await File.WriteAllTextAsync(
+            cliPath,
+            """
+            #!/bin/sh
+            printf 'first\n'
+            printf 'warning\n' >&2
+            sleep 1
+            printf 'last\n'
+            exit 7
+            """);
+        File.SetUnixFileMode(
+            cliPath,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        var provider = new AppleContainerProvider(
+            JsonSerializer.Serialize(new { cliPath }),
+            NullLogger<AppleContainerProvider>.Instance);
+        var firstLine = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var chunks = new List<ExecOutputChunk>();
+
+        var execTask = provider.ExecStreamingAsync(
+            "container-id",
+            "agent-runner",
+            TimeSpan.FromSeconds(5),
+            (chunk, _) =>
+            {
+                chunks.Add(chunk);
+                firstLine.TrySetResult();
+                return ValueTask.CompletedTask;
+            });
+
+        await firstLine.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        execTask.IsCompleted.Should().BeFalse(
+            "the first line must be delivered while the CLI process is still running");
+
+        var result = await execTask;
+
+        result.ExitCode.Should().Be(7);
+        chunks.Should().Contain(new ExecOutputChunk(ExecStreamKind.Stdout, "first"));
+        chunks.Should().Contain(new ExecOutputChunk(ExecStreamKind.Stderr, "warning"));
+        chunks.Should().Contain(new ExecOutputChunk(ExecStreamKind.Stdout, "last"));
+        result.StdOut.Should().Be("first\nlast");
+        result.StdErr.Should().Be("warning");
+    }
+}


### PR DESCRIPTION
## Summary\n- add POST /api/containers/{id}/exec/stream with stdout, stderr, and terminal done SSE events\n- propagate disconnect cancellation and await response writes for backpressure\n- retain the existing buffered and synchronous callback APIs\n- add native live streaming for Apple Containers alongside Docker\n- publish the OpenAPI and API-reference contract\n\n## Validation\n- 2,182 tests passed, 9 skipped across all four test projects\n- targeted streaming tests: 10 passed\n- Spectral: 0 errors\n- changed-file dotnet format verification passed\n\nCloses #279