### PR TITLE
Publish the client packages to nuget.org from CI

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,94 @@
+name: Publish NuGet packages
+
+# Consumers of andy-containers need its client library from nuget.org: a
+# ProjectReference across repositories does not survive CI, which has no
+# sibling checkouts.
+#
+# Both packages are published together. Andy.Containers.Client has a project
+# reference to Andy.Containers, which packs as a package dependency, so
+# publishing the client alone would ship something that cannot be restored.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/Andy.Containers/**'
+      - 'src/Andy.Containers.Client/**'
+      - 'proto/**'
+      - '.github/workflows/publish-packages.yml'
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_VERSION: '8.0.x'
+  NUGET_SOURCE: 'https://api.nuget.org/v3/index.json'
+
+jobs:
+  pack:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: dotnet restore src/Andy.Containers.Client/Andy.Containers.Client.csproj
+
+      - name: Build
+        run: |
+          dotnet build src/Andy.Containers.Client/Andy.Containers.Client.csproj \
+            --configuration Release --no-restore
+
+      - name: Pack
+        run: |
+          # A tag publishes its own version; main publishes a dated prerelease
+          # so consumers can move forward without waiting for a release.
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          else
+            VERSION=$(date +%Y.%m.%d)-rc.$GITHUB_RUN_NUMBER
+          fi
+
+          echo "Packing $VERSION"
+
+          for project in Andy.Containers Andy.Containers.Client; do
+            dotnet pack "src/$project/$project.csproj" \
+              --configuration Release \
+              --no-build \
+              --output ./artifacts \
+              -p:PackageVersion="$VERSION"
+          done
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nuget-packages
+          path: ./artifacts/*.nupkg
+          retention-days: 7
+
+  publish:
+    needs: pack
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: nuget-packages
+          path: ./artifacts
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Publish
+        # --skip-duplicate so re-running the same commit is a no-op rather than
+        # a failure; nuget.org rejects a republished version.
+        run: |
+          dotnet nuget push ./artifacts/*.nupkg \
+            --source ${{ env.NUGET_SOURCE }} \
+            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --skip-duplicate


### PR DESCRIPTION
`Andy.Containers.Client` is not on nuget.org, so a consumer can only reach it by `ProjectReference` across repositories — which does not survive CI, since a build agent has no sibling checkouts. andy-ahp needs it for its runtime adapter (rivoli-ai/andy-ahp#14).

## Both packages, same version

`Andy.Containers.Client` has a project reference to `Andy.Containers`, which packs as a **package dependency**:

```xml
<dependency id="Andy.Containers" version="2026.7.28-rc.1" exclude="Build,Analyzers" />
```

`Andy.Containers` is also unpublished, so pushing the client alone would ship a package nobody can restore. Both are packed and published together at the same version. I verified this by packing locally and reading the generated nuspec.

## Pattern

Follows `andy-acp`'s existing workflow so the two behave the same way:

- a dated prerelease from `main`, so consumers can move forward without waiting for a release;
- the tag's own version from `v*` tags;
- `--skip-duplicate`, so re-running a commit is a no-op rather than a failure — nuget.org rejects a republished version.

Uses the organisation's `NUGET_API_KEY` secret, same as andy-acp.

## Note

Both packages currently declare `<Version>0.1.0-alpha</Version>` in their csproj; the workflow overrides it with `-p:PackageVersion`, so the first publish from `main` will be a dated rc rather than `0.1.0-alpha`. Say the word if you would rather the csproj version be authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)