### PR TITLE
feat: add user-scoped API key management proxy

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -133,7 +133,7 @@ Application code: `containers`
 | WorkspacesController | Delete | `workspace:delete` |
 | ProvidersController | List, Get, Health, CostEstimate | `provider:read` |
 | ProvidersController | Create, Delete | `provider:admin` |
-| ApiKeysController | List, Get, History | `settings:read` |
+| ApiKeysController | List, History | `settings:read` |
 | ApiKeysController | Create, Update, Delete, Validate | `settings:write` |
 
 ### 2.6 Authorization Flow

--- a/docs/api-mcp-cli-parity.md
+++ b/docs/api-mcp-cli-parity.md
@@ -132,7 +132,7 @@ MCP coverage is solid for the introspection-heavy surfaces agents use. CLI is in
 
 | REST | MCP | CLI |
 |---|---|---|
-| `* /api/api-keys*` (8 routes) | ❌ | — |
+| `* /api/apikeys*` (6 routes) | HTTP-only settings transport | — |
 | `GET /api/git-credentials` | `ListGitCredentials` ✅ | — |
 | `POST /api/git-credentials` | `StoreGitCredential` ✅ | — |
 | `DELETE /api/git-credentials/{id}` | ❌ | — |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -169,12 +169,16 @@ non-owner, `400` when the runtime can't publish post-create.
 
 | Method | Endpoint | Permission | Description |
 |--------|----------|------------|-------------|
-| GET | `/api-keys` | settings:read | List API keys |
-| POST | `/api-keys` | settings:write | Create API key |
-| PUT | `/api-keys/{id}` | settings:write | Update API key |
-| DELETE | `/api-keys/{id}` | settings:write | Delete API key |
-| POST | `/api-keys/{id}/validate` | settings:write | Re-validate key |
-| GET | `/api-keys/{id}/history` | settings:read | Get audit trail |
+| GET | `/apikeys` | settings:read | List the current user's masked API-key metadata |
+| POST | `/apikeys` | settings:write | Store a user-scoped key in andy-settings |
+| PUT | `/apikeys/{id}` | settings:write | Update metadata or rotate the key |
+| DELETE | `/apikeys/{id}` | settings:write | Revoke and delete the key registration |
+| POST | `/apikeys/{id}/validate` | settings:write | Re-validate the stored key |
+| GET | `/apikeys/{id}/history` | settings:read | Get newest-first audit history |
+
+Raw provider keys are encrypted by andy-settings and are never stored in the
+andy-containers database or returned by these endpoints. The local
+`ApiKeyRegistrations` table contains masked display metadata only.
 
 ## Git Credentials
 

--- a/docs/migrations/api-keys-to-settings.md
+++ b/docs/migrations/api-keys-to-settings.md
@@ -111,3 +111,17 @@ in step 1.
   andy-settings directly.
 - DbContext: `DbSet<ApiKeyCredential> ApiKeyCredentials` removed.
 - EF migration `20260512173330_DropApiKeyCredentials` drops the table.
+
+## Current management API
+
+Issue #313 later restored the Conductor-facing `/api/apikeys` CRUD and
+validation contract as a thin control-plane facade. It does **not** restore
+`ApiKeyCredentials` or local plaintext/ciphertext storage:
+
+- raw values are written to the user-scoped andy-settings secret
+  `andy.models.providers.<slug>.apiKey`;
+- `ApiKeyRegistrations` contains only the label, provider, model/base URL,
+  masked suffix, and validation timestamps;
+- `ApiKeyAuditRecords` is append-only metadata history and remains queryable
+  after deletion;
+- responses never include the raw value.

--- a/openapi/containers-api.yaml
+++ b/openapi/containers-api.yaml
@@ -246,6 +246,136 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/ConnectionInfo' }
 
+  # --- User-scoped provider API keys (#313) ---
+  # Raw values live in andy-settings; these routes expose only masked
+  # metadata and the Conductor-compatible management contract.
+  /api/apikeys:
+    get:
+      tags: [API Keys]
+      summary: List the current user's provider API keys
+      description: Returns masked metadata only; plaintext key values are never returned.
+      operationId: listApiKeys
+      responses:
+        '200':
+          description: User-scoped API-key entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/ApiKeyEntry' }
+    post:
+      tags: [API Keys]
+      summary: Create a user-scoped provider API key
+      description: Stores the plaintext in andy-settings and persists only masked metadata locally.
+      operationId: createApiKey
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateApiKeyRequest' }
+      responses:
+        '201':
+          description: API key created
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiKeyEntry' }
+        '400':
+          description: Invalid provider, name, value, or base URL
+        '409':
+          description: The user already has a key for this provider
+        '503':
+          description: andy-settings is unavailable or not configured
+
+  /api/apikeys/{id}:
+    put:
+      tags: [API Keys]
+      summary: Update or rotate a provider API key
+      description: Updates display metadata and optionally rotates the user-scoped secret in andy-settings.
+      operationId: updateApiKey
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/UpdateApiKeyRequest' }
+      responses:
+        '200':
+          description: API key updated
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiKeyEntry' }
+        '400':
+          description: Invalid update
+        '404':
+          description: API key not found for the current user
+        '503':
+          description: andy-settings is unavailable
+    delete:
+      tags: [API Keys]
+      summary: Delete a provider API key
+      description: Revokes the user-scoped secret and retains the append-only audit history.
+      operationId: deleteApiKey
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '204':
+          description: API key deleted
+        '404':
+          description: API key not found for the current user
+        '503':
+          description: andy-settings is unavailable
+
+  /api/apikeys/{id}/validate:
+    post:
+      tags: [API Keys]
+      summary: Validate a stored key against its provider
+      description: Uses a lightweight provider models/health endpoint and never logs the key.
+      operationId: validateApiKey
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: Validation completed, including invalid-key results
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiKeyValidationResult' }
+        '404':
+          description: API key not found for the current user
+        '503':
+          description: andy-settings is unavailable
+
+  /api/apikeys/{id}/history:
+    get:
+      tags: [API Keys]
+      summary: Get API-key audit history
+      description: Returns newest-first metadata events, including the final deletion event.
+      operationId: getApiKeyHistory
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: Newest-first audit entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/ApiKeyAuditEntry' }
+        '404':
+          description: No key or retained history exists for the current user
+
   # --- Workspaces ---
   /api/workspaces:
     get:
@@ -1188,6 +1318,73 @@ components:
         exitCode: { type: integer }
         stdout: { type: string }
         stderr: { type: string }
+
+    ApiKeyEntry:
+      type: object
+      required: [id, name, provider, maskedValue]
+      properties:
+        id: { type: string, format: uuid }
+        name: { type: string, maxLength: 128 }
+        provider:
+          type: string
+          enum: [anthropic, openai, google, dashscope, openrouter, ollama, openai-compatible, custom]
+        maskedValue:
+          type: string
+          description: Display-safe value containing at most the provider prefix and final four characters.
+        isValid: { type: boolean, nullable: true }
+        createdAt: { type: string, format: date-time, nullable: true }
+        lastUsedAt: { type: string, format: date-time, nullable: true }
+        lastValidatedAt: { type: string, format: date-time, nullable: true }
+        model: { type: string, nullable: true }
+        baseURL: { type: string, format: uri, nullable: true }
+
+    CreateApiKeyRequest:
+      type: object
+      required: [name, provider, value]
+      properties:
+        name: { type: string, minLength: 1, maxLength: 128 }
+        provider:
+          type: string
+          enum: [anthropic, openai, google, dashscope, openrouter, ollama, openai-compatible, custom]
+        value:
+          type: string
+          format: password
+          minLength: 1
+          writeOnly: true
+        model: { type: string, nullable: true }
+        baseURL: { type: string, format: uri, nullable: true }
+
+    UpdateApiKeyRequest:
+      type: object
+      properties:
+        name: { type: string, minLength: 1, maxLength: 128 }
+        value:
+          type: string
+          format: password
+          minLength: 1
+          writeOnly: true
+        model: { type: string, nullable: true }
+        baseURL: { type: string, format: uri, nullable: true }
+
+    ApiKeyValidationResult:
+      type: object
+      required: [isValid]
+      properties:
+        isValid: { type: boolean }
+        message: { type: string, nullable: true }
+        quotaRemaining: { type: integer, nullable: true }
+
+    ApiKeyAuditEntry:
+      type: object
+      required: [id, keyId, kind, occurredAt]
+      properties:
+        id: { type: string, format: uuid }
+        keyId: { type: string, format: uuid }
+        kind:
+          type: string
+          enum: [created, updated, validated, used, deleted]
+        occurredAt: { type: string, format: date-time }
+        detail: { type: string, nullable: true }
 
     ConnectionInfo:
       type: object

--- a/src/Andy.Containers.Api/Controllers/ApiKeysController.cs
+++ b/src/Andy.Containers.Api/Controllers/ApiKeysController.cs
@@ -1,0 +1,224 @@
+using Andy.Containers.Api.Services;
+using Andy.Containers.Models;
+using Andy.Rbac.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Andy.Containers.Api.Controllers;
+
+[ApiController]
+[Route("api/apikeys")]
+[Authorize]
+public sealed class ApiKeysController : ControllerBase
+{
+    private readonly IApiKeyService _apiKeys;
+    private readonly ICurrentUserService _currentUser;
+
+    public ApiKeysController(
+        IApiKeyService apiKeys,
+        ICurrentUserService currentUser)
+    {
+        _apiKeys = apiKeys;
+        _currentUser = currentUser;
+    }
+
+    [HttpGet]
+    [RequirePermission("settings:read")]
+    public async Task<IActionResult> List(CancellationToken ct)
+    {
+        var entries = await _apiKeys.ListAsync(_currentUser.GetUserId(), ct);
+        return Ok(entries.Select(ToDto));
+    }
+
+    [HttpPost]
+    [RequirePermission("settings:write")]
+    public async Task<IActionResult> Create(
+        [FromBody] CreateApiKeyRequest request,
+        CancellationToken ct)
+    {
+        try
+        {
+            var entry = await _apiKeys.CreateAsync(
+                _currentUser.GetUserId(),
+                new CreateApiKeyCommand(
+                    request.Name,
+                    request.Provider,
+                    request.Value,
+                    request.Model,
+                    request.BaseURL),
+                ct);
+            return StatusCode(StatusCodes.Status201Created, ToDto(entry));
+        }
+        catch (ApiKeyValidationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+        catch (ApiKeyConflictException ex)
+        {
+            return Conflict(new { error = ex.Message });
+        }
+        catch (ApiKeySecretStoreUnavailableException ex)
+        {
+            return StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                new { error = ex.Message });
+        }
+    }
+
+    [HttpPut("{id:guid}")]
+    [RequirePermission("settings:write")]
+    public async Task<IActionResult> Update(
+        Guid id,
+        [FromBody] UpdateApiKeyRequest request,
+        CancellationToken ct)
+    {
+        try
+        {
+            var entry = await _apiKeys.UpdateAsync(
+                id,
+                _currentUser.GetUserId(),
+                new UpdateApiKeyCommand(
+                    request.Name,
+                    request.Value,
+                    request.Model,
+                    request.BaseURL),
+                ct);
+            return Ok(ToDto(entry));
+        }
+        catch (ApiKeyNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (ApiKeyValidationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+        catch (ApiKeySecretStoreUnavailableException ex)
+        {
+            return StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                new { error = ex.Message });
+        }
+    }
+
+    [HttpDelete("{id:guid}")]
+    [RequirePermission("settings:write")]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        try
+        {
+            await _apiKeys.DeleteAsync(id, _currentUser.GetUserId(), ct);
+            return NoContent();
+        }
+        catch (ApiKeyNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (ApiKeySecretStoreUnavailableException ex)
+        {
+            return StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                new { error = ex.Message });
+        }
+    }
+
+    [HttpPost("{id:guid}/validate")]
+    [RequirePermission("settings:write")]
+    public async Task<IActionResult> Validate(Guid id, CancellationToken ct)
+    {
+        try
+        {
+            var result = await _apiKeys.ValidateAsync(
+                id,
+                _currentUser.GetUserId(),
+                ct);
+            return Ok(new ApiKeyValidationResult(
+                result.IsValid,
+                result.Message,
+                result.QuotaRemaining));
+        }
+        catch (ApiKeyNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (ApiKeySecretStoreUnavailableException ex)
+        {
+            return StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                new { error = ex.Message });
+        }
+    }
+
+    [HttpGet("{id:guid}/history")]
+    [RequirePermission("settings:read")]
+    public async Task<IActionResult> History(Guid id, CancellationToken ct)
+    {
+        try
+        {
+            var history = await _apiKeys.HistoryAsync(
+                id,
+                _currentUser.GetUserId(),
+                ct);
+            return Ok(history.Select(a => new ApiKeyAuditEntry(
+                a.Id,
+                a.KeyId,
+                a.Kind,
+                a.OccurredAt,
+                a.Detail)));
+        }
+        catch (ApiKeyNotFoundException)
+        {
+            return NotFound();
+        }
+    }
+
+    private static ApiKeyEntry ToDto(ApiKeyRegistration entry)
+        => new(
+            entry.Id,
+            entry.Name,
+            entry.Provider,
+            entry.MaskedValue,
+            entry.IsValid,
+            entry.CreatedAt,
+            entry.LastUsedAt,
+            entry.LastValidatedAt,
+            entry.Model,
+            entry.BaseUrl);
+}
+
+public sealed record ApiKeyEntry(
+    Guid Id,
+    string Name,
+    string Provider,
+    string MaskedValue,
+    bool? IsValid,
+    DateTimeOffset? CreatedAt,
+    DateTimeOffset? LastUsedAt,
+    DateTimeOffset? LastValidatedAt,
+    string? Model,
+    string? BaseURL);
+
+public sealed record CreateApiKeyRequest(
+    string Name,
+    string Provider,
+    string Value,
+    string? Model = null,
+    string? BaseURL = null);
+
+public sealed record UpdateApiKeyRequest(
+    string? Name = null,
+    string? Value = null,
+    string? Model = null,
+    string? BaseURL = null);
+
+public sealed record ApiKeyValidationResult(
+    bool IsValid,
+    string? Message,
+    int? QuotaRemaining);
+
+public sealed record ApiKeyAuditEntry(
+    Guid Id,
+    Guid KeyId,
+    string Kind,
+    DateTimeOffset OccurredAt,
+    string? Detail);

--- a/src/Andy.Containers.Api/Program.cs
+++ b/src/Andy.Containers.Api/Program.cs
@@ -173,6 +173,18 @@ try
         .SetApplicationName("andy-containers")
         .PersistKeysToDbContext<ContainersDbContext>();
     builder.Services.AddScoped<IGitCredentialService, GitCredentialService>();
+    builder.Services.AddScoped<IApiKeyService, ApiKeyService>();
+    builder.Services.AddSingleton<IApiKeyValidator, ApiKeyValidator>();
+    builder.Services.AddHttpClient(ApiKeyValidator.HttpClientName, client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(10);
+        })
+        .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+        {
+            // Provider validation must not follow an attacker-controlled
+            // redirect to a second internal endpoint.
+            AllowAutoRedirect = false,
+        });
     // Shared git-credential materialiser: used by the provisioning worker
     // (create-time) AND the headless runner (run-dispatch) so a
     // sourceControl.github.pat saved after a container exists still reaches it.
@@ -513,10 +525,12 @@ try
             });
         }
         builder.Services.AddSingleton<ISourceControlSecretResolver, AndySettingsHttpClient>();
+        builder.Services.AddSingleton<IApiKeySecretStore, AndySettingsApiKeySecretStore>();
     }
     else
     {
         builder.Services.AddSingleton<ISourceControlSecretResolver, NullSourceControlSecretResolver>();
+        builder.Services.AddSingleton<IApiKeySecretStore, UnavailableApiKeySecretStore>();
     }
 
     builder.Services.AddSingleton<IHeadlessConfigBuilder, HeadlessConfigBuilder>();

--- a/src/Andy.Containers.Api/Services/ApiKeyProviderCatalog.cs
+++ b/src/Andy.Containers.Api/Services/ApiKeyProviderCatalog.cs
@@ -1,0 +1,239 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Andy.Containers.Api.Services;
+
+public static class ApiKeyProviderCatalog
+{
+    private static readonly IReadOnlyDictionary<string, ApiKeyProviderDefinition> Providers =
+        new Dictionary<string, ApiKeyProviderDefinition>(StringComparer.Ordinal)
+        {
+            ["anthropic"] = new(
+                "anthropic",
+                "andy.models.providers.anthropic.apiKey",
+                new Uri("https://api.anthropic.com/v1/"),
+                "models",
+                ApiKeyAuthentication.Anthropic),
+            ["openai"] = new(
+                "openai",
+                "andy.models.providers.openai.apiKey",
+                new Uri("https://api.openai.com/v1/"),
+                "models",
+                ApiKeyAuthentication.Bearer),
+            ["google"] = new(
+                "google",
+                "andy.models.providers.google.apiKey",
+                new Uri("https://generativelanguage.googleapis.com/v1beta/"),
+                "models",
+                ApiKeyAuthentication.Google),
+            ["dashscope"] = new(
+                "dashscope",
+                "andy.models.providers.alibaba.apiKey",
+                new Uri("https://dashscope.aliyuncs.com/compatible-mode/v1/"),
+                "models",
+                ApiKeyAuthentication.Bearer),
+            ["openrouter"] = new(
+                "openrouter",
+                "andy.models.providers.openrouter.apiKey",
+                new Uri("https://openrouter.ai/api/v1/"),
+                "models",
+                ApiKeyAuthentication.Bearer),
+            ["ollama"] = new(
+                "ollama",
+                "andy.models.providers.ollama.apiKey",
+                new Uri("http://localhost:11434/"),
+                "api/tags",
+                ApiKeyAuthentication.None),
+            ["openai-compatible"] = new(
+                "openai-compatible",
+                "andy.models.providers.openai-compatible.apiKey",
+                null,
+                "models",
+                ApiKeyAuthentication.Bearer),
+            ["custom"] = new(
+                "custom",
+                "andy.models.providers.openai-compatible-generic.apiKey",
+                null,
+                "models",
+                ApiKeyAuthentication.Bearer),
+        };
+
+    public static bool TryGet(
+        string? provider,
+        out ApiKeyProviderDefinition definition)
+    {
+        var normalized = provider?.Trim().ToLowerInvariant();
+        return Providers.TryGetValue(normalized ?? string.Empty, out definition!);
+    }
+
+    public static IReadOnlyCollection<string> SupportedProviders => Providers.Keys.ToArray();
+}
+
+public sealed record ApiKeyProviderDefinition(
+    string WireName,
+    string SecretDefinitionKey,
+    Uri? DefaultBaseUri,
+    string ValidationPath,
+    ApiKeyAuthentication Authentication);
+
+public enum ApiKeyAuthentication
+{
+    Bearer,
+    Anthropic,
+    Google,
+    None,
+}
+
+public interface IApiKeyValidator
+{
+    Task<ApiKeyValidationOutcome> ValidateAsync(
+        ApiKeyProviderDefinition provider,
+        string value,
+        string? baseUrl,
+        CancellationToken ct = default);
+}
+
+public sealed record ApiKeyValidationOutcome(
+    bool IsValid,
+    string? Message,
+    int? QuotaRemaining);
+
+public sealed class ApiKeyValidator : IApiKeyValidator
+{
+    public const string HttpClientName = "api-key-validation";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public ApiKeyValidator(IHttpClientFactory httpClientFactory)
+        => _httpClientFactory = httpClientFactory;
+
+    public async Task<ApiKeyValidationOutcome> ValidateAsync(
+        ApiKeyProviderDefinition provider,
+        string value,
+        string? baseUrl,
+        CancellationToken ct = default)
+    {
+        var endpoint = BuildValidationUri(provider, baseUrl);
+        using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
+        ApplyAuthentication(request, provider.Authentication, value);
+
+        try
+        {
+            var http = _httpClientFactory.CreateClient(HttpClientName);
+            using var response = await http.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                ct);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return new ApiKeyValidationOutcome(
+                    true,
+                    "Key is functional.",
+                    ReadQuota(response.Headers));
+            }
+
+            if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+            {
+                return new ApiKeyValidationOutcome(
+                    false,
+                    "Provider rejected the API key.",
+                    null);
+            }
+
+            return new ApiKeyValidationOutcome(
+                false,
+                $"Provider validation returned HTTP {(int)response.StatusCode}.",
+                null);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            return new ApiKeyValidationOutcome(
+                false,
+                "Provider validation could not be completed.",
+                null);
+        }
+    }
+
+    public static Uri BuildValidationUri(
+        ApiKeyProviderDefinition provider,
+        string? baseUrl)
+    {
+        Uri? baseUri;
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            baseUri = provider.DefaultBaseUri;
+        }
+        else if (!Uri.TryCreate(baseUrl.Trim(), UriKind.Absolute, out baseUri) ||
+                 baseUri.Scheme is not ("http" or "https") ||
+                 !string.IsNullOrEmpty(baseUri.UserInfo) ||
+                 !string.IsNullOrEmpty(baseUri.Query) ||
+                 !string.IsNullOrEmpty(baseUri.Fragment))
+        {
+            throw new ApiKeyValidationException(
+                "BaseURL must be an absolute HTTP(S) URL without credentials, query, or fragment.");
+        }
+
+        if (baseUri is null)
+        {
+            throw new ApiKeyValidationException(
+                $"BaseURL is required for provider '{provider.WireName}'.");
+        }
+
+        var normalized = new Uri(baseUri.AbsoluteUri.TrimEnd('/') + "/");
+        return new Uri(normalized, provider.ValidationPath);
+    }
+
+    private static void ApplyAuthentication(
+        HttpRequestMessage request,
+        ApiKeyAuthentication authentication,
+        string value)
+    {
+        switch (authentication)
+        {
+            case ApiKeyAuthentication.Bearer:
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", value);
+                break;
+            case ApiKeyAuthentication.Anthropic:
+                request.Headers.TryAddWithoutValidation("x-api-key", value);
+                request.Headers.TryAddWithoutValidation("anthropic-version", "2023-06-01");
+                break;
+            case ApiKeyAuthentication.Google:
+                request.Headers.TryAddWithoutValidation("x-goog-api-key", value);
+                break;
+            case ApiKeyAuthentication.None:
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(authentication),
+                    authentication,
+                    null);
+        }
+    }
+
+    private static int? ReadQuota(HttpResponseHeaders headers)
+    {
+        foreach (var name in new[]
+                 {
+                     "x-ratelimit-remaining-requests",
+                     "x-ratelimit-remaining",
+                 })
+        {
+            if (headers.TryGetValues(name, out var values) &&
+                int.TryParse(values.FirstOrDefault(), out var remaining))
+            {
+                return remaining;
+            }
+        }
+        return null;
+    }
+}
+
+public sealed class ApiKeyValidationException : Exception
+{
+    public ApiKeyValidationException(string message) : base(message) { }
+}

--- a/src/Andy.Containers.Api/Services/ApiKeyService.cs
+++ b/src/Andy.Containers.Api/Services/ApiKeyService.cs
@@ -1,0 +1,424 @@
+using Andy.Containers.Infrastructure.Data;
+using Andy.Containers.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Containers.Api.Services;
+
+public interface IApiKeyService
+{
+    Task<IReadOnlyList<ApiKeyRegistration>> ListAsync(
+        string ownerId,
+        CancellationToken ct = default);
+
+    Task<ApiKeyRegistration> CreateAsync(
+        string ownerId,
+        CreateApiKeyCommand command,
+        CancellationToken ct = default);
+
+    Task<ApiKeyRegistration> UpdateAsync(
+        Guid id,
+        string ownerId,
+        UpdateApiKeyCommand command,
+        CancellationToken ct = default);
+
+    Task DeleteAsync(Guid id, string ownerId, CancellationToken ct = default);
+
+    Task<ApiKeyValidationOutcome> ValidateAsync(
+        Guid id,
+        string ownerId,
+        CancellationToken ct = default);
+
+    Task<IReadOnlyList<ApiKeyAuditRecord>> HistoryAsync(
+        Guid id,
+        string ownerId,
+        CancellationToken ct = default);
+}
+
+public sealed record CreateApiKeyCommand(
+    string Name,
+    string Provider,
+    string Value,
+    string? Model,
+    string? BaseUrl);
+
+public sealed record UpdateApiKeyCommand(
+    string? Name,
+    string? Value,
+    string? Model,
+    string? BaseUrl);
+
+public sealed class ApiKeyService : IApiKeyService
+{
+    private readonly ContainersDbContext _db;
+    private readonly IApiKeySecretStore _secretStore;
+    private readonly IApiKeyValidator _validator;
+
+    public ApiKeyService(
+        ContainersDbContext db,
+        IApiKeySecretStore secretStore,
+        IApiKeyValidator validator)
+    {
+        _db = db;
+        _secretStore = secretStore;
+        _validator = validator;
+    }
+
+    public async Task<IReadOnlyList<ApiKeyRegistration>> ListAsync(
+        string ownerId,
+        CancellationToken ct = default)
+        => await _db.ApiKeyRegistrations
+            .AsNoTracking()
+            .Where(k => k.OwnerId == ownerId)
+            .OrderBy(k => k.Provider)
+            .ThenBy(k => k.Name)
+            .ToListAsync(ct);
+
+    public async Task<ApiKeyRegistration> CreateAsync(
+        string ownerId,
+        CreateApiKeyCommand command,
+        CancellationToken ct = default)
+    {
+        var name = ValidateName(command.Name);
+        var value = ValidateValue(command.Value);
+        var provider = ResolveProvider(command.Provider);
+        var baseUrl = NormalizeOptional(command.BaseUrl);
+        _ = ApiKeyValidator.BuildValidationUri(provider, baseUrl);
+
+        if (await _db.ApiKeyRegistrations.AnyAsync(
+                k => k.OwnerId == ownerId && k.Provider == provider.WireName,
+                ct))
+        {
+            throw new ApiKeyConflictException(
+                $"A key for provider '{provider.WireName}' already exists.");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var registration = new ApiKeyRegistration
+        {
+            OwnerId = ownerId,
+            Name = name,
+            Provider = provider.WireName,
+            SecretDefinitionKey = provider.SecretDefinitionKey,
+            MaskedValue = Mask(value),
+            Model = NormalizeOptional(command.Model),
+            BaseUrl = baseUrl,
+            CreatedAt = now,
+        };
+
+        var previousValue = await _secretStore.GetAsync(
+            provider.SecretDefinitionKey,
+            ownerId,
+            ct);
+        await _secretStore.SetAsync(
+            provider.SecretDefinitionKey,
+            ownerId,
+            value,
+            ct);
+
+        _db.ApiKeyRegistrations.Add(registration);
+        AppendAudit(
+            registration.Id,
+            ownerId,
+            "created",
+            $"Provider: {provider.WireName}.",
+            now);
+
+        try
+        {
+            await _db.SaveChangesAsync(ct);
+        }
+        catch
+        {
+            await RestoreSecretAsync(
+                provider.SecretDefinitionKey,
+                ownerId,
+                previousValue,
+                CancellationToken.None);
+            throw;
+        }
+
+        return registration;
+    }
+
+    public async Task<ApiKeyRegistration> UpdateAsync(
+        Guid id,
+        string ownerId,
+        UpdateApiKeyCommand command,
+        CancellationToken ct = default)
+    {
+        var registration = await FindAsync(id, ownerId, ct);
+        var provider = ResolveProvider(registration.Provider);
+        var newName = command.Name is null
+            ? registration.Name
+            : ValidateName(command.Name);
+        var newBaseUrl = command.BaseUrl is null
+            ? registration.BaseUrl
+            : NormalizeOptional(command.BaseUrl);
+        _ = ApiKeyValidator.BuildValidationUri(provider, newBaseUrl);
+
+        string? previousValue = null;
+        var keyChanged = command.Value is not null;
+        if (keyChanged)
+        {
+            var value = ValidateValue(command.Value!);
+            previousValue = await _secretStore.GetAsync(
+                registration.SecretDefinitionKey,
+                ownerId,
+                ct);
+            await _secretStore.SetAsync(
+                registration.SecretDefinitionKey,
+                ownerId,
+                value,
+                ct);
+            registration.MaskedValue = Mask(value);
+            registration.IsValid = null;
+            registration.LastValidatedAt = null;
+        }
+
+        registration.Name = newName;
+        registration.Model = command.Model is null
+            ? registration.Model
+            : NormalizeOptional(command.Model);
+        registration.BaseUrl = newBaseUrl;
+        registration.UpdatedAt = DateTimeOffset.UtcNow;
+        AppendAudit(
+            registration.Id,
+            ownerId,
+            "updated",
+            keyChanged ? "Key rotated and metadata updated." : "Metadata updated.",
+            registration.UpdatedAt.Value);
+
+        try
+        {
+            await _db.SaveChangesAsync(ct);
+        }
+        catch
+        {
+            if (keyChanged)
+            {
+                await RestoreSecretAsync(
+                    registration.SecretDefinitionKey,
+                    ownerId,
+                    previousValue,
+                    CancellationToken.None);
+            }
+            throw;
+        }
+
+        return registration;
+    }
+
+    public async Task DeleteAsync(
+        Guid id,
+        string ownerId,
+        CancellationToken ct = default)
+    {
+        var registration = await FindAsync(id, ownerId, ct);
+        var previousValue = await _secretStore.GetAsync(
+            registration.SecretDefinitionKey,
+            ownerId,
+            ct);
+        await _secretStore.ClearAsync(
+            registration.SecretDefinitionKey,
+            ownerId,
+            ct);
+
+        _db.ApiKeyRegistrations.Remove(registration);
+        AppendAudit(
+            registration.Id,
+            ownerId,
+            "deleted",
+            $"Provider: {registration.Provider}.",
+            DateTimeOffset.UtcNow);
+
+        try
+        {
+            await _db.SaveChangesAsync(ct);
+        }
+        catch
+        {
+            await RestoreSecretAsync(
+                registration.SecretDefinitionKey,
+                ownerId,
+                previousValue,
+                CancellationToken.None);
+            throw;
+        }
+    }
+
+    public async Task<ApiKeyValidationOutcome> ValidateAsync(
+        Guid id,
+        string ownerId,
+        CancellationToken ct = default)
+    {
+        var registration = await FindAsync(id, ownerId, ct);
+        var provider = ResolveProvider(registration.Provider);
+        var value = await _secretStore.GetAsync(
+            registration.SecretDefinitionKey,
+            ownerId,
+            ct);
+
+        var outcome = value is null
+            ? new ApiKeyValidationOutcome(
+                false,
+                "No stored key is available for this provider.",
+                null)
+            : await _validator.ValidateAsync(
+                provider,
+                value,
+                registration.BaseUrl,
+                ct);
+
+        var now = DateTimeOffset.UtcNow;
+        registration.IsValid = outcome.IsValid;
+        registration.LastValidatedAt = now;
+        registration.UpdatedAt = now;
+        AppendAudit(
+            registration.Id,
+            ownerId,
+            "validated",
+            outcome.IsValid
+                ? "Validation succeeded."
+                : $"Validation failed: {outcome.Message}",
+            now);
+        await _db.SaveChangesAsync(ct);
+        return outcome;
+    }
+
+    public async Task<IReadOnlyList<ApiKeyAuditRecord>> HistoryAsync(
+        Guid id,
+        string ownerId,
+        CancellationToken ct = default)
+    {
+        var hasRegistration = await _db.ApiKeyRegistrations
+            .AsNoTracking()
+            .AnyAsync(k => k.Id == id && k.OwnerId == ownerId, ct);
+        var hasHistory = await _db.ApiKeyAuditRecords
+            .AsNoTracking()
+            .AnyAsync(a => a.KeyId == id && a.OwnerId == ownerId, ct);
+        if (!hasRegistration && !hasHistory)
+        {
+            throw new ApiKeyNotFoundException();
+        }
+
+        return await _db.ApiKeyAuditRecords
+            .AsNoTracking()
+            .Where(a => a.KeyId == id && a.OwnerId == ownerId)
+            .OrderByDescending(a => a.OccurredAt)
+            .ThenByDescending(a => a.Id)
+            .ToListAsync(ct);
+    }
+
+    private async Task<ApiKeyRegistration> FindAsync(
+        Guid id,
+        string ownerId,
+        CancellationToken ct)
+        => await _db.ApiKeyRegistrations
+               .FirstOrDefaultAsync(k => k.Id == id && k.OwnerId == ownerId, ct)
+           ?? throw new ApiKeyNotFoundException();
+
+    private void AppendAudit(
+        Guid keyId,
+        string ownerId,
+        string kind,
+        string? detail,
+        DateTimeOffset occurredAt)
+        => _db.ApiKeyAuditRecords.Add(new ApiKeyAuditRecord
+        {
+            KeyId = keyId,
+            OwnerId = ownerId,
+            Kind = kind,
+            Detail = detail,
+            OccurredAt = occurredAt,
+        });
+
+    private async Task RestoreSecretAsync(
+        string definitionKey,
+        string ownerId,
+        string? previousValue,
+        CancellationToken ct)
+    {
+        if (previousValue is null)
+        {
+            await _secretStore.ClearAsync(definitionKey, ownerId, ct);
+        }
+        else
+        {
+            await _secretStore.SetAsync(
+                definitionKey,
+                ownerId,
+                previousValue,
+                ct);
+        }
+    }
+
+    private static ApiKeyProviderDefinition ResolveProvider(string provider)
+    {
+        if (ApiKeyProviderCatalog.TryGet(provider, out var definition))
+        {
+            return definition;
+        }
+
+        throw new ApiKeyValidationException(
+            $"Unsupported provider. Expected one of: " +
+            $"{string.Join(", ", ApiKeyProviderCatalog.SupportedProviders)}.");
+    }
+
+    private static string ValidateName(string name)
+    {
+        var normalized = name.Trim();
+        if (normalized.Length is < 1 or > 128)
+        {
+            throw new ApiKeyValidationException(
+                "Name must be between 1 and 128 characters.");
+        }
+        return normalized;
+    }
+
+    private static string ValidateValue(string value)
+    {
+        var normalized = value.Trim();
+        if (normalized.Length is < 1 or > 16_384)
+        {
+            throw new ApiKeyValidationException(
+                "Value must be between 1 and 16384 characters.");
+        }
+        return normalized;
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrEmpty(normalized) ? null : normalized;
+    }
+
+    internal static string Mask(string rawValue)
+    {
+        var trimmed = rawValue.Trim();
+        var suffix = trimmed.Length >= 4 ? trimmed[^4..] : trimmed;
+        var prefix = string.Empty;
+
+        var dash = trimmed.IndexOf('-');
+        if (dash is >= 0 and <= 4)
+        {
+            prefix = trimmed[..(dash + 1)];
+        }
+        else
+        {
+            var underscore = trimmed.IndexOf('_');
+            if (underscore is >= 0 and <= 4)
+            {
+                prefix = trimmed[..(underscore + 1)];
+            }
+        }
+
+        return $"{prefix}••••••••{suffix}";
+    }
+}
+
+public sealed class ApiKeyNotFoundException : Exception;
+
+public sealed class ApiKeyConflictException : Exception
+{
+    public ApiKeyConflictException(string message) : base(message) { }
+}

--- a/src/Andy.Containers.Api/Services/IApiKeySecretStore.cs
+++ b/src/Andy.Containers.Api/Services/IApiKeySecretStore.cs
@@ -1,0 +1,187 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Andy.Containers.Api.Services;
+
+/// <summary>
+/// User-scoped provider-key storage. Implementations must never log or expose
+/// plaintext values beyond the trusted service boundary.
+/// </summary>
+public interface IApiKeySecretStore
+{
+    Task SetAsync(
+        string definitionKey,
+        string ownerId,
+        string value,
+        CancellationToken ct = default);
+
+    Task<string?> GetAsync(
+        string definitionKey,
+        string ownerId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Revokes the scoped secret without deleting other users' or machine
+    /// scopes. andy-settings' current DELETE route is definition-wide, so the
+    /// safe scoped operation is rotation to an empty value.
+    /// </summary>
+    Task ClearAsync(
+        string definitionKey,
+        string ownerId,
+        CancellationToken ct = default);
+}
+
+public sealed class AndySettingsApiKeySecretStore : IApiKeySecretStore
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public AndySettingsApiKeySecretStore(IHttpClientFactory httpClientFactory)
+        => _httpClientFactory = httpClientFactory;
+
+    public Task SetAsync(
+        string definitionKey,
+        string ownerId,
+        string value,
+        CancellationToken ct = default)
+        => WriteAsync(definitionKey, ownerId, value, ct);
+
+    public Task ClearAsync(
+        string definitionKey,
+        string ownerId,
+        CancellationToken ct = default)
+        => WriteAsync(definitionKey, ownerId, string.Empty, ct);
+
+    public async Task<string?> GetAsync(
+        string definitionKey,
+        string ownerId,
+        CancellationToken ct = default)
+    {
+        var http = _httpClientFactory.CreateClient(AndySettingsHttpClient.HttpClientName);
+        var path =
+            $"api/secrets/{Uri.EscapeDataString(definitionKey)}" +
+            $"?scopeType=User&scopeId={Uri.EscapeDataString(ownerId)}";
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await http.GetAsync(path, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            throw new ApiKeySecretStoreUnavailableException(
+                "The API-key secret store is unavailable.", ex);
+        }
+
+        using (response)
+        {
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw Unavailable(response.StatusCode);
+            }
+
+            try
+            {
+                var payload = await response.Content
+                    .ReadFromJsonAsync<SecretValueResponse>(cancellationToken: ct);
+                return string.IsNullOrWhiteSpace(payload?.Value) ? null : payload.Value;
+            }
+            catch (Exception ex) when (ex is JsonException or NotSupportedException)
+            {
+                throw new ApiKeySecretStoreUnavailableException(
+                    "The API-key secret store returned an invalid response.", ex);
+            }
+        }
+    }
+
+    private async Task WriteAsync(
+        string definitionKey,
+        string ownerId,
+        string value,
+        CancellationToken ct)
+    {
+        var http = _httpClientFactory.CreateClient(AndySettingsHttpClient.HttpClientName);
+        var path = $"api/secrets/{Uri.EscapeDataString(definitionKey)}";
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await http.PostAsJsonAsync(
+                path,
+                new
+                {
+                    scopeType = "User",
+                    scopeId = ownerId,
+                    value,
+                },
+                ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            throw new ApiKeySecretStoreUnavailableException(
+                "The API-key secret store is unavailable.", ex);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                throw Unavailable(response.StatusCode);
+            }
+        }
+    }
+
+    private static ApiKeySecretStoreUnavailableException Unavailable(HttpStatusCode status)
+        => new(
+            "The API-key secret store rejected the request " +
+            $"with HTTP {(int)status} ({status}).");
+
+    private sealed record SecretValueResponse(string? DefinitionKey, string? Value);
+}
+
+public sealed class UnavailableApiKeySecretStore : IApiKeySecretStore
+{
+    public Task SetAsync(
+        string definitionKey,
+        string ownerId,
+        string value,
+        CancellationToken ct = default)
+        => Task.FromException(Unavailable());
+
+    public Task<string?> GetAsync(
+        string definitionKey,
+        string ownerId,
+        CancellationToken ct = default)
+        => Task.FromException<string?>(Unavailable());
+
+    public Task ClearAsync(
+        string definitionKey,
+        string ownerId,
+        CancellationToken ct = default)
+        => Task.FromException(Unavailable());
+
+    private static ApiKeySecretStoreUnavailableException Unavailable()
+        => new(
+            "API-key management requires AndySettings:ApiBaseUrl to be configured.");
+}
+
+public sealed class ApiKeySecretStoreUnavailableException : Exception
+{
+    public ApiKeySecretStoreUnavailableException(string message) : base(message) { }
+
+    public ApiKeySecretStoreUnavailableException(string message, Exception inner)
+        : base(message, inner) { }
+}

--- a/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
+++ b/src/Andy.Containers.Infrastructure/Data/ContainersDbContext.cs
@@ -33,10 +33,12 @@ public class ContainersDbContext : DbContext, IDataProtectionKeyContext
     public DbSet<ContainerGitRepository> ContainerGitRepositories => Set<ContainerGitRepository>();
     public DbSet<GitCredential> GitCredentials => Set<GitCredential>();
     // ApiKeyCredentials retired in rivoli-ai/conductor#946 (M1.5.4).
-    // Provider keys now live in andy-settings under
-    // `andy.models.providers.<slug>.apiKey`; per-tool routing in
-    // ContainerOrchestrationService + CodeAssistantProxyRouting (#944)
-    // brings them into the container via the andy-models proxy.
+    // Raw provider keys remain in andy-settings under
+    // `andy.models.providers.<slug>.apiKey`. #313 adds only user-scoped
+    // display metadata and audit rows here; plaintext never returns to this
+    // database.
+    public DbSet<ApiKeyRegistration> ApiKeyRegistrations => Set<ApiKeyRegistration>();
+    public DbSet<ApiKeyAuditRecord> ApiKeyAuditRecords => Set<ApiKeyAuditRecord>();
     public DbSet<Organization> Organizations => Set<Organization>();
     public DbSet<Team> Teams => Set<Team>();
     public DbSet<ImageBuildRecord> ImageBuildRecords => Set<ImageBuildRecord>();
@@ -293,7 +295,29 @@ public class ContainersDbContext : DbContext, IDataProtectionKeyContext
             e.HasIndex(c => new { c.OwnerId, c.Label }).IsUnique();
         });
 
-        // ApiKeyCredential mapping retired with the table — see #946.
+        // API-key metadata only. Raw values live in andy-settings.
+        modelBuilder.Entity<ApiKeyRegistration>(e =>
+        {
+            e.HasKey(k => k.Id);
+            e.Property(k => k.OwnerId).HasMaxLength(256);
+            e.Property(k => k.Name).HasMaxLength(128);
+            e.Property(k => k.Provider).HasMaxLength(64);
+            e.Property(k => k.SecretDefinitionKey).HasMaxLength(256);
+            e.Property(k => k.MaskedValue).HasMaxLength(64);
+            e.Property(k => k.Model).HasMaxLength(256);
+            e.Property(k => k.BaseUrl).HasMaxLength(2048);
+            e.HasIndex(k => k.OwnerId);
+            e.HasIndex(k => new { k.OwnerId, k.Provider }).IsUnique();
+        });
+
+        modelBuilder.Entity<ApiKeyAuditRecord>(e =>
+        {
+            e.HasKey(a => a.Id);
+            e.Property(a => a.OwnerId).HasMaxLength(256);
+            e.Property(a => a.Kind).HasMaxLength(32);
+            e.Property(a => a.Detail).HasMaxLength(1024);
+            e.HasIndex(a => new { a.OwnerId, a.KeyId, a.OccurredAt });
+        });
 
         // Organization
         modelBuilder.Entity<Organization>(e =>

--- a/src/Andy.Containers.Infrastructure/Migrations/20260724175605_AddApiKeyRegistrations.Designer.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260724175605_AddApiKeyRegistrations.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Andy.Containers.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Containers.Infrastructure.Migrations
 {
     [DbContext(typeof(ContainersDbContext))]
-    partial class ContainersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724175605_AddApiKeyRegistrations")]
+    partial class AddApiKeyRegistrations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Containers.Infrastructure/Migrations/20260724175605_AddApiKeyRegistrations.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260724175605_AddApiKeyRegistrations.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Containers.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddApiKeyRegistrations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ApiKeyAuditRecords",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    KeyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Kind = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    OccurredAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Detail = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ApiKeyAuditRecords", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ApiKeyRegistrations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Name = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Provider = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    SecretDefinitionKey = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    MaskedValue = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Model = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    BaseUrl = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: true),
+                    IsValid = table.Column<bool>(type: "boolean", nullable: true),
+                    LastValidatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    LastUsedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ApiKeyRegistrations", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApiKeyAuditRecords_OwnerId_KeyId_OccurredAt",
+                table: "ApiKeyAuditRecords",
+                columns: new[] { "OwnerId", "KeyId", "OccurredAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApiKeyRegistrations_OwnerId",
+                table: "ApiKeyRegistrations",
+                column: "OwnerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApiKeyRegistrations_OwnerId_Provider",
+                table: "ApiKeyRegistrations",
+                columns: new[] { "OwnerId", "Provider" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ApiKeyAuditRecords");
+
+            migrationBuilder.DropTable(
+                name: "ApiKeyRegistrations");
+        }
+    }
+}

--- a/src/Andy.Containers/Models/ApiKeyRegistration.cs
+++ b/src/Andy.Containers/Models/ApiKeyRegistration.cs
@@ -1,0 +1,38 @@
+namespace Andy.Containers.Models;
+
+/// <summary>
+/// User-scoped metadata for a provider API key. The plaintext secret is not
+/// stored in this database; <see cref="SecretDefinitionKey"/> points to the
+/// encrypted, user-scoped value in andy-settings.
+/// </summary>
+public sealed class ApiKeyRegistration
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public required string OwnerId { get; set; }
+    public required string Name { get; set; }
+    public required string Provider { get; set; }
+    public required string SecretDefinitionKey { get; set; }
+    public required string MaskedValue { get; set; }
+    public string? Model { get; set; }
+    public string? BaseUrl { get; set; }
+    public bool? IsValid { get; set; }
+    public DateTimeOffset? LastValidatedAt { get; set; }
+    public DateTimeOffset? LastUsedAt { get; set; }
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? UpdatedAt { get; set; }
+}
+
+/// <summary>
+/// Append-only, user-scoped history for an API-key registration. There is no
+/// foreign key to <see cref="ApiKeyRegistration"/> so the final deletion event
+/// remains queryable after the registration row is removed.
+/// </summary>
+public sealed class ApiKeyAuditRecord
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid KeyId { get; set; }
+    public required string OwnerId { get; set; }
+    public required string Kind { get; set; }
+    public DateTimeOffset OccurredAt { get; set; } = DateTimeOffset.UtcNow;
+    public string? Detail { get; set; }
+}

--- a/tests/Andy.Containers.Api.Tests/Controllers/ApiKeysControllerTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Controllers/ApiKeysControllerTests.cs
@@ -1,0 +1,178 @@
+using System.Reflection;
+using Andy.Containers.Api.Controllers;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Moq;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Controllers;
+
+public sealed class ApiKeysControllerTests
+{
+    private readonly Mock<IApiKeyService> _apiKeys = new();
+    private readonly Mock<ICurrentUserService> _currentUser = new();
+    private readonly ApiKeysController _controller;
+
+    public ApiKeysControllerTests()
+    {
+        _currentUser.Setup(u => u.GetUserId()).Returns("current-user");
+        _controller = new ApiKeysController(_apiKeys.Object, _currentUser.Object);
+    }
+
+    [Fact]
+    public async Task List_ReturnsOnlyCurrentUsersMaskedEntries()
+    {
+        _apiKeys
+            .Setup(s => s.ListAsync("current-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                Registration(
+                    Guid.NewGuid(),
+                    "current-user",
+                    "openai",
+                    "sk-••••••••abcd"),
+            ]);
+
+        var result = await _controller.List(CancellationToken.None);
+
+        var entries = result.Should()
+            .BeOfType<OkObjectResult>().Subject.Value.Should()
+            .BeAssignableTo<IEnumerable<ApiKeyEntry>>().Subject;
+        entries.Should().ContainSingle()
+            .Which.MaskedValue.Should().Be("sk-••••••••abcd");
+        _apiKeys.Verify(s => s.ListAsync(
+            "current-user",
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_MapsExactConductorRequestAndNeverReturnsRawValue()
+    {
+        CreateApiKeyCommand? captured = null;
+        var id = Guid.NewGuid();
+        _apiKeys
+            .Setup(s => s.CreateAsync(
+                "current-user",
+                It.IsAny<CreateApiKeyCommand>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, CreateApiKeyCommand, CancellationToken>(
+                (_, command, _) => captured = command)
+            .ReturnsAsync(Registration(
+                id,
+                "current-user",
+                "openai-compatible",
+                "sk-••••••••abcd",
+                "model-x",
+                "https://models.example/v1"));
+
+        var result = await _controller.Create(
+            new CreateApiKeyRequest(
+                "Primary",
+                "openai-compatible",
+                "sk-raw-must-not-return-abcd",
+                "model-x",
+                "https://models.example/v1"),
+            CancellationToken.None);
+
+        var created = result.Should().BeOfType<ObjectResult>().Subject;
+        created.StatusCode.Should().Be(201);
+        var dto = created.Value.Should().BeOfType<ApiKeyEntry>().Subject;
+        dto.Id.Should().Be(id);
+        dto.MaskedValue.Should().Be("sk-••••••••abcd");
+        typeof(ApiKeyEntry).GetProperties().Select(p => p.Name)
+            .Should().NotContain("Value");
+        captured.Should().Be(new CreateApiKeyCommand(
+            "Primary",
+            "openai-compatible",
+            "sk-raw-must-not-return-abcd",
+            "model-x",
+            "https://models.example/v1"));
+    }
+
+    [Fact]
+    public async Task Validate_ReturnsConductorValidationShape()
+    {
+        var id = Guid.NewGuid();
+        _apiKeys
+            .Setup(s => s.ValidateAsync(
+                id,
+                "current-user",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiKeyValidationOutcome(
+                true,
+                "Key is functional.",
+                12));
+
+        var result = await _controller.Validate(id, CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>().Subject.Value.Should()
+            .Be(new ApiKeyValidationResult(true, "Key is functional.", 12));
+    }
+
+    [Fact]
+    public async Task Create_WhenSettingsUnavailable_Returns503WithoutRawValue()
+    {
+        _apiKeys
+            .Setup(s => s.CreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<CreateApiKeyCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ApiKeySecretStoreUnavailableException(
+                "The API-key secret store is unavailable."));
+
+        var result = await _controller.Create(
+            new CreateApiKeyRequest(
+                "Primary",
+                "openai",
+                "sk-MUST-NOT-LEAK"),
+            CancellationToken.None);
+
+        var unavailable = result.Should().BeOfType<ObjectResult>().Subject;
+        unavailable.StatusCode.Should().Be(503);
+        System.Text.Json.JsonSerializer.Serialize(unavailable.Value)
+            .Should().NotContain("sk-MUST-NOT-LEAK");
+    }
+
+    [Theory]
+    [InlineData(nameof(ApiKeysController.List), "GET", null)]
+    [InlineData(nameof(ApiKeysController.Create), "POST", null)]
+    [InlineData(nameof(ApiKeysController.Update), "PUT", "{id:guid}")]
+    [InlineData(nameof(ApiKeysController.Delete), "DELETE", "{id:guid}")]
+    [InlineData(nameof(ApiKeysController.Validate), "POST", "{id:guid}/validate")]
+    [InlineData(nameof(ApiKeysController.History), "GET", "{id:guid}/history")]
+    public void Routes_MatchConductorClient(
+        string methodName,
+        string httpMethod,
+        string? template)
+    {
+        var method = typeof(ApiKeysController).GetMethod(methodName)!;
+        var attribute = method.GetCustomAttributes<HttpMethodAttribute>().Single();
+
+        attribute.HttpMethods.Should().ContainSingle().Which.Should().Be(httpMethod);
+        attribute.Template.Should().Be(template);
+        typeof(ApiKeysController).GetCustomAttribute<RouteAttribute>()!
+            .Template.Should().Be("api/apikeys");
+    }
+
+    private static ApiKeyRegistration Registration(
+        Guid id,
+        string owner,
+        string provider,
+        string masked,
+        string? model = null,
+        string? baseUrl = null)
+        => new()
+        {
+            Id = id,
+            OwnerId = owner,
+            Name = "Primary",
+            Provider = provider,
+            SecretDefinitionKey =
+                $"andy.models.providers.{provider}.apiKey",
+            MaskedValue = masked,
+            Model = model,
+            BaseUrl = baseUrl,
+        };
+}

--- a/tests/Andy.Containers.Api.Tests/Services/ApiKeyServiceTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/ApiKeyServiceTests.cs
@@ -1,0 +1,382 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Andy.Containers.Api.Controllers;
+using Andy.Containers.Api.Services;
+using Andy.Containers.Api.Tests.Helpers;
+using Andy.Containers.Infrastructure.Data;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.Containers.Api.Tests.Services;
+
+public sealed class ApiKeyServiceTests : IDisposable
+{
+    private readonly ContainersDbContext _db = InMemoryDbHelper.CreateContext();
+    private readonly InMemorySecretStore _secrets = new();
+    private readonly StubValidator _validator = new();
+    private readonly ApiKeyService _service;
+
+    public ApiKeyServiceTests()
+        => _service = new ApiKeyService(_db, _secrets, _validator);
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task Create_StoresPlaintextOnlyInAndySettingsAndReturnsMaskedMetadata()
+    {
+        const string raw = "sk-test-12345678abcd";
+
+        var entry = await _service.CreateAsync(
+            "user-1",
+            new CreateApiKeyCommand(
+                "My OpenAI Key",
+                "openai",
+                raw,
+                "gpt-4o",
+                null));
+
+        entry.Provider.Should().Be("openai");
+        entry.MaskedValue.Should().Be("sk-••••••••abcd");
+        entry.Model.Should().Be("gpt-4o");
+        entry.IsValid.Should().BeNull();
+        _secrets.Values[(
+            "andy.models.providers.openai.apiKey",
+            "user-1")].Should().Be(raw);
+
+        var persisted = await _db.ApiKeyRegistrations.SingleAsync();
+        persisted.MaskedValue.Should().Be("sk-••••••••abcd");
+        typeof(Andy.Containers.Models.ApiKeyRegistration)
+            .GetProperties()
+            .Select(p => p.Name)
+            .Should()
+            .NotContain(name =>
+                name.Contains("Encrypted", StringComparison.OrdinalIgnoreCase) ||
+                name == "Value" ||
+                name == "PlaintextValue",
+                "raw provider keys belong only to andy-settings");
+        (await _db.ApiKeyAuditRecords.SingleAsync()).Kind.Should().Be("created");
+    }
+
+    [Fact]
+    public async Task CrudValidateAndHistory_AreUserScopedAndRetainDeletionAudit()
+    {
+        var entry = await _service.CreateAsync(
+            "owner",
+            new CreateApiKeyCommand(
+                "Primary",
+                "anthropic",
+                "sk-ant-old-value",
+                null,
+                null));
+
+        var updated = await _service.UpdateAsync(
+            entry.Id,
+            "owner",
+            new UpdateApiKeyCommand(
+                "Rotated",
+                "sk-ant-new-value",
+                "claude-sonnet-4-7",
+                null));
+        updated.Name.Should().Be("Rotated");
+        updated.MaskedValue.Should().EndWith("alue");
+        updated.IsValid.Should().BeNull();
+
+        _validator.Outcome = new ApiKeyValidationOutcome(
+            true,
+            "Key is functional.",
+            42);
+        var validation = await _service.ValidateAsync(entry.Id, "owner");
+        validation.IsValid.Should().BeTrue();
+        validation.QuotaRemaining.Should().Be(42);
+
+        await _service.DeleteAsync(entry.Id, "owner");
+
+        (await _service.ListAsync("owner")).Should().BeEmpty();
+        _secrets.Values.Should().NotContainKey((
+            "andy.models.providers.anthropic.apiKey",
+            "owner"));
+        var history = await _service.HistoryAsync(entry.Id, "owner");
+        history.Select(h => h.Kind).Should().Equal(
+            "deleted",
+            "validated",
+            "updated",
+            "created");
+        history.Should().OnlyContain(h => h.OwnerId == "owner");
+    }
+
+    [Fact]
+    public async Task UserIsolation_HidesRegistrationAndHistory()
+    {
+        var entry = await _service.CreateAsync(
+            "owner",
+            new CreateApiKeyCommand("Key", "google", "secret-value", null, null));
+
+        (await _service.ListAsync("another-user")).Should().BeEmpty();
+        var act = () => _service.HistoryAsync(entry.Id, "another-user");
+        await act.Should().ThrowAsync<ApiKeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task Create_RejectsSecondKeyForSameProviderAndOwner()
+    {
+        await _service.CreateAsync(
+            "owner",
+            new CreateApiKeyCommand("First", "openai", "secret-one", null, null));
+
+        var act = () => _service.CreateAsync(
+            "owner",
+            new CreateApiKeyCommand("Second", "openai", "secret-two", null, null));
+
+        await act.Should().ThrowAsync<ApiKeyConflictException>();
+        _secrets.Values[(
+            "andy.models.providers.openai.apiKey",
+            "owner")].Should().Be("secret-one");
+    }
+
+    [Fact]
+    public async Task CustomProvider_RequiresValidBaseUrlBeforeWritingSecret()
+    {
+        var act = () => _service.CreateAsync(
+            "owner",
+            new CreateApiKeyCommand("Custom", "custom", "secret", null, null));
+
+        await act.Should().ThrowAsync<ApiKeyValidationException>()
+            .WithMessage("*BaseURL is required*");
+        _secrets.Values.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("sk-1234567890abcd", "sk-••••••••abcd")]
+    [InlineData("gsk_1234567890wxyz", "gsk_••••••••wxyz")]
+    [InlineData("tiny", "••••••••tiny")]
+    [InlineData("x", "••••••••x")]
+    public void Mask_MatchesConductorWireHelper(string raw, string expected)
+        => ApiKeyService.Mask(raw).Should().Be(expected);
+
+    private sealed class InMemorySecretStore : IApiKeySecretStore
+    {
+        public Dictionary<(string Definition, string Owner), string> Values { get; } = new();
+
+        public Task SetAsync(
+            string definitionKey,
+            string ownerId,
+            string value,
+            CancellationToken ct = default)
+        {
+            Values[(definitionKey, ownerId)] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> GetAsync(
+            string definitionKey,
+            string ownerId,
+            CancellationToken ct = default)
+        {
+            Values.TryGetValue((definitionKey, ownerId), out var value);
+            return Task.FromResult<string?>(value);
+        }
+
+        public Task ClearAsync(
+            string definitionKey,
+            string ownerId,
+            CancellationToken ct = default)
+        {
+            Values.Remove((definitionKey, ownerId));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StubValidator : IApiKeyValidator
+    {
+        public ApiKeyValidationOutcome Outcome { get; set; } =
+            new(true, "Valid.", null);
+
+        public Task<ApiKeyValidationOutcome> ValidateAsync(
+            ApiKeyProviderDefinition provider,
+            string value,
+            string? baseUrl,
+            CancellationToken ct = default)
+            => Task.FromResult(Outcome);
+    }
+}
+
+public sealed class ApiKeySettingsProxyTests
+{
+    [Fact]
+    public async Task Store_WritesAndReadsUserScopedSecretWithoutLeakingIntoUri()
+    {
+        var requests = new List<(HttpMethod Method, string Uri, string? Body)>();
+        var handler = new StubHandler(async request =>
+        {
+            var body = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync();
+            requests.Add((
+                request.Method,
+                request.RequestUri!.ToString(),
+                body));
+
+            return request.Method == HttpMethod.Get
+                ? JsonResponse(
+                    """{"definitionKey":"andy.models.providers.openai.apiKey","value":"sk-secret"}""")
+                : new HttpResponseMessage(HttpStatusCode.Created);
+        });
+        var store = CreateStore(handler);
+
+        await store.SetAsync(
+            "andy.models.providers.openai.apiKey",
+            "user/with spaces",
+            "sk-secret");
+        var value = await store.GetAsync(
+            "andy.models.providers.openai.apiKey",
+            "user/with spaces");
+        await store.ClearAsync(
+            "andy.models.providers.openai.apiKey",
+            "user/with spaces");
+
+        value.Should().Be("sk-secret");
+        requests[0].Body.Should().Contain("\"scopeType\":\"User\"");
+        requests[0].Body.Should().Contain("\"scopeId\":\"user/with spaces\"");
+        requests[0].Body.Should().Contain("\"value\":\"sk-secret\"");
+        requests[1].Uri.Should().Contain("scopeType=User");
+        requests[1].Uri.Should().Contain("scopeId=user%2Fwith spaces");
+        requests[1].Uri.Should().NotContain("sk-secret");
+        requests[2].Body.Should().Contain("\"value\":\"\"");
+    }
+
+    [Fact]
+    public async Task Store_MapsSettingsOutageToUnavailable()
+    {
+        var store = CreateStore(new StubHandler(_ =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadGateway))));
+
+        var act = () => store.SetAsync(
+            "andy.models.providers.openai.apiKey",
+            "owner",
+            "sk-MUST-NOT-LEAK-1234");
+
+        await act.Should().ThrowAsync<ApiKeySecretStoreUnavailableException>()
+            .Where(ex => !ex.Message.Contains(
+                "sk-MUST-NOT-LEAK-1234",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Validator_UsesHeaderAuthenticationAndNeverPlacesKeyInUrl()
+    {
+        HttpRequestMessage? captured = null;
+        var handler = new StubHandler(request =>
+        {
+            captured = request;
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.Headers.TryAddWithoutValidation(
+                "x-ratelimit-remaining-requests",
+                "17");
+            return Task.FromResult(response);
+        });
+        var validator = CreateValidator(handler);
+        ApiKeyProviderCatalog.TryGet("openai", out var provider).Should().BeTrue();
+
+        var result = await validator.ValidateAsync(
+            provider,
+            "sk-never-in-uri",
+            null);
+
+        result.Should().Be(new ApiKeyValidationOutcome(
+            true,
+            "Key is functional.",
+            17));
+        captured!.RequestUri!.ToString().Should().Be(
+            "https://api.openai.com/v1/models");
+        captured.RequestUri.ToString().Should().NotContain("sk-never-in-uri");
+        captured.Headers.Authorization!.Scheme.Should().Be("Bearer");
+        captured.Headers.Authorization.Parameter.Should().Be("sk-never-in-uri");
+    }
+
+    [Fact]
+    public async Task Validator_RejectsCredentialBearingBaseUrlBeforeNetwork()
+    {
+        var validator = CreateValidator(new StubHandler(_ =>
+            throw new InvalidOperationException("network should not run")));
+        ApiKeyProviderCatalog.TryGet("custom", out var provider).Should().BeTrue();
+
+        var act = () => validator.ValidateAsync(
+            provider,
+            "secret",
+            "https://user:password@example.com/v1");
+
+        await act.Should().ThrowAsync<ApiKeyValidationException>();
+    }
+
+    [Fact]
+    public void ApiKeyEntry_UsesExactConductorCamelCaseWireNamesAndNoRawValue()
+    {
+        var dto = new ApiKeyEntry(
+            Guid.Parse("11111111-2222-3333-4444-555555555555"),
+            "Primary",
+            "openai-compatible",
+            "sk-••••••••abcd",
+            true,
+            DateTimeOffset.Parse("2026-07-24T12:00:00Z"),
+            null,
+            null,
+            "model",
+            "https://example.test/v1");
+        var json = JsonSerializer.Serialize(
+            dto,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        json.Should().Contain("\"maskedValue\"");
+        json.Should().Contain("\"isValid\"");
+        json.Should().Contain("\"lastUsedAt\"");
+        json.Should().Contain("\"lastValidatedAt\"");
+        json.Should().Contain("\"baseURL\"");
+        json.Should().NotContain("\"value\"");
+        json.Should().NotContain("secret");
+    }
+
+    private static AndySettingsApiKeySecretStore CreateStore(HttpMessageHandler handler)
+    {
+        var http = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://andy-settings.test/"),
+        };
+        return new AndySettingsApiKeySecretStore(new SingleClientFactory(http));
+    }
+
+    private static ApiKeyValidator CreateValidator(HttpMessageHandler handler)
+    {
+        var http = new HttpClient(handler);
+        return new ApiKeyValidator(new SingleClientFactory(http));
+    }
+
+    private static HttpResponseMessage JsonResponse(string json)
+        => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> _responder;
+
+        public StubHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder)
+            => _responder = responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => _responder(request);
+    }
+
+    private sealed class SingleClientFactory : IHttpClientFactory
+    {
+        private readonly HttpClient _client;
+
+        public SingleClientFactory(HttpClient client) => _client = client;
+
+        public HttpClient CreateClient(string name) => _client;
+    }
+}


### PR DESCRIPTION
Closes #313

## Summary
- add the six Conductor-compatible /api/apikeys management routes
- keep plaintext provider keys exclusively in user-scoped andy-settings secrets
- persist masked display metadata and append-only audit history locally
- validate supported providers without putting keys in URLs, logs, responses, or errors
- add the EF migration, OpenAPI contract, security/migration docs, and route/service tests

## Validation
- dotnet test Andy.Containers.sln --no-restore --maxcpucount:1: 2,206 passed, 9 skipped, 0 failed
- pending-migration guard and SQLite migration probes: 5 passed
- dotnet format on all changed C# files: clean
- Spectral OpenAPI lint: 0 errors (repository baseline warnings remain)
- git diff --check: clean