### PR TITLE
chore: migrate to .NET 10

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
   NUGET_SOURCE: 'https://api.nuget.org/v3/index.json'
 
 jobs:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,10 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- Lets the PackageVersion entries below govern transitive dependencies too,
+         so a vulnerable transitive can be lifted centrally instead of adding a
+         placeholder PackageReference to every project that happens to pull it. -->
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <!-- Andy internal packages -->
@@ -11,28 +15,28 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <!-- Entity Framework Core -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <!-- gRPC -->
     <PackageVersion Include="Grpc.AspNetCore" Version="2.67.0" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.67.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.28.3" />
     <PackageVersion Include="Grpc.Tools" Version="2.67.0" />
     <!-- Caching -->
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.10" />
     <!-- HTTP Client -->
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.10" />
     <!-- Docker -->
     <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
     <!-- Azure -->
@@ -55,7 +59,7 @@
     <!-- YAML -->
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <!-- Utilities -->
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <!-- Observability -->
@@ -76,7 +80,13 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
     <PackageVersion Include="bunit" Version="1.36.0" />
+    <!-- Transitive pin: the SQLite provider resolves 2.1.11 (GHSA-2m69-gcr7-jv3q, high). -->
+    <!-- Pinned transitively: 1.9.0/1.11.1 carry GHSA-4625-4j76-fww9,
+         GHSA-g94r-2vxg-569j and GHSA-8785-wc3w-h8q6. -->
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestMajor"
+  }
+}

--- a/src/Andy.Containers.Api/Dockerfile
+++ b/src/Andy.Containers.Api/Dockerfile
@@ -17,7 +17,7 @@ COPY src/andy-containers-web/ ./
 RUN npm run build
 
 # ── Build stage ───────────────────────────────────────────────────────────────
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /build
 
 # Trust corporate root CAs from the centralized certs/ directory
@@ -50,7 +50,7 @@ COPY . .
 RUN dotnet publish src/Andy.Containers.Api/Andy.Containers.Api.csproj -c Release -o /app/publish /p:UseAppHost=false
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
 WORKDIR /app
 
 # Install ca-certificates, curl, openssl, and Docker CLI (needed for image builds and terminal exec)

--- a/src/Andy.Containers.Infrastructure/Data/DatabaseProviderExtensions.cs
+++ b/src/Andy.Containers.Infrastructure/Data/DatabaseProviderExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 
 namespace Andy.Containers.Infrastructure.Data;
@@ -69,6 +70,17 @@ public static class DatabaseProviderExtensions
                 {
                     sqlite.MigrationsAssembly(migrationsAssembly);
                 });
+                // The migrations and model snapshot are generated against the
+                // PostgreSQL provider, so the model EF builds for SQLite
+                // legitimately differs from the snapshot (array columns model as
+                // PrimitiveCollection under Npgsql, for instance). EF 9+ promotes
+                // that mismatch from a warning to an exception, which makes
+                // Migrate() throw on the embedded SQLite path -- the migration
+                // entry point started returning exit 1, which the Helm hook reads
+                // as a failed migration. Postgres still matches the snapshot and is
+                // unaffected, so this is scoped to the SQLite branch.
+                options.ConfigureWarnings(w =>
+                    w.Ignore(RelationalEventId.PendingModelChangesWarning));
                 // Embedded SQLite is hit concurrently by a hot reconciliation
                 // read loop and by writes (e.g. ensure-pull bookkeeping). Apply
                 // WAL + busy_timeout on every connection so writers wait for the

--- a/src/Andy.Containers.Infrastructure/Migrations/20260808204758_Net10ModelSnapshotRefresh.Designer.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260808204758_Net10ModelSnapshotRefresh.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Andy.Containers.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Containers.Infrastructure.Migrations
 {
     [DbContext(typeof(ContainersDbContext))]
-    partial class ContainersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260808204758_Net10ModelSnapshotRefresh")]
+    partial class Net10ModelSnapshotRefresh
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Containers.Infrastructure/Migrations/20260808204758_Net10ModelSnapshotRefresh.cs
+++ b/src/Andy.Containers.Infrastructure/Migrations/20260808204758_Net10ModelSnapshotRefresh.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Containers.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Net10ModelSnapshotRefresh : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/src/Andy.Containers/Andy.Containers.csproj
+++ b/src/Andy.Containers/Andy.Containers.csproj
@@ -11,8 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
-    <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 
 </Project>

--- a/tests/Andy.Containers.Api.Tests/DataProtection/DataProtectionKeyStoreTests.cs
+++ b/tests/Andy.Containers.Api.Tests/DataProtection/DataProtectionKeyStoreTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -57,7 +58,7 @@ public sealed class DataProtectionKeyStoreTests : IDisposable
     private ContainersDbContext NewContext()
     {
         var options = new DbContextOptionsBuilder<ContainersDbContext>()
-            .UseSqlite(_connection)
+            .UseSqlite(_connection).ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
             .Options;
         return new ContainersDbContext(options);
     }
@@ -70,7 +71,7 @@ public sealed class DataProtectionKeyStoreTests : IDisposable
     private ServiceProvider BuildReplica()
     {
         var services = new ServiceCollection();
-        services.AddDbContext<ContainersDbContext>(opts => opts.UseSqlite(_connection));
+        services.AddDbContext<ContainersDbContext>(opts => opts.UseSqlite(_connection).ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)));
         services.AddDataProtection()
             .SetApplicationName("andy-containers")
             .PersistKeysToDbContext<ContainersDbContext>();

--- a/tests/Andy.Containers.Api.Tests/Messaging/OutboxDispatcherTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Messaging/OutboxDispatcherTests.cs
@@ -6,6 +6,7 @@ using Andy.Containers.Infrastructure.Messaging;
 using Andy.Containers.Messaging;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -152,7 +153,7 @@ public class OutboxDispatcherTests
         {
             var services = new ServiceCollection();
             services.AddDbContext<Andy.Containers.Infrastructure.Data.ContainersDbContext>(o =>
-                o.UseSqlite(connection));
+                o.UseSqlite(connection).ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)));
             var bus = new RecordingMessageBus();
             services.AddSingleton<IMessageBus>(bus);
             using var provider = services.BuildServiceProvider();

--- a/tests/Andy.Containers.Api.Tests/Services/RunEventStreamTests.cs
+++ b/tests/Andy.Containers.Api.Tests/Services/RunEventStreamTests.cs
@@ -6,6 +6,7 @@ using Andy.Containers.Messaging.Events;
 using Andy.Containers.Models;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Xunit;
 
 namespace Andy.Containers.Api.Tests.Services;
@@ -65,7 +66,7 @@ public class RunEventStreamTests : IDisposable
         await connection.OpenAsync();
 
         var options = new DbContextOptionsBuilder<ContainersDbContext>()
-            .UseSqlite(connection)
+            .UseSqlite(connection).ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
             .Options;
         using var db = new ContainersDbContext(options);
         await db.Database.EnsureCreatedAsync();

--- a/tests/Andy.Containers.Integration.Tests/AndyCliTemplateProvisioningTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/AndyCliTemplateProvisioningTests.cs
@@ -10,6 +10,7 @@ using Andy.Containers.Models;
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -135,7 +136,7 @@ public sealed class AndyCliTemplateProvisioningTests : IAsyncLifetime
         await using var conn = new SqliteConnection("DataSource=:memory:");
         await conn.OpenAsync();
         await using var db = new ContainersDbContext(
-            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(conn).Options);
+            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(conn).ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)).Options);
         await db.Database.EnsureCreatedAsync();
 
         await DataSeeder.SeedAsync(db);

--- a/tests/Andy.Containers.Integration.Tests/Build/ImageBuildOrchestratorTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/Build/ImageBuildOrchestratorTests.cs
@@ -12,6 +12,7 @@ using Andy.Containers.Storage;
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Andy.Containers.Configuration;
@@ -42,7 +43,7 @@ public class ImageBuildOrchestratorTests : IAsyncLifetime
         _conn = new SqliteConnection("DataSource=:memory:");
         await _conn.OpenAsync();
         var options = new DbContextOptionsBuilder<ContainersDbContext>()
-            .UseSqlite(_conn).Options;
+            .UseSqlite(_conn).ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)).Options;
         _db = new ContainersDbContext(options);
         await _db.Database.EnsureCreatedAsync();
         _store = new BuildArtifactStore(_db);

--- a/tests/Andy.Containers.Integration.Tests/Data/BuildArtifactStoreTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/Data/BuildArtifactStoreTests.cs
@@ -8,6 +8,7 @@ using Andy.Containers.Storage;
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Xunit;
 
 namespace Andy.Containers.Integration.Tests.Data;
@@ -33,7 +34,7 @@ public class BuildArtifactStoreTests : IAsyncLifetime
         await _conn.OpenAsync();
 
         var options = new DbContextOptionsBuilder<ContainersDbContext>()
-            .UseSqlite(_conn)
+            .UseSqlite(_conn).ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
             .Options;
 
         _db = new ContainersDbContext(options);

--- a/tests/Andy.Containers.Integration.Tests/Data/EnvironmentProfileRepositoryTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/Data/EnvironmentProfileRepositoryTests.cs
@@ -6,6 +6,7 @@ using Andy.Containers.Models;
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Xunit;
 
 namespace Andy.Containers.Integration.Tests.Data;
@@ -25,7 +26,7 @@ public class EnvironmentProfileRepositoryTests : IAsyncLifetime
         await _conn.OpenAsync();
 
         var options = new DbContextOptionsBuilder<ContainersDbContext>()
-            .UseSqlite(_conn)
+            .UseSqlite(_conn).ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
             .Options;
 
         _db = new ContainersDbContext(options);
@@ -61,7 +62,7 @@ public class EnvironmentProfileRepositoryTests : IAsyncLifetime
 
         // Fresh DbContext so we re-hydrate from the database, not the change tracker.
         using var otherDb = new ContainersDbContext(
-            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).Options);
+            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)).Options);
         var reloaded = await otherDb.EnvironmentProfiles.SingleAsync(p => p.Id == profile.Id);
 
         reloaded.Should().BeEquivalentTo(profile, options => options

--- a/tests/Andy.Containers.Integration.Tests/Data/RunRepositoryTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/Data/RunRepositoryTests.cs
@@ -6,6 +6,7 @@ using Andy.Containers.Models;
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Xunit;
 
 namespace Andy.Containers.Integration.Tests.Data;
@@ -31,7 +32,7 @@ public class RunRepositoryTests : IAsyncLifetime
         await _conn.OpenAsync();
 
         var options = new DbContextOptionsBuilder<ContainersDbContext>()
-            .UseSqlite(_conn)
+            .UseSqlite(_conn).ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
             .Options;
 
         _db = new ContainersDbContext(options);
@@ -70,7 +71,7 @@ public class RunRepositoryTests : IAsyncLifetime
 
         // New DbContext so we read fresh state, not the tracked entity.
         using var otherDb = new ContainersDbContext(
-            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).Options);
+            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)).Options);
         var reloaded = await otherDb.Runs.SingleAsync(r => r.Id == runId);
 
         reloaded.Should().BeEquivalentTo(run, options => options
@@ -144,7 +145,7 @@ public class RunRepositoryTests : IAsyncLifetime
 
         // And verify EF round-trips the owned value object end-to-end.
         using var otherDb = new ContainersDbContext(
-            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).Options);
+            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)).Options);
         var reloaded = await otherDb.Runs.SingleAsync(r => r.Id == run.Id);
         reloaded.WorkspaceRef.WorkspaceId.Should().Be(workspaceId);
         reloaded.WorkspaceRef.Branch.Should().Be("feature/x");
@@ -189,7 +190,7 @@ public class RunRepositoryTests : IAsyncLifetime
         await _db.SaveChangesAsync();
 
         using var otherDb = new ContainersDbContext(
-            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).Options);
+            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)).Options);
         var reloaded = await otherDb.Runs.SingleAsync(r => r.Id == run.Id);
 
         reloaded.Status.Should().Be(RunStatus.Running);
@@ -223,7 +224,7 @@ public class RunRepositoryTests : IAsyncLifetime
         await _db.SaveChangesAsync();
 
         using var otherDb = new ContainersDbContext(
-            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).Options);
+            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)).Options);
         var reloaded = await otherDb.Runs.SingleAsync(r => r.Id == run.Id);
 
         reloaded.OutputArtifacts.Should().NotBeNull();
@@ -249,7 +250,7 @@ public class RunRepositoryTests : IAsyncLifetime
         await _db.SaveChangesAsync();
 
         using var otherDb = new ContainersDbContext(
-            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).Options);
+            new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)).Options);
         var reloaded = await otherDb.Runs.SingleAsync(r => r.Id == run.Id);
 
         reloaded.OutputArtifacts.Should().BeNull();

--- a/tests/Andy.Containers.Integration.Tests/GitDiffIntegrationTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/GitDiffIntegrationTests.cs
@@ -9,6 +9,7 @@ using Andy.Containers.Models;
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -47,7 +48,7 @@ public class GitDiffIntegrationTests : IAsyncLifetime
     {
         _conn = new SqliteConnection("DataSource=:memory:");
         await _conn.OpenAsync();
-        _db = new ContainersDbContext(new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).Options);
+        _db = new ContainersDbContext(new DbContextOptionsBuilder<ContainersDbContext>().UseSqlite(_conn).ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)).Options);
         await _db.Database.EnsureCreatedAsync();
 
         // Real container.

--- a/tests/Andy.Containers.Integration.Tests/SqliteAutoMigrationProbeTests.cs
+++ b/tests/Andy.Containers.Integration.Tests/SqliteAutoMigrationProbeTests.cs
@@ -3,6 +3,7 @@ using Andy.Containers.Infrastructure.Data;
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -237,6 +238,11 @@ public class SqliteAutoMigrationProbeTests : IDisposable
             .UseSqlite(
                 connectionString,
                 sqlite => sqlite.MigrationsAssembly("Andy.Containers.Infrastructure"))
+            // Migrations/snapshot are generated for Npgsql; applying them to SQLite
+            // makes the built model legitimately differ, which EF 10 raises as an
+            // exception. Mirrors the scoped suppression on the production SQLite
+            // branch in DatabaseProviderExtensions.
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
             .Options;
         return new ContainersDbContext(options);
     }


### PR DESCRIPTION
## Verification

SDK 10.0.302: build clean, **2206/2206 tests pass** (Client 32, Unit 549, Api 1561, Integration 64, plus 9 pre-existing skips), no vulnerable packages.

Identical to the net8 baseline of `main`, which I captured first. **Note:** that baseline is fully green — so the migration plan's warning that this repo has pre-existing test failures is out of date.

## ⚠️ EF 10 breaks the embedded SQLite deployment mode, not just tests

Migrations and the model snapshot are generated against **PostgreSQL**, so the model EF builds for **SQLite** legitimately differs (array columns model as `PrimitiveCollection` under Npgsql, for instance). EF 9+ promotes that mismatch from a warning to an exception.

Result: `Migrate()` throws on the SQLite path and the migration entry point returns **exit 1** — which **the Helm hook reads as a failed migration**. That's a deployment failure, not a test artifact.

Fixed by scoping `PendingModelChangesWarning` suppression to the SQLite branch in `DatabaseProviderExtensions` — **production code, deliberately** — plus the test setups that build their own SQLite options. PostgreSQL still matches the snapshot and is untouched.

## Security handled centrally

Enabled **`CentralPackageTransitivePinningEnabled`**, so a vulnerable transitive can be lifted once in `Directory.Packages.props` rather than adding a placeholder `PackageReference` to every project that happens to pull it:

- `OpenTelemetry.Api` / `.Exporter.OpenTelemetryProtocol` → 1.17.0 (GHSA-4625-4j76-fww9, GHSA-g94r-2vxg-569j, GHSA-8785-wc3w-h8q6)
- `SQLitePCLRaw.lib.e_sqlite3` → 2.1.12 (GHSA-2m69-gcr7-jv3q)

## Also

- All projects → `net10.0`; Dockerfile → 10.0; CI → `10.0.x`
- EF Core → 10.0.10, Npgsql → 10.0.3, `Microsoft.AspNetCore.*` → 10.0.10; Swashbuckle → 10.2.3
- Dropped `Microsoft.Extensions.{Caching.Memory,Http}` from `Andy.Containers` — it carries `FrameworkReference Microsoft.AspNetCore.App`, so both are framework-provided on net10 (`NU1510`)
- Model snapshot regenerated — **empty migration, no DDL**

🤖 Generated with [Claude Code](https://claude.com/claude-code)